### PR TITLE
feat(platforms): add utility function to parse boolean values from extras

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1885,7 +1885,7 @@ dependencies = [
 
 [[package]]
 name = "mesio"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "bytes",
  "clap",
@@ -3040,7 +3040,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strev"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2269,7 +2269,7 @@ dependencies = [
 
 [[package]]
 name = "platforms-parser"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "async-trait",
  "boa_engine",

--- a/crates/platforms/Cargo.toml
+++ b/crates/platforms/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "platforms-parser"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2024"
 description = "A library for extracting streaming data from various online platforms."
 repository = "https://github.com/hua0512/rust-srec"

--- a/crates/platforms/src/extractor/mod.rs
+++ b/crates/platforms/src/extractor/mod.rs
@@ -3,6 +3,7 @@ pub mod error;
 pub mod factory;
 pub mod platform_extractor;
 pub mod platforms;
+pub mod utils;
 
 pub use default::{ProxyConfig, default_factory, factory_with_proxy};
 

--- a/crates/platforms/src/extractor/platforms/douyin/builder.rs
+++ b/crates/platforms/src/extractor/platforms/douyin/builder.rs
@@ -13,6 +13,7 @@ use crate::extractor::platforms::douyin::utils::{
     GlobalTtwidManager, extract_rid, fetch_ttwid, generate_ms_token, generate_nonce,
     generate_odin_ttid, get_common_params,
 };
+use crate::extractor::utils::parse_bool_from_extras;
 use crate::media::formats::{MediaFormat, StreamFormat};
 use crate::media::media_info::MediaInfo;
 use crate::media::stream_info::StreamInfo;
@@ -84,10 +85,8 @@ impl Douyin {
         //     extractor.add_param(key.to_string(), value.to_string());
         // }
 
-        let force_origin_quality = extras
-            .as_ref()
-            .and_then(|extras| extras.get("force_origin_quality").and_then(|v| v.as_bool()))
-            .unwrap_or(true);
+        let force_origin_quality =
+            parse_bool_from_extras(extras.as_ref(), "force_origin_quality", false);
 
         let ttwid_management_mode_str = extras
             .as_ref()
@@ -797,7 +796,7 @@ mod tests {
         let config = Douyin::new(TEST_URL.to_string(), default_client(), None, None);
 
         assert_eq!(config.extractor.url, TEST_URL);
-        assert!(config.force_origin_quality);
+        assert!(!config.force_origin_quality);
         assert_eq!(config.ttwid_management_mode, TtwidManagementMode::Global);
         assert!(config.ttwid.is_none());
     }

--- a/crates/platforms/src/extractor/platforms/huya/builder.rs
+++ b/crates/platforms/src/extractor/platforms/huya/builder.rs
@@ -3,6 +3,7 @@ use std::sync::LazyLock;
 use crate::extractor::error::ExtractorError;
 use crate::extractor::platform_extractor::{Extractor, PlatformExtractor};
 use crate::extractor::platforms::huya::huya_tars::decode_get_cdn_token_info_response;
+use crate::extractor::utils::parse_bool_from_extras;
 use crate::media::MediaFormat;
 use crate::media::formats::StreamFormat;
 use crate::media::media_info::MediaInfo;
@@ -60,15 +61,9 @@ impl Huya {
             extractor.set_cookies_from_string(&cookies);
         }
 
-        let force_origin_quality = extras
-            .as_ref()
-            .and_then(|extras| extras.get("force_origin_quality").and_then(|v| v.as_bool()))
-            .unwrap_or(true);
-
-        let use_wup = extras
-            .as_ref()
-            .and_then(|extras| extras.get("use_wup").and_then(|v| v.as_bool()))
-            .unwrap_or(true);
+        let force_origin_quality =
+            parse_bool_from_extras(extras.as_ref(), "force_origin_quality", true);
+        let use_wup = parse_bool_from_extras(extras.as_ref(), "use_wup", true);
 
         Self {
             extractor,

--- a/crates/platforms/src/extractor/utils.rs
+++ b/crates/platforms/src/extractor/utils.rs
@@ -1,0 +1,16 @@
+use serde_json::Value;
+
+pub fn parse_bool_from_extras(extras: Option<&Value>, key: &str, default: bool) -> bool {
+    extras
+        .and_then(|e| e.get(key))
+        .and_then(|v| {
+            if let Some(b) = v.as_bool() {
+                Some(b)
+            } else if let Some(s) = v.as_str() {
+                s.parse::<bool>().ok()
+            } else {
+                None
+            }
+        })
+        .unwrap_or(default)
+}

--- a/mesio-cli/Cargo.toml
+++ b/mesio-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mesio"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2024"
 description = "Mesio (media) streaming downloader CLI"
 license = "MIT OR Apache-2.0"

--- a/strev-cli/Cargo.toml
+++ b/strev-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "strev"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2024"
 description = "Strev (Streev) - CLI tool for streaming media extraction and retrieval from various platforms"
 authors = ["rust-srec team"]
@@ -13,13 +13,7 @@ thiserror = "2.0"
 platforms-parser = { path = "../crates/platforms" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-reqwest = { version = "0.12", default-features = false, features = [
-    "json",
-    "stream",
-    "rustls-tls",
-    "system-proxy",
-    "socks"
-] }
+reqwest = { version = "0.12", default-features = false}
 
 tokio = { version = "1.47.1", features = [
     "rt-multi-thread",


### PR DESCRIPTION
- Introduced `parse_bool_from_extras` function in `utils.rs` to simplify boolean parsing from extras.
- Updated `force_origin_quality` handling in Douyin and Huya builders to use the new utility function.