### PR TITLE
fix(frontend): subscription dialog overflow on scaled displays

### DIFF
--- a/rust-srec/frontend/src/components/notifications/subscription-manager.tsx
+++ b/rust-srec/frontend/src/components/notifications/subscription-manager.tsx
@@ -244,15 +244,8 @@ export function SubscriptionManager({
     hidden: { opacity: 0 },
     show: {
       opacity: 1,
-      transition: {
-        staggerChildren: 0.05,
-      },
+      transition: { duration: 0.15 },
     },
-  };
-
-  const item = {
-    hidden: { opacity: 0, x: -10 },
-    show: { opacity: 1, x: 0 },
   };
 
   const handleSelectAll = (filteredTypes: typeof eventTypes) => {
@@ -295,8 +288,8 @@ export function SubscriptionManager({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-[550px] max-h-[85vh] bg-background/95 backdrop-blur-xl border-border/50 shadow-2xl">
-        <DialogHeader className="pb-4 border-b border-border/40 space-y-2">
+      <DialogContent className="sm:max-w-[550px] max-h-[85vh] overflow-hidden flex flex-col bg-background/95 backdrop-blur-xl border-border/50 shadow-2xl">
+        <DialogHeader className="shrink-0 pb-4 border-b border-border/40 space-y-2">
           <DialogTitle className="flex items-center gap-2 text-xl">
             <BellRing className="h-5 w-5 text-primary" />
             <Trans>Manage Subscriptions</Trans>
@@ -324,7 +317,7 @@ export function SubscriptionManager({
             </div>
           </div>
         ) : (
-          <div className="flex flex-col gap-4 py-4">
+          <div className="flex flex-col gap-4 py-4 min-h-0 flex-1">
             {/* Search and Filters */}
             <div className="flex items-center gap-2">
               <div className="relative flex-1">
@@ -353,7 +346,7 @@ export function SubscriptionManager({
               </Button>
             </div>
 
-            <ScrollArea className="h-[400px] -mr-4 pr-4">
+            <ScrollArea className="h-[50vh] -mr-4 pr-4">
               <motion.div
                 className="space-y-2"
                 variants={container}
@@ -373,9 +366,8 @@ export function SubscriptionManager({
                     const iconConfig = getEventIcon(type.event_type);
                     const IconComponent = iconConfig.icon;
                     return (
-                      <motion.div
+                      <div
                         key={type.event_type}
-                        variants={item}
                         className={`
                                                     group flex flex-row items-center space-x-3 rounded-xl border p-3 transition-all duration-200 cursor-pointer
                                                     ${
@@ -419,14 +411,14 @@ export function SubscriptionManager({
                             {getEventDescription(type.event_type, i18n)}
                           </p>
                         </div>
-                      </motion.div>
+                      </div>
                     );
                   })
                 )}
               </motion.div>
             </ScrollArea>
 
-            <div className="flex items-center justify-between text-xs text-muted-foreground px-1">
+            <div className="shrink-0 flex items-center justify-between text-xs text-muted-foreground px-1">
               <span>
                 {selectedEvents.length} <Trans>selected</Trans>
               </span>
@@ -437,7 +429,7 @@ export function SubscriptionManager({
           </div>
         )}
 
-        <DialogFooter className="pt-4 border-t border-border/40">
+        <DialogFooter className="shrink-0 pt-4 border-t border-border/40">
           <Button variant="ghost" onClick={() => onOpenChange(false)}>
             <Trans>Cancel</Trans>
           </Button>

--- a/rust-srec/frontend/src/locales/en/messages.po
+++ b/rust-srec/frontend/src/locales/en/messages.po
@@ -672,7 +672,7 @@ msgstr "Automate your stream recordings with ease and reliability."
 msgid "Automatically generate a thumbnail for the first segment of each session."
 msgstr "Automatically generate a thumbnail for the first segment of each session."
 
-#: src/components/notifications/subscription-manager.tsx:434
+#: src/components/notifications/subscription-manager.tsx:426
 msgid "available"
 msgstr "available"
 
@@ -886,7 +886,7 @@ msgstr "Caching"
 #: src/components/filters/FilterDialog.tsx:247
 #: src/components/notifications/channel-card.tsx:212
 #: src/components/notifications/channel-form.tsx:385
-#: src/components/notifications/subscription-manager.tsx:442
+#: src/components/notifications/subscription-manager.tsx:434
 #: src/components/pipeline/jobs/pipeline-summary-card.tsx:174
 #: src/components/pipeline/jobs/pipeline-summary-card.tsx:197
 #: src/components/pipeline/jobs/pipeline-summary-card.tsx:234
@@ -1905,7 +1905,7 @@ msgstr "Description"
 msgid "Description is managed by the system"
 msgstr "Description is managed by the system"
 
-#: src/components/notifications/subscription-manager.tsx:348
+#: src/components/notifications/subscription-manager.tsx:341
 msgid "Deselect All"
 msgstr "Deselect All"
 
@@ -3951,7 +3951,7 @@ msgstr "Manage specialized extraction and identification options."
 msgid "Manage storage paths and file formats."
 msgstr "Manage storage paths and file formats."
 
-#: src/components/notifications/subscription-manager.tsx:302
+#: src/components/notifications/subscription-manager.tsx:295
 msgid "Manage Subscriptions"
 msgstr "Manage Subscriptions"
 
@@ -4456,7 +4456,7 @@ msgstr "No logs available for this execution."
 msgid "No logs to display"
 msgstr "No logs to display"
 
-#: src/components/notifications/subscription-manager.tsx:367
+#: src/components/notifications/subscription-manager.tsx:360
 msgid "No matching events found"
 msgstr "No matching events found"
 
@@ -6053,7 +6053,7 @@ msgstr "Sanitized streamer name"
 #: src/components/config/platforms/platform-editor.tsx:159
 #: src/components/config/templates/template-editor.tsx:213
 #: src/components/filters/FilterDialog.tsx:260
-#: src/components/notifications/subscription-manager.tsx:452
+#: src/components/notifications/subscription-manager.tsx:444
 #: src/components/pipeline/presets/editor/preset-save-fab.tsx:37
 #: src/components/pipeline/workflows/step-config-dialog.tsx:543
 #: src/components/streamers/edit/streamer-save-fab.tsx:53
@@ -6126,7 +6126,7 @@ msgstr "Search by name or description..."
 msgid "Search engines..."
 msgstr "Search engines..."
 
-#: src/components/notifications/subscription-manager.tsx:333
+#: src/components/notifications/subscription-manager.tsx:326
 msgid "Search events..."
 msgstr "Search events..."
 
@@ -6229,7 +6229,7 @@ msgid "Select a streamer"
 msgstr "Select a streamer"
 
 #: src/components/notifications/desktop-channel-dialog.tsx:190
-#: src/components/notifications/subscription-manager.tsx:351
+#: src/components/notifications/subscription-manager.tsx:344
 msgid "Select All"
 msgstr "Select All"
 
@@ -6296,7 +6296,7 @@ msgid "Select the days required for this filter to apply."
 msgstr "Select the days required for this filter to apply."
 
 #. placeholder {0}: channel.name
-#: src/components/notifications/subscription-manager.tsx:305
+#: src/components/notifications/subscription-manager.tsx:298
 msgid "Select the events that should trigger notifications for <0>{0}</0>."
 msgstr "Select the events that should trigger notifications for <0>{0}</0>."
 
@@ -6318,7 +6318,7 @@ msgstr "Select type"
 msgid "Select your preferred color scheme."
 msgstr "Select your preferred color scheme."
 
-#: src/components/notifications/subscription-manager.tsx:431
+#: src/components/notifications/subscription-manager.tsx:423
 msgid "selected"
 msgstr "selected"
 

--- a/rust-srec/frontend/src/locales/zh-CN/messages.po
+++ b/rust-srec/frontend/src/locales/zh-CN/messages.po
@@ -672,7 +672,7 @@ msgstr "轻松自动化您的直播录制。"
 msgid "Automatically generate a thumbnail for the first segment of each session."
 msgstr "自动为每个会话的第一段生成封面图。"
 
-#: src/components/notifications/subscription-manager.tsx:434
+#: src/components/notifications/subscription-manager.tsx:426
 msgid "available"
 msgstr "可选"
 
@@ -886,7 +886,7 @@ msgstr "缓存"
 #: src/components/filters/FilterDialog.tsx:247
 #: src/components/notifications/channel-card.tsx:212
 #: src/components/notifications/channel-form.tsx:385
-#: src/components/notifications/subscription-manager.tsx:442
+#: src/components/notifications/subscription-manager.tsx:434
 #: src/components/pipeline/jobs/pipeline-summary-card.tsx:174
 #: src/components/pipeline/jobs/pipeline-summary-card.tsx:197
 #: src/components/pipeline/jobs/pipeline-summary-card.tsx:234
@@ -1905,7 +1905,7 @@ msgstr "描述"
 msgid "Description is managed by the system"
 msgstr "描述由系统管理"
 
-#: src/components/notifications/subscription-manager.tsx:348
+#: src/components/notifications/subscription-manager.tsx:341
 msgid "Deselect All"
 msgstr "取消全选"
 
@@ -3951,7 +3951,7 @@ msgstr "管理专门的提取和识别选项。"
 msgid "Manage storage paths and file formats."
 msgstr "管理存储路径和文件格式。"
 
-#: src/components/notifications/subscription-manager.tsx:302
+#: src/components/notifications/subscription-manager.tsx:295
 msgid "Manage Subscriptions"
 msgstr "管理订阅"
 
@@ -4456,7 +4456,7 @@ msgstr "该执行记录暂无日志。"
 msgid "No logs to display"
 msgstr "暂无日志可显示"
 
-#: src/components/notifications/subscription-manager.tsx:367
+#: src/components/notifications/subscription-manager.tsx:360
 msgid "No matching events found"
 msgstr "未找到匹配的事件"
 
@@ -6053,7 +6053,7 @@ msgstr "清理后的主播名称"
 #: src/components/config/platforms/platform-editor.tsx:159
 #: src/components/config/templates/template-editor.tsx:213
 #: src/components/filters/FilterDialog.tsx:260
-#: src/components/notifications/subscription-manager.tsx:452
+#: src/components/notifications/subscription-manager.tsx:444
 #: src/components/pipeline/presets/editor/preset-save-fab.tsx:37
 #: src/components/pipeline/workflows/step-config-dialog.tsx:543
 #: src/components/streamers/edit/streamer-save-fab.tsx:53
@@ -6126,7 +6126,7 @@ msgstr "按名称或描述搜索..."
 msgid "Search engines..."
 msgstr "搜索引擎..."
 
-#: src/components/notifications/subscription-manager.tsx:333
+#: src/components/notifications/subscription-manager.tsx:326
 msgid "Search events..."
 msgstr "搜索事件..."
 
@@ -6229,7 +6229,7 @@ msgid "Select a streamer"
 msgstr "选择主播"
 
 #: src/components/notifications/desktop-channel-dialog.tsx:190
-#: src/components/notifications/subscription-manager.tsx:351
+#: src/components/notifications/subscription-manager.tsx:344
 msgid "Select All"
 msgstr "全选"
 
@@ -6296,7 +6296,7 @@ msgid "Select the days required for this filter to apply."
 msgstr "选择此过滤器生效的日期。"
 
 #. placeholder {0}: channel.name
-#: src/components/notifications/subscription-manager.tsx:305
+#: src/components/notifications/subscription-manager.tsx:298
 msgid "Select the events that should trigger notifications for <0>{0}</0>."
 msgstr "选择会为 <0>{0}</0> 触发通知的事件。"
 
@@ -6318,7 +6318,7 @@ msgstr "选择类型"
 msgid "Select your preferred color scheme."
 msgstr "选择你偏好的配色方案。"
 
-#: src/components/notifications/subscription-manager.tsx:431
+#: src/components/notifications/subscription-manager.tsx:423
 msgid "selected"
 msgstr "已选"
 


### PR DESCRIPTION
## Summary
Closes #467

- Fix subscription manager dialog content overflowing its bounds on 1920x1080 displays at 125% scaling
- Switch `DialogContent` to flex-col layout with `overflow-hidden` and `shrink-0` on header/footer to prevent content from spilling out
- Replace fixed `h-[400px]` ScrollArea with viewport-relative `h-[50vh]` so it adapts to smaller effective viewports
- Replace per-item stagger animation with a single container fade (150ms) for smoother rendering and less JS overhead with 20+ event items

## Test plan
- [ ] Open Notifications page, add a channel, click 3-dot menu → Subscriptions
- [ ] Verify dialog content stays within bounds on 1920x1080 at 125% scaling
- [ ] Verify the event list is scrollable
- [ ] Verify footer buttons (Cancel / Save) are visible and clickable
- [ ] Verify animation is smooth without flickering