### PR TITLE
ci: skip Rust CI jobs on frontend-only PRs

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -17,6 +17,8 @@ env:
 jobs:
   clippy:
     name: Clippy
+    needs: check-changes
+    if: needs.check-changes.outputs.rust == 'true'
     runs-on: ubuntu-latest
     env:
       RUSTC_WRAPPER: sccache
@@ -46,6 +48,8 @@ jobs:
 
   test:
     name: Test Suite
+    needs: check-changes
+    if: needs.check-changes.outputs.rust == 'true'
     strategy:
       matrix:
         include:
@@ -96,6 +100,7 @@ jobs:
     name: Check Changed Files
     runs-on: ubuntu-latest
     outputs:
+      rust: ${{ steps.filter.outputs.rust }}
       frontend: ${{ steps.filter.outputs.frontend }}
       desktop: ${{ steps.filter.outputs.desktop }}
     steps:
@@ -104,6 +109,12 @@ jobs:
         id: filter
         with:
           filters: |
+            rust:
+              - 'crates/**'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - 'rust-srec/src-tauri/**'
+              - '.github/workflows/pr.yml'
             frontend:
               - 'rust-srec/frontend/**'
             desktop:


### PR DESCRIPTION
Add path filtering to clippy and 	est jobs in pr.yml so they only run when Rust-related files change.

## Changes

- Added a ust path filter to the existing check-changes job, matching: crates/**, Cargo.toml, Cargo.lock, ust-srec/src-tauri/**, .github/workflows/pr.yml
- Made clippy and 	est jobs depend on check-changes with \if: needs.check-changes.outputs.rust == 'true'\

## Why

Dependabot PRs that only update frontend npm dependencies (files in ust-srec/frontend/) were unnecessarily triggering the full Rust CI (clippy + test suite across 5 OS targets), wasting CI minutes.