### PR TITLE
refactor(platforms): cache bilibili wbi generation

### DIFF
--- a/crates/platforms/src/extractor/platforms/bilibili/builder.rs
+++ b/crates/platforms/src/extractor/platforms/bilibili/builder.rs
@@ -71,7 +71,7 @@ impl Bilibili {
         url: String,
         client: Client,
         cookies: Option<String>,
-        _extras: Option<serde_json::Value>,
+        extras: Option<serde_json::Value>,
     ) -> Self {
         let mut extractor = Extractor::new("Bilibili", url, client);
 
@@ -81,17 +81,12 @@ impl Bilibili {
         let base_url_value = HeaderValue::from_str(Self::BASE_URL).unwrap();
         extractor.add_header_owned(reqwest::header::REFERER, base_url_value);
 
-        let mut quality = BilibiliQuality::Original;
-
-        if let Some(extras) = _extras {
-            let default_quality = serde_json::Value::Number(10000.into());
-            let quality_value = extras.get("quality").unwrap_or(&default_quality);
-            if quality_value.is_number() {
-                let quality_num = quality_value.as_u64().unwrap_or(10000);
-                quality = BilibiliQuality::try_from_primitive(quality_num as u32)
-                    .unwrap_or(BilibiliQuality::Original);
-            }
-        }
+        let quality = extras
+            .as_ref()
+            .and_then(|extras| extras.get("quality"))
+            .and_then(|v| v.as_u64())
+            .and_then(|num| BilibiliQuality::try_from_primitive(num as u32).ok())
+            .unwrap_or(BilibiliQuality::DolbyVision);
 
         Self { extractor, quality }
     }
@@ -108,11 +103,11 @@ impl Bilibili {
         url: &str,
         params: Vec<(&str, String)>,
     ) -> Result<T, ExtractorError> {
-        let (img_key, sub_key) = get_wbi_keys(&self.extractor.client)
+        let keys = get_wbi_keys(&self.extractor.client)
             .await
             .map_err(ExtractorError::from)?;
 
-        let params = encode_wbi(params, (img_key.as_str(), sub_key.as_str()));
+        let params = encode_wbi(params, keys)?;
         debug!("params: {:?}", params);
 
         let api_url = format!("{url}?{params}");
@@ -426,7 +421,7 @@ mod tests {
             .with_max_level(Level::DEBUG)
             .init();
         let bilibili = Bilibili::new(
-            "https://live.bilibili.com/10".to_string(),
+            "https://live.bilibili.com/6".to_string(),
             default_client(),
             None,
             None,

--- a/crates/platforms/src/extractor/platforms/bilibili/builder.rs
+++ b/crates/platforms/src/extractor/platforms/bilibili/builder.rs
@@ -103,9 +103,7 @@ impl Bilibili {
         url: &str,
         params: Vec<(&str, String)>,
     ) -> Result<T, ExtractorError> {
-        let keys = get_wbi_keys(&self.extractor.client)
-            .await
-            .map_err(ExtractorError::from)?;
+        let keys = get_wbi_keys(&self.extractor.client).await?;
 
         let params = encode_wbi(params, keys)?;
         debug!("params: {:?}", params);

--- a/crates/platforms/src/extractor/platforms/bilibili/mod.rs
+++ b/crates/platforms/src/extractor/platforms/bilibili/mod.rs
@@ -1,7 +1,9 @@
 mod builder;
 mod models;
+mod utils;
 mod wbi;
 
 pub use builder::Bilibili;
 pub use builder::BilibiliQuality;
 pub use builder::URL_REGEX;
+pub use utils::generate_fake_buvid3;

--- a/crates/platforms/src/extractor/platforms/bilibili/utils.rs
+++ b/crates/platforms/src/extractor/platforms/bilibili/utils.rs
@@ -1,0 +1,21 @@
+/// Generates a fake BUVID3 identifier for Bilibili API requests.
+///
+/// BUVID3 is a unique identifier used by Bilibili for tracking and authentication.
+/// This function creates a fake one by generating a UUID, removing hyphens,
+/// converting to uppercase, and formatting it with the required pattern ending in "infoc".
+///
+/// # Returns
+///
+/// A string in the format `XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXXinfoc` where X are hexadecimal characters.
+pub fn generate_fake_buvid3() -> String {
+    let u = uuid::Uuid::new_v4();
+    let u_str = u.to_string().to_uppercase().replace('-', "");
+    format!(
+        "{}-{}-{}-{}-{}infoc",
+        &u_str[0..8],
+        &u_str[8..12],
+        &u_str[12..16],
+        &u_str[16..20],
+        &u_str[20..]
+    )
+}

--- a/crates/platforms/src/extractor/platforms/bilibili/wbi.rs
+++ b/crates/platforms/src/extractor/platforms/bilibili/wbi.rs
@@ -1,8 +1,43 @@
 use md5::Digest;
 use reqwest::{Client, header::USER_AGENT};
 use serde::Deserialize;
+use std::time::{Duration, Instant};
 use std::time::{SystemTime, UNIX_EPOCH};
+use tokio::sync::{Mutex, watch};
+const CACHE_EXPIRATION: Duration = Duration::from_secs(2 * 60 * 60); // 2 hours
 
+#[derive(Clone, Debug)]
+pub struct WbiKeys {
+    img_key: String,
+    sub_key: String,
+    timestamp: Instant,
+}
+
+impl WbiKeys {
+    fn new(img_key: String, sub_key: String) -> Self {
+        Self {
+            img_key,
+            sub_key,
+            timestamp: Instant::now(),
+        }
+    }
+
+    fn is_stale(&self) -> bool {
+        self.timestamp.elapsed() > CACHE_EXPIRATION
+    }
+}
+
+use std::sync::LazyLock;
+static WBI_KEYS_WATCH: LazyLock<(watch::Sender<Option<WbiKeys>>, Mutex<()>)> =
+    LazyLock::new(|| {
+        let (tx, _) = watch::channel(None);
+        (tx, Mutex::new(()))
+    });
+
+static WBI_KEYS_RX: LazyLock<watch::Receiver<Option<WbiKeys>>> =
+    LazyLock::new(|| WBI_KEYS_WATCH.0.subscribe());
+
+use crate::extractor::error::ExtractorError;
 use crate::extractor::{default::DEFAULT_UA, platforms::bilibili::Bilibili};
 
 const MIXIN_KEY_ENC_TAB: [usize; 64] = [
@@ -37,31 +72,45 @@ fn get_mixin_key(orig: &[u8]) -> String {
 }
 
 fn get_url_encoded(s: &str) -> String {
-    s.chars()
-        .filter_map(|c| match c.is_ascii_alphanumeric() || "-_.~".contains(c) {
-            true => Some(c.to_string()),
-            false => {
-                // 过滤 value 中的 "!'()*" 字符
-                if "!'()*".contains(c) {
-                    return None;
-                }
-                let encoded = c
-                    .encode_utf8(&mut [0; 4])
-                    .bytes()
-                    .fold("".to_string(), |acc, b| acc + &format!("%{b:02X}"));
-                Some(encoded)
+    let mut encoded = String::with_capacity(s.len());
+    for c in s.chars() {
+        match c {
+            // Unreserved characters that do not need to be encoded.
+            'a'..='z' | 'A'..='Z' | '0'..='9' | '-' | '_' | '.' | '~' => {
+                encoded.push(c);
             }
-        })
-        .collect::<String>()
+            // Characters that are explicitly filtered out and not included in the output.
+            '!' | '\'' | '(' | ')' | '*' => {}
+            // All other characters are percent-encoded.
+            _ => {
+                let mut buf = [0; 4];
+                for b in c.encode_utf8(&mut buf).bytes() {
+                    encoded.push_str(&format!("%{b:02X}"));
+                }
+            }
+        }
+    }
+    encoded
 }
 
 // 为请求参数进行 wbi 签名
-pub(super) fn encode_wbi(params: Vec<(&str, String)>, (img_key, sub_key): (&str, &str)) -> String {
+pub(super) fn encode_wbi(
+    params: Vec<(&str, String)>,
+    keys: WbiKeys,
+) -> Result<String, ExtractorError> {
     let cur_time = match SystemTime::now().duration_since(UNIX_EPOCH) {
         Ok(t) => t.as_secs(),
-        Err(_) => panic!("SystemTime before UNIX EPOCH!"),
+        Err(_) => {
+            return Err(ExtractorError::Other(
+                "SystemTime before UNIX EPOCH!".to_string(),
+            ));
+        }
     };
-    _encode_wbi(params, (img_key, sub_key), cur_time)
+    Ok(_encode_wbi(
+        params,
+        (&keys.img_key, &keys.sub_key),
+        cur_time,
+    ))
 }
 
 fn _encode_wbi(
@@ -89,23 +138,53 @@ fn _encode_wbi(
     query + &format!("&w_rid={web_sign}")
 }
 
-pub(super) async fn get_wbi_keys(client: &Client) -> Result<(String, String), reqwest::Error> {
+async fn fetch_new_keys(client: &Client) -> Result<WbiKeys, reqwest::Error> {
     let ResWbi {
         data: Data { wbi_img },
     } = client
         .get("https://api.bilibili.com/x/web-interface/nav")
         .header(USER_AGENT, DEFAULT_UA)
         .header(reqwest::header::REFERER.to_string(), Bilibili::BASE_URL)
-        // SESSDATA=xxxxx
-        // .header("Cookie", "SESSDATA=xxxxx")
         .send()
         .await?
         .json::<ResWbi>()
         .await?;
-    Ok((
-        take_filename(wbi_img.img_url).unwrap(),
-        take_filename(wbi_img.sub_url).unwrap(),
-    ))
+
+    let img_key = take_filename(wbi_img.img_url).unwrap();
+    let sub_key = take_filename(wbi_img.sub_url).unwrap();
+
+    Ok(WbiKeys::new(img_key, sub_key))
+}
+
+pub(super) async fn get_wbi_keys(client: &Client) -> Result<WbiKeys, reqwest::Error> {
+    let check_keys = || {
+        let rx = WBI_KEYS_RX.clone();
+        let keys = rx.borrow();
+        if let Some(k) = &*keys {
+            if !k.is_stale() {
+                return Some(Ok(k.clone()));
+            }
+        }
+        None
+    };
+
+    // Initial check
+    if let Some(result) = check_keys() {
+        return result;
+    }
+
+    // If cache is stale or empty, acquire lock to refresh.
+    let _lock = WBI_KEYS_WATCH.1.lock().await;
+
+    // Double-check after acquiring lock
+    if let Some(result) = check_keys() {
+        return result;
+    }
+
+    // If still stale, fetch and send the new keys.
+    let new_keys = fetch_new_keys(client).await?;
+    WBI_KEYS_WATCH.0.send(Some(new_keys.clone())).ok();
+    Ok(new_keys)
 }
 
 fn take_filename(url: String) -> Option<String> {
@@ -136,7 +215,8 @@ mod tests {
     #[tokio::test]
     #[ignore]
     async fn test_get_wbi_keys() {
-        let keys = get_wbi_keys(&default_client()).await.unwrap();
+        let keys = get_wbi_keys(&default_client()).await;
+        assert!(keys.is_ok());
         println!("{keys:?}");
     }
 
@@ -167,15 +247,12 @@ mod tests {
             ("bar", String::from("514")),
             ("zab", String::from("1919810")),
         ];
+        let keys = (
+            "7cd084941338484aae1ad9425b84077c",
+            "4932caff0ff746eab6f01bf08b70ac45",
+        );
         assert_eq!(
-            _encode_wbi(
-                params,
-                (
-                    "7cd084941338484aae1ad9425b84077c",
-                    "4932caff0ff746eab6f01bf08b70ac45"
-                ),
-                1702204169
-            ),
+            _encode_wbi(params, keys, 1702204169),
             "bar=514&foo=114&wts=1702204169&zab=1919810&w_rid=8f6f2b5b3d485fe1886cec6a0be8c5d4"
                 .to_string()
         )


### PR DESCRIPTION
- Renamed `_extras` parameter to `extras` in `Bilibili::new` method for clarity.
- Simplified quality determination logic using `Option` combinators.
- Introduced `generate_fake_buvid3` utility function for generating a fake BUVID3 identifier.
- Updated `get_wbi_keys` to utilize a caching mechanism for WBI keys, improving efficiency.
- Adjusted `encode_wbi` to accept a `WbiKeys` struct instead of separate keys.