### PR TITLE
fix(scheduler): preserve actor state when authoritative temp-disable suppresses live

### DIFF
--- a/rust-srec/src/monitor/mod.rs
+++ b/rust-srec/src/monitor/mod.rs
@@ -18,4 +18,6 @@ pub use batch_detector::{BatchDetector, BatchFailure, BatchResult};
 pub use detector::{FilterReason, LiveStatus, StreamDetector, StreamInfo};
 pub use events::{FatalErrorType, MonitorEvent, MonitorEventBroadcaster};
 pub use rate_limiter::{RateLimiter, RateLimiterConfig, RateLimiterManager};
-pub use service::{StreamMonitor, StreamMonitorConfig};
+pub use service::{
+    ProcessStatusResult, ProcessStatusSuppression, StreamMonitor, StreamMonitorConfig,
+};

--- a/rust-srec/src/monitor/service.rs
+++ b/rust-srec/src/monitor/service.rs
@@ -32,6 +32,53 @@ use super::detector::{FilterReason, LiveStatus, StreamDetector};
 use super::events::{FatalErrorType, MonitorEvent, MonitorEventBroadcaster};
 use super::rate_limiter::{RateLimiterConfig, RateLimiterManager};
 
+/// Result of [`StreamMonitor::process_status`].
+///
+/// This separates two outcomes that previously looked identical at the type level:
+///
+/// - the monitor accepted the observed [`LiveStatus`] and applied its normal side effects
+///   (state changes, session updates, outbox events)
+/// - the monitor intentionally suppressed those side effects because the streamer is disabled
+///   or still inside temporary backoff
+///
+/// Callers such as the scheduler actor use this to preserve authoritative backoff while still
+/// keeping their local runtime state recoverable. In particular, a suppressed LIVE observation
+/// must not leave the actor stuck in a pseudo-live state when no [`MonitorEvent::StreamerLive`]
+/// was emitted.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ProcessStatusResult {
+    /// The status was accepted and normal side effects were applied.
+    ///
+    /// For example, a LIVE status may create or resume a session and enqueue a
+    /// [`MonitorEvent::StreamerLive`] outbox entry.
+    Applied,
+    /// The status was intentionally suppressed.
+    ///
+    /// Suppression means the status was observed, but `process_status()` deliberately skipped
+    /// downstream effects. Callers should inspect the [`ProcessStatusSuppression`] reason and
+    /// decide how to schedule the next retry without assuming the streamer has fully transitioned.
+    Suppressed(ProcessStatusSuppression),
+}
+
+/// Reason a status was suppressed by [`StreamMonitor::process_status`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ProcessStatusSuppression {
+    /// The streamer is manually disabled.
+    ///
+    /// This is the strongest suppression mode: manual disable should block monitor-driven state
+    /// changes and side effects until the user re-enables the streamer.
+    Disabled,
+    /// The streamer is temporarily disabled due to error backoff.
+    ///
+    /// Backoff remains authoritative: monitor side effects are skipped while cooldown is active.
+    /// The optional `retry_after` value tells callers when status processing can be retried
+    /// without re-entering the same suppression path.
+    TemporarilyDisabled {
+        /// Remaining delay before status processing should be retried.
+        retry_after: Option<Duration>,
+    },
+}
+
 /// Hard upper bound for a single streamer status check to avoid indefinitely-stuck in-flight
 /// deduplication entries when upstream requests hang.
 const STREAM_CHECK_HARD_TIMEOUT: Duration = Duration::from_secs(300);
@@ -613,7 +660,7 @@ impl<
         &self,
         streamer: &StreamerMetadata,
         status: LiveStatus,
-    ) -> Result<()> {
+    ) -> Result<ProcessStatusResult> {
         debug!(
             "Processing status for {}: {:?}",
             streamer.id,
@@ -633,7 +680,9 @@ impl<
                 streamer.id,
                 status_summary(&status)
             );
-            return Ok(());
+            return Ok(ProcessStatusResult::Suppressed(
+                ProcessStatusSuppression::Disabled,
+            ));
         }
 
         if streamer.is_disabled() {
@@ -643,7 +692,13 @@ impl<
                 disabled_until = ?streamer.disabled_until,
                 "Ignoring monitor status while temporarily disabled"
             );
-            return Ok(());
+            return Ok(ProcessStatusResult::Suppressed(
+                ProcessStatusSuppression::TemporarilyDisabled {
+                    retry_after: streamer
+                        .remaining_backoff()
+                        .and_then(|duration| duration.to_std().ok()),
+                },
+            ));
         }
 
         match status {
@@ -729,7 +784,7 @@ impl<
             }
         }
 
-        Ok(())
+        Ok(ProcessStatusResult::Applied)
     }
 
     /// Handle a streamer going live.
@@ -1786,10 +1841,11 @@ mod tests {
         let monitor = build_test_monitor(&pool).await;
         let streamer = monitor.streamer_manager.get_streamer("streamer-3").unwrap();
 
-        monitor
+        let outcome = monitor
             .process_status(&streamer, LiveStatus::Offline)
             .await
             .unwrap();
+        assert_eq!(outcome, ProcessStatusResult::Applied);
 
         let session_row = sqlx::query("SELECT end_time FROM live_sessions WHERE id = ?")
             .bind("session-3")
@@ -1824,6 +1880,139 @@ mod tests {
         assert_eq!(entries.len(), 1);
         assert!(entries[0].payload.contains("StreamerOffline"));
         assert!(entries[0].payload.contains("session-3"));
+
+        monitor.stop();
+    }
+
+    #[tokio::test]
+    async fn test_process_status_live_is_suppressed_while_temporarily_disabled() {
+        let pool = setup_monitor_test_db().await;
+        insert_streamer(
+            &pool,
+            "streamer-live-suppressed",
+            StreamerState::TemporalDisabled,
+            3,
+            Some(chrono::Utc::now().timestamp_millis() + 60_000),
+        )
+        .await;
+
+        let monitor = build_test_monitor(&pool).await;
+        let streamer = monitor
+            .streamer_manager
+            .get_streamer("streamer-live-suppressed")
+            .unwrap();
+
+        let outcome = monitor
+            .process_status(
+                &streamer,
+                LiveStatus::Live {
+                    title: "Suppressed Live".to_string(),
+                    category: None,
+                    avatar: None,
+                    started_at: None,
+                    viewer_count: None,
+                    streams: vec![platforms_parser::media::StreamInfo {
+                        url: "https://example.com/stream.m3u8".to_string(),
+                        stream_format: platforms_parser::media::StreamFormat::Flv,
+                        media_format: platforms_parser::media::formats::MediaFormat::Flv,
+                        quality: "best".to_string(),
+                        bitrate: 5_000_000,
+                        priority: 1,
+                        extras: None,
+                        codec: "h264".to_string(),
+                        fps: 30.0,
+                        is_headers_needed: false,
+                        is_audio_only: false,
+                    }],
+                    media_headers: None,
+                    media_extras: None,
+                    next_check_hint: None,
+                },
+            )
+            .await
+            .unwrap();
+
+        assert!(matches!(
+            outcome,
+            ProcessStatusResult::Suppressed(ProcessStatusSuppression::TemporarilyDisabled {
+                retry_after: Some(_)
+            })
+        ));
+
+        let active_session_count: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM live_sessions WHERE streamer_id = ? AND end_time IS NULL",
+        )
+        .bind("streamer-live-suppressed")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(active_session_count, 0);
+
+        let entries = MonitorOutboxOps::fetch_undelivered(&pool, 10)
+            .await
+            .unwrap();
+        assert!(entries.is_empty());
+
+        monitor.stop();
+    }
+
+    #[tokio::test]
+    async fn test_process_status_live_is_suppressed_for_user_disabled_streamer() {
+        let pool = setup_monitor_test_db().await;
+        insert_streamer(
+            &pool,
+            "streamer-user-disabled",
+            StreamerState::Disabled,
+            0,
+            None,
+        )
+        .await;
+
+        let monitor = build_test_monitor(&pool).await;
+        let streamer = monitor
+            .streamer_manager
+            .get_streamer("streamer-user-disabled")
+            .unwrap();
+
+        let outcome = monitor
+            .process_status(
+                &streamer,
+                LiveStatus::Live {
+                    title: "Should Stay Disabled".to_string(),
+                    category: None,
+                    avatar: None,
+                    started_at: None,
+                    viewer_count: None,
+                    streams: vec![platforms_parser::media::StreamInfo {
+                        url: "https://example.com/stream.flv".to_string(),
+                        stream_format: platforms_parser::media::StreamFormat::Flv,
+                        media_format: platforms_parser::media::formats::MediaFormat::Flv,
+                        quality: "best".to_string(),
+                        bitrate: 5_000_000,
+                        priority: 1,
+                        extras: None,
+                        codec: "h264".to_string(),
+                        fps: 30.0,
+                        is_headers_needed: false,
+                        is_audio_only: false,
+                    }],
+                    media_headers: None,
+                    media_extras: None,
+                    next_check_hint: None,
+                },
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            outcome,
+            ProcessStatusResult::Suppressed(ProcessStatusSuppression::Disabled)
+        );
+
+        let entries = MonitorOutboxOps::fetch_undelivered(&pool, 10)
+            .await
+            .unwrap();
+        assert!(entries.is_empty());
 
         monitor.stop();
     }

--- a/rust-srec/src/scheduler/actor/monitor_adapter.rs
+++ b/rust-srec/src/scheduler/actor/monitor_adapter.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 
-use crate::monitor::{FilterReason, LiveStatus};
+use crate::monitor::{FilterReason, LiveStatus, ProcessStatusResult};
 use crate::streamer::StreamerMetadata;
 
 use super::messages::{BatchDetectionResult, CheckResult};
@@ -29,14 +29,21 @@ pub trait StatusChecker: Send + Sync + 'static {
         streamer: &StreamerMetadata,
     ) -> Result<(CheckResult, LiveStatus), CheckError>;
 
-    /// Process a status result and update the streamer state.
+    /// Process a detected status and return whether monitor side effects were applied.
     ///
-    /// This handles state transitions, event emission, and persistence.
+    /// This handles state transitions, event emission, and persistence, but callers must not
+    /// assume every successful call fully applied the status. A successful return may still be
+    /// [`ProcessStatusResult::Suppressed`] when the monitor intentionally skips side effects due
+    /// to disable/backoff rules.
+    ///
+    /// The scheduler actor relies on this distinction to avoid entering a sticky runtime `Live`
+    /// state when a LIVE observation was suppressed and no [`crate::monitor::MonitorEvent::StreamerLive`]
+    /// event was emitted.
     async fn process_status(
         &self,
         streamer: &StreamerMetadata,
         status: LiveStatus,
-    ) -> Result<(), CheckError>;
+    ) -> Result<ProcessStatusResult, CheckError>;
 
     /// Handle an error during status checking.
     async fn handle_error(
@@ -170,9 +177,9 @@ where
         &self,
         streamer: &StreamerMetadata,
         status: LiveStatus,
-    ) -> Result<(), CheckError> {
-        self.monitor.process_status(streamer, status).await?;
-        Ok(())
+    ) -> Result<ProcessStatusResult, CheckError> {
+        let outcome = self.monitor.process_status(streamer, status).await?;
+        Ok(outcome)
     }
 
     async fn handle_error(
@@ -375,8 +382,8 @@ impl StatusChecker for NoOpStatusChecker {
         &self,
         _streamer: &StreamerMetadata,
         _status: LiveStatus,
-    ) -> Result<(), CheckError> {
-        Ok(())
+    ) -> Result<ProcessStatusResult, CheckError> {
+        Ok(ProcessStatusResult::Applied)
     }
 
     async fn handle_error(

--- a/rust-srec/src/scheduler/actor/streamer_actor.rs
+++ b/rust-srec/src/scheduler/actor/streamer_actor.rs
@@ -35,7 +35,7 @@ use super::metrics::ActorMetrics;
 use super::monitor_adapter::StatusChecker;
 use crate::domain::{Priority, StreamerState};
 use crate::downloader::DownloadStopCause;
-use crate::monitor::LiveStatus;
+use crate::monitor::{LiveStatus, ProcessStatusResult, ProcessStatusSuppression};
 use crate::scheduler::actor::DownloadEndPolicy;
 use crate::streamer::StreamerMetadata;
 
@@ -484,6 +484,38 @@ impl StreamerActor {
         }
     }
 
+    fn handle_suppressed_live_status(
+        &mut self,
+        suppression: ProcessStatusSuppression,
+        previous_runtime_state: StreamerActorState,
+    ) {
+        let retry_after = match suppression {
+            ProcessStatusSuppression::Disabled => {
+                debug!(
+                    streamer_id = %self.id,
+                    previous_state = ?previous_runtime_state.streamer_state,
+                    "live status suppressed because streamer is manually disabled"
+                );
+                Duration::from_millis(self.config.check_interval_ms)
+            }
+            ProcessStatusSuppression::TemporarilyDisabled { retry_after } => {
+                let retry_after = retry_after
+                    .unwrap_or_else(|| Duration::from_millis(self.config.check_interval_ms));
+                debug!(
+                    streamer_id = %self.id,
+                    previous_state = ?previous_runtime_state.streamer_state,
+                    retry_after = ?retry_after,
+                    "live status suppressed by temporary disable; reverting actor state"
+                );
+                retry_after
+            }
+        };
+
+        self.state = previous_runtime_state;
+        self.state.last_download_activity_at = None;
+        self.state.next_check = Some(Instant::now() + retry_after);
+    }
+
     /// Initiate a status check.
     ///
     /// If on a batch-capable platform, delegates to the PlatformActor.
@@ -579,7 +611,7 @@ impl StreamerActor {
         // Perform the actual status check using the status checker
         match self.status_checker.check_status(&metadata).await {
             Ok((result, status)) => {
-                // let prev_state = self.state.streamer_state;
+                let previous_runtime_state = self.state.clone();
                 let next_state = result.state;
                 let error_count = self.get_error_count();
 
@@ -591,16 +623,27 @@ impl StreamerActor {
                 let should_emit = self.state.record_check(result, &self.config, error_count);
 
                 // Call process_status only if hysteresis allows it
-                if should_emit
-                    && let Err(e) = self.status_checker.process_status(&metadata, status).await
-                {
-                    warn!("StreamerActor {} failed to process status: {}", self.id, e);
-                    // Revert Live state to prevent the actor from getting stuck in
-                    // the watchdog path when no session/download was actually created.
-                    if self.state.streamer_state == StreamerState::Live {
-                        self.state.streamer_state = StreamerState::NotLive;
-                        self.state.last_download_activity_at = None;
-                        self.state.schedule_immediate_check();
+                if should_emit {
+                    match self.status_checker.process_status(&metadata, status).await {
+                        Ok(ProcessStatusResult::Applied) => {}
+                        Ok(ProcessStatusResult::Suppressed(suppression)) => {
+                            if next_state == StreamerState::Live {
+                                self.handle_suppressed_live_status(
+                                    suppression,
+                                    previous_runtime_state,
+                                );
+                            }
+                        }
+                        Err(e) => {
+                            warn!("StreamerActor {} failed to process status: {}", self.id, e);
+                            // Revert Live state to prevent the actor from getting stuck in
+                            // the watchdog path when no session/download was actually created.
+                            if self.state.streamer_state == StreamerState::Live {
+                                self.state.streamer_state = StreamerState::NotLive;
+                                self.state.last_download_activity_at = None;
+                                self.state.schedule_immediate_check();
+                            }
+                        }
                     }
                 }
 
@@ -779,7 +822,7 @@ impl StreamerActor {
             return Ok(());
         }
 
-        let _prev_state = self.state.streamer_state;
+        let previous_runtime_state = self.state.clone();
         let next_state = result.result.state;
         let error_count = self.get_error_count();
         let is_error = result.result.is_error();
@@ -828,22 +871,31 @@ impl StreamerActor {
         // Call process_status only if hysteresis allows it
         if should_emit {
             // Fetch fresh metadata for process_status
-            if let Some(metadata) = self.get_metadata()
-                && let Err(e) = self
+            if let Some(metadata) = self.get_metadata() {
+                match self
                     .status_checker
                     .process_status(&metadata, result.status)
                     .await
-            {
-                warn!(
-                    "StreamerActor {} failed to process batch status: {}",
-                    self.id, e
-                );
-                // Revert Live state to prevent the actor from getting stuck in
-                // the watchdog path when no session/download was actually created.
-                if self.state.streamer_state == StreamerState::Live {
-                    self.state.streamer_state = StreamerState::NotLive;
-                    self.state.last_download_activity_at = None;
-                    self.state.schedule_immediate_check();
+                {
+                    Ok(ProcessStatusResult::Applied) => {}
+                    Ok(ProcessStatusResult::Suppressed(suppression)) => {
+                        if next_state == StreamerState::Live {
+                            self.handle_suppressed_live_status(suppression, previous_runtime_state);
+                        }
+                    }
+                    Err(e) => {
+                        warn!(
+                            "StreamerActor {} failed to process batch status: {}",
+                            self.id, e
+                        );
+                        // Revert Live state to prevent the actor from getting stuck in
+                        // the watchdog path when no session/download was actually created.
+                        if self.state.streamer_state == StreamerState::Live {
+                            self.state.streamer_state = StreamerState::NotLive;
+                            self.state.last_download_activity_at = None;
+                            self.state.schedule_immediate_check();
+                        }
+                    }
                 }
             }
         }
@@ -1423,8 +1475,12 @@ impl PersistedActorState {
 mod tests {
     use super::*;
     use crate::domain::Priority;
-    use crate::scheduler::actor::monitor_adapter::NoOpStatusChecker;
+    use crate::monitor::{ProcessStatusResult, ProcessStatusSuppression};
+    use crate::scheduler::actor::monitor_adapter::{CheckError, NoOpStatusChecker};
+    use async_trait::async_trait;
+    use std::collections::VecDeque;
     use std::sync::Arc;
+    use std::sync::Mutex;
 
     fn create_test_metadata() -> StreamerMetadata {
         StreamerMetadata {
@@ -1465,6 +1521,64 @@ mod tests {
 
     fn create_noop_checker() -> Arc<dyn StatusChecker> {
         Arc::new(NoOpStatusChecker)
+    }
+
+    #[derive(Debug)]
+    struct SequenceStatusChecker {
+        checks: Mutex<VecDeque<(CheckResult, LiveStatus)>>,
+        outcomes: Mutex<VecDeque<ProcessStatusResult>>,
+    }
+
+    impl SequenceStatusChecker {
+        fn new(checks: Vec<(CheckResult, LiveStatus)>, outcomes: Vec<ProcessStatusResult>) -> Self {
+            Self {
+                checks: Mutex::new(VecDeque::from(checks)),
+                outcomes: Mutex::new(VecDeque::from(outcomes)),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl StatusChecker for SequenceStatusChecker {
+        async fn check_status(
+            &self,
+            _streamer: &StreamerMetadata,
+        ) -> Result<(CheckResult, LiveStatus), CheckError> {
+            self.checks
+                .lock()
+                .unwrap()
+                .pop_front()
+                .ok_or_else(|| CheckError::transient("missing check result"))
+        }
+
+        async fn process_status(
+            &self,
+            _streamer: &StreamerMetadata,
+            _status: LiveStatus,
+        ) -> Result<ProcessStatusResult, CheckError> {
+            Ok(self
+                .outcomes
+                .lock()
+                .unwrap()
+                .pop_front()
+                .unwrap_or(ProcessStatusResult::Applied))
+        }
+
+        async fn handle_error(
+            &self,
+            _streamer: &StreamerMetadata,
+            _error: &str,
+        ) -> Result<(), CheckError> {
+            Ok(())
+        }
+
+        async fn set_circuit_breaker_blocked(
+            &self,
+            _streamer: &StreamerMetadata,
+            _retry_after_secs: u64,
+        ) -> Result<(), CheckError> {
+            Ok(())
+        }
     }
 
     #[test]
@@ -1955,5 +2069,250 @@ mod tests {
         assert!(actor.state.next_check.is_some());
         // Hysteresis should be preserved - let checks determine actual state
         assert!(actor.state.hysteresis.was_live());
+    }
+
+    #[tokio::test]
+    async fn test_perform_check_suppressed_live_does_not_leave_actor_stuck_live() {
+        let metadata_store = create_test_metadata_store();
+        let config = create_test_config();
+        let token = CancellationToken::new();
+
+        let checker: Arc<dyn StatusChecker> = Arc::new(SequenceStatusChecker::new(
+            vec![(
+                CheckResult::success(StreamerState::Live),
+                LiveStatus::Live {
+                    title: "Suppressed Live".to_string(),
+                    category: None,
+                    started_at: None,
+                    viewer_count: None,
+                    avatar: None,
+                    streams: vec![],
+                    media_headers: None,
+                    media_extras: None,
+                    next_check_hint: None,
+                },
+            )],
+            vec![ProcessStatusResult::Suppressed(
+                ProcessStatusSuppression::TemporarilyDisabled {
+                    retry_after: Some(Duration::from_secs(30)),
+                },
+            )],
+        ));
+
+        let (mut actor, _handle) = StreamerActor::new(
+            "test-streamer".to_string(),
+            metadata_store,
+            config,
+            token,
+            checker,
+        );
+
+        actor.perform_check().await.unwrap();
+
+        assert_eq!(actor.state.streamer_state, StreamerState::NotLive);
+        assert!(actor.state.last_download_activity_at.is_none());
+        assert!(actor.state.next_check.is_some());
+        assert!(!actor.state.hysteresis.was_live());
+
+        let until = actor.state.time_until_next_check().unwrap();
+        assert!(until <= Duration::from_secs(30));
+    }
+
+    #[tokio::test]
+    async fn test_perform_check_recovers_after_suppressed_live_when_backoff_expires() {
+        let metadata_store = create_test_metadata_store();
+        let config = create_test_config();
+        let token = CancellationToken::new();
+
+        let checker: Arc<dyn StatusChecker> = Arc::new(SequenceStatusChecker::new(
+            vec![
+                (
+                    CheckResult::success(StreamerState::Live),
+                    LiveStatus::Live {
+                        title: "Suppressed Live".to_string(),
+                        category: None,
+                        started_at: None,
+                        viewer_count: None,
+                        avatar: None,
+                        streams: vec![],
+                        media_headers: None,
+                        media_extras: None,
+                        next_check_hint: None,
+                    },
+                ),
+                (
+                    CheckResult::success(StreamerState::Live),
+                    LiveStatus::Live {
+                        title: "Recovered Live".to_string(),
+                        category: None,
+                        started_at: None,
+                        viewer_count: None,
+                        avatar: None,
+                        streams: vec![],
+                        media_headers: None,
+                        media_extras: None,
+                        next_check_hint: None,
+                    },
+                ),
+            ],
+            vec![
+                ProcessStatusResult::Suppressed(ProcessStatusSuppression::TemporarilyDisabled {
+                    retry_after: Some(Duration::from_secs(1)),
+                }),
+                ProcessStatusResult::Applied,
+            ],
+        ));
+
+        let (mut actor, _handle) = StreamerActor::new(
+            "test-streamer".to_string(),
+            metadata_store,
+            config,
+            token,
+            checker,
+        );
+
+        actor.perform_check().await.unwrap();
+        assert_eq!(actor.state.streamer_state, StreamerState::NotLive);
+        assert!(!actor.state.hysteresis.was_live());
+
+        actor.perform_check().await.unwrap();
+
+        assert_eq!(actor.state.streamer_state, StreamerState::Live);
+        assert!(actor.state.last_download_activity_at.is_some());
+        assert!(actor.state.next_check.is_none());
+        assert!(actor.state.hysteresis.was_live());
+    }
+
+    #[tokio::test]
+    async fn test_suppressed_live_restores_notlive_grace_hysteresis_context() {
+        let metadata_store = create_test_metadata_store();
+        let config = create_test_config();
+        let token = CancellationToken::new();
+
+        let checker: Arc<dyn StatusChecker> = Arc::new(SequenceStatusChecker::new(
+            vec![(
+                CheckResult::success(StreamerState::Live),
+                LiveStatus::Live {
+                    title: "Suppressed Live".to_string(),
+                    category: None,
+                    started_at: None,
+                    viewer_count: None,
+                    avatar: None,
+                    streams: vec![],
+                    media_headers: None,
+                    media_extras: None,
+                    next_check_hint: None,
+                },
+            )],
+            vec![ProcessStatusResult::Suppressed(
+                ProcessStatusSuppression::TemporarilyDisabled {
+                    retry_after: Some(Duration::from_secs(30)),
+                },
+            )],
+        ));
+
+        let (mut actor, _handle) = StreamerActor::new(
+            "test-streamer".to_string(),
+            metadata_store,
+            config.clone(),
+            token,
+            checker,
+        );
+
+        actor.state.streamer_state = StreamerState::NotLive;
+        actor.state.hysteresis.mark_live();
+        actor.state.hysteresis.mark_offline_observed();
+        let original_offline_count = actor.state.hysteresis.offline_count();
+        actor.state.last_check = Some(CheckResult {
+            state: StreamerState::NotLive,
+            stream_url: None,
+            title: Some("Previous offline".to_string()),
+            checked_at: chrono::Utc::now(),
+            error: None,
+            next_check_hint: None,
+        });
+
+        actor.perform_check().await.unwrap();
+
+        assert_eq!(actor.state.streamer_state, StreamerState::NotLive);
+        assert!(actor.state.hysteresis.was_live());
+        assert_eq!(
+            actor.state.hysteresis.offline_count(),
+            original_offline_count
+        );
+        assert_eq!(
+            actor
+                .state
+                .last_check
+                .as_ref()
+                .and_then(|check| check.title.as_deref()),
+            Some("Previous offline")
+        );
+        let until = actor.state.time_until_next_check().unwrap();
+        assert!(until <= Duration::from_secs(30));
+    }
+
+    #[tokio::test]
+    async fn test_suppressed_live_restores_out_of_schedule_smart_wake_context() {
+        let metadata_store = create_test_metadata_store();
+        let config = create_test_config();
+        let token = CancellationToken::new();
+
+        let checker: Arc<dyn StatusChecker> = Arc::new(SequenceStatusChecker::new(
+            vec![(
+                CheckResult::success(StreamerState::Live),
+                LiveStatus::Live {
+                    title: "Suppressed Live".to_string(),
+                    category: None,
+                    started_at: None,
+                    viewer_count: None,
+                    avatar: None,
+                    streams: vec![],
+                    media_headers: None,
+                    media_extras: None,
+                    next_check_hint: None,
+                },
+            )],
+            vec![ProcessStatusResult::Suppressed(
+                ProcessStatusSuppression::TemporarilyDisabled {
+                    retry_after: Some(Duration::from_secs(30)),
+                },
+            )],
+        ));
+
+        let (mut actor, _handle) = StreamerActor::new(
+            "test-streamer".to_string(),
+            metadata_store,
+            config,
+            token,
+            checker,
+        );
+
+        let smart_wake_hint = chrono::Utc::now() + chrono::Duration::minutes(15);
+        actor.state.streamer_state = StreamerState::OutOfSchedule;
+        actor.state.hysteresis.mark_live();
+        actor.state.last_check = Some(CheckResult {
+            state: StreamerState::OutOfSchedule,
+            stream_url: None,
+            title: Some("Out of schedule".to_string()),
+            checked_at: chrono::Utc::now(),
+            error: None,
+            next_check_hint: Some(smart_wake_hint),
+        });
+
+        actor.perform_check().await.unwrap();
+
+        assert_eq!(actor.state.streamer_state, StreamerState::OutOfSchedule);
+        assert!(actor.state.hysteresis.was_live());
+        assert_eq!(
+            actor
+                .state
+                .last_check
+                .as_ref()
+                .and_then(|check| check.next_check_hint),
+            Some(smart_wake_hint)
+        );
+        let until = actor.state.time_until_next_check().unwrap();
+        assert!(until <= Duration::from_secs(30));
     }
 }


### PR DESCRIPTION
Fix the regression introduced by #365 change where suppressed LIVE checks could leave the scheduler in a pseudo-live state. Restore the full pre-check actor runtime context so backoff stays authoritative while post-live grace polling, smart wake hints, and recovery after cooldown still work correctly.

## What changed?

Describe the change and the motivation.

## Scope

- Affected components (backend / frontend / desktop / CLI / crates / docs):
- Breaking change: yes/no

## How to test

Steps reviewers can run to validate locally.

## Checklist

- [ ] I ran formatting (`cargo fmt --all`) if Rust code changed
- [ ] I ran lint (`cargo clippy ...`) if Rust code changed
- [ ] I ran tests (`cargo test` or `cargo nextest run`) if feasible
- [ ] I updated docs/config examples if behavior changed
- [ ] I avoided logging secrets and redacted sensitive info in screenshots/logs

## Related issues

Link issues (e.g. `Fixes #123`).
