### PR TITLE
fix(docker): add NVIDIA GPU support for hardware-accelerated transcoding

### DIFF
--- a/rust-srec/docker-compose.yml
+++ b/rust-srec/docker-compose.yml
@@ -44,13 +44,6 @@ services:
         reservations:
           cpus: "${CPU_RESERVATION:-1}"
           memory: ${MEMORY_RESERVATION:-512M}
-          # Uncomment below to enable NVIDIA GPU access for hardware-accelerated
-          # transcoding (NVENC/NVDEC). Requires NVIDIA Container Toolkit on the host:
-          # https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html
-          # devices:
-          #   - driver: nvidia
-          #     count: 1
-          #     capabilities: [gpu, video]
     logging:
       driver: "json-file"
       options:

--- a/rust-srec/docs/.vitepress/config.mts
+++ b/rust-srec/docs/.vitepress/config.mts
@@ -10,6 +10,7 @@ export default defineConfig({
         /^\/api\/docs/,
         /^http:\/\/localhost/,
         '/docker-compose.example.yml',
+        '/docker-compose.gpu.yml',
         '/env.example',
         '/env.zh.example',
     ],

--- a/rust-srec/docs/en/getting-started/docker.md
+++ b/rust-srec/docs/en/getting-started/docker.md
@@ -192,14 +192,29 @@ If you have an NVIDIA GPU, you can enable hardware-accelerated video transcoding
      sudo systemctl restart docker
      ```
 
-### Enable GPU in docker-compose.yml
+### Enable GPU in docker-compose
 
-Uncomment the `deploy` section in your `docker-compose.yml` to grant GPU access to the container:
+Download the GPU compose override file alongside your `docker-compose.yml`:
+
+- <a :href="withBase('/docker-compose.gpu.yml')" download>docker-compose.gpu.yml</a>
+
+Then start with both files:
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.gpu.yml up -d
+```
+
+Or set `COMPOSE_FILE` in your `.env` so `docker compose up -d` picks it up automatically:
+
+```bash
+echo "COMPOSE_FILE=docker-compose.yml:docker-compose.gpu.yml" >> .env
+```
+
+The override file adds the NVIDIA device reservation:
 
 ```yaml
 services:
   rust-srec:
-    # ...
     deploy:
       resources:
         reservations:

--- a/rust-srec/docs/public/docker-compose.example.yml
+++ b/rust-srec/docs/public/docker-compose.example.yml
@@ -49,13 +49,6 @@ services:
     #     reservations:
     #       cpus: "${CPU_RESERVATION:-1}"
     #       memory: ${MEMORY_RESERVATION:-512M}
-    #       # Uncomment below to enable NVIDIA GPU access for hardware-accelerated
-    #       # transcoding (NVENC/NVDEC). Requires NVIDIA Container Toolkit on the host:
-    #       # https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html
-    #       devices:
-    #         - driver: nvidia
-    #           count: 1
-    #           capabilities: [gpu, video]
     logging:
       driver: "json-file"
       options:

--- a/rust-srec/docs/public/docker-compose.gpu.yml
+++ b/rust-srec/docs/public/docker-compose.gpu.yml
@@ -1,0 +1,15 @@
+# NVIDIA GPU support for hardware-accelerated transcoding (NVENC/NVDEC).
+# Requires NVIDIA Container Toolkit on the host:
+# https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html
+#
+# Usage:
+#   docker compose -f docker-compose.yml -f docker-compose.gpu.yml up -d
+services:
+  rust-srec:
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: 1
+              capabilities: [gpu, video]

--- a/rust-srec/docs/public/docker-install-zh.ps1
+++ b/rust-srec/docs/public/docker-install-zh.ps1
@@ -190,24 +190,17 @@ function Install-RustSrec {
             Write-Host ""
             $gpuChoice = Read-Host "是否启用 NVIDIA GPU 硬件加速 (NVENC/NVDEC)? [Y/n]"
             if ($gpuChoice -notmatch "^[Nn]$") {
-                Write-Info "正在启用 docker-compose.yml 中的 GPU 支持..."
-                $composeContent = Get-Content "docker-compose.yml" -Raw -Encoding UTF8
-                # Uncomment the deploy block and remove comment instructions
-                $composeContent = $composeContent -replace '(?m)^    # (deploy:)', '    $1'
-                $composeContent = $composeContent -replace '(?m)^    #   (resources:)', '      $1'
-                $composeContent = $composeContent -replace '(?m)^    #     (limits:)', '        $1'
-                $composeContent = $composeContent -replace '(?m)^    #       (cpus:)', '          $1'
-                $composeContent = $composeContent -replace '(?m)^    #       (memory:)', '          $1'
-                $composeContent = $composeContent -replace '(?m)^    #     (reservations:)', '        $1'
-                $composeContent = $composeContent -replace '(?m)^    #       # Uncomment below[^\r\n]*\r?\n', ''
-                $composeContent = $composeContent -replace '(?m)^    #       # transcoding[^\r\n]*\r?\n', ''
-                $composeContent = $composeContent -replace '(?m)^    #       # https://docs\.nvidia[^\r\n]*\r?\n', ''
-                $composeContent = $composeContent -replace '(?m)^    #       (devices:)', '          $1'
-                $composeContent = $composeContent -replace '(?m)^    #         (- driver:)', '            $1'
-                $composeContent = $composeContent -replace '(?m)^    #           (count:)', '              $1'
-                $composeContent = $composeContent -replace '(?m)^    #           (capabilities:)', '              $1'
-                Set-Content "docker-compose.yml" $composeContent -NoNewline -Encoding UTF8
-                Write-Success "已在 docker-compose.yml 中启用 GPU 加速"
+                Write-Info "下载 docker-compose.gpu.yml..."
+                Get-RemoteFile -Url "$($script:BaseUrl)/docker-compose.gpu.yml" -OutFile "docker-compose.gpu.yml"
+                # 设置 COMPOSE_FILE 以便 docker compose 自动加载两个文件
+                $envContent = Get-Content ".env" -Raw -Encoding UTF8
+                if ($envContent -match "(?m)^COMPOSE_FILE=") {
+                    $envContent = $envContent -replace "(?m)^COMPOSE_FILE=.*", "COMPOSE_FILE=docker-compose.yml:docker-compose.gpu.yml"
+                } else {
+                    $envContent = $envContent.TrimEnd() + "`nCOMPOSE_FILE=docker-compose.yml:docker-compose.gpu.yml`n"
+                }
+                Set-Content ".env" $envContent -NoNewline -Encoding UTF8
+                Write-Success "已启用 GPU 加速 (docker-compose.gpu.yml)"
                 Write-Host ""
                 Write-Warn "请确保此主机已安装 NVIDIA Container Toolkit。"
                 Write-Host "  安装指南: https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html" -ForegroundColor Cyan

--- a/rust-srec/docs/public/docker-install-zh.sh
+++ b/rust-srec/docs/public/docker-install-zh.sh
@@ -194,38 +194,19 @@ main() {
         read -p "是否启用 NVIDIA GPU 硬件加速 (NVENC/NVDEC)? [Y/n] " -n 1 -r < /dev/tty
         echo
         if [[ ! $REPLY =~ ^[Nn]$ ]]; then
-            info "正在启用 docker-compose.yml 中的 GPU 支持..."
-            # Uncomment the deploy block
-            if [[ "$OSTYPE" == "darwin"* ]]; then
-                sed -i '' 's/^    # \(deploy:\)/    \1/' docker-compose.yml
-                sed -i '' 's/^    #   \(resources:\)/      \1/' docker-compose.yml
-                sed -i '' 's/^    #     \(limits:\)/        \1/' docker-compose.yml
-                sed -i '' 's/^    #       \(cpus:.*\)/          \1/' docker-compose.yml
-                sed -i '' 's/^    #       \(memory:.*\)/          \1/' docker-compose.yml
-                sed -i '' 's/^    #     \(reservations:\)/        \1/' docker-compose.yml
-                sed -i '' '/^    #       # Uncomment below/d' docker-compose.yml
-                sed -i '' '/^    #       # transcoding/d' docker-compose.yml
-                sed -i '' '/^    #       # https:\/\/docs.nvidia.com/d' docker-compose.yml
-                sed -i '' 's/^    #       \(devices:\)/          \1/' docker-compose.yml
-                sed -i '' 's/^    #         \(- driver:.*\)/            \1/' docker-compose.yml
-                sed -i '' 's/^    #           \(count:.*\)/              \1/' docker-compose.yml
-                sed -i '' 's/^    #           \(capabilities:.*\)/              \1/' docker-compose.yml
+            info "下载 docker-compose.gpu.yml..."
+            download "$BASE_URL/docker-compose.gpu.yml" "docker-compose.gpu.yml"
+            # 设置 COMPOSE_FILE 以便 docker compose 自动加载两个文件
+            if grep -q "^COMPOSE_FILE=" .env 2>/dev/null; then
+                if [[ "$OSTYPE" == "darwin"* ]]; then
+                    sed -i '' 's|^COMPOSE_FILE=.*|COMPOSE_FILE=docker-compose.yml:docker-compose.gpu.yml|' .env
+                else
+                    sed -i 's|^COMPOSE_FILE=.*|COMPOSE_FILE=docker-compose.yml:docker-compose.gpu.yml|' .env
+                fi
             else
-                sed -i 's/^    # \(deploy:\)/    \1/' docker-compose.yml
-                sed -i 's/^    #   \(resources:\)/      \1/' docker-compose.yml
-                sed -i 's/^    #     \(limits:\)/        \1/' docker-compose.yml
-                sed -i 's/^    #       \(cpus:.*\)/          \1/' docker-compose.yml
-                sed -i 's/^    #       \(memory:.*\)/          \1/' docker-compose.yml
-                sed -i 's/^    #     \(reservations:\)/        \1/' docker-compose.yml
-                sed -i '/^    #       # Uncomment below/d' docker-compose.yml
-                sed -i '/^    #       # transcoding/d' docker-compose.yml
-                sed -i '/^    #       # https:\/\/docs.nvidia.com/d' docker-compose.yml
-                sed -i 's/^    #       \(devices:\)/          \1/' docker-compose.yml
-                sed -i 's/^    #         \(- driver:.*\)/            \1/' docker-compose.yml
-                sed -i 's/^    #           \(count:.*\)/              \1/' docker-compose.yml
-                sed -i 's/^    #           \(capabilities:.*\)/              \1/' docker-compose.yml
+                echo "COMPOSE_FILE=docker-compose.yml:docker-compose.gpu.yml" >> .env
             fi
-            success "已在 docker-compose.yml 中启用 GPU 加速"
+            success "已启用 GPU 加速 (docker-compose.gpu.yml)"
             echo ""
             warn "请确保此主机已安装 NVIDIA Container Toolkit。"
             echo "  安装指南: ${BLUE}https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html${NC}"

--- a/rust-srec/docs/public/docker-install.ps1
+++ b/rust-srec/docs/public/docker-install.ps1
@@ -190,24 +190,17 @@ function Install-RustSrec {
             Write-Host ""
             $gpuChoice = Read-Host "Enable NVIDIA GPU hardware acceleration (NVENC/NVDEC)? [Y/n]"
             if ($gpuChoice -notmatch "^[Nn]$") {
-                Write-Info "Enabling GPU support in docker-compose.yml..."
-                $composeContent = Get-Content "docker-compose.yml" -Raw -Encoding UTF8
-                # Uncomment the deploy block and remove comment instructions
-                $composeContent = $composeContent -replace '(?m)^    # (deploy:)', '    $1'
-                $composeContent = $composeContent -replace '(?m)^    #   (resources:)', '      $1'
-                $composeContent = $composeContent -replace '(?m)^    #     (limits:)', '        $1'
-                $composeContent = $composeContent -replace '(?m)^    #       (cpus:)', '          $1'
-                $composeContent = $composeContent -replace '(?m)^    #       (memory:)', '          $1'
-                $composeContent = $composeContent -replace '(?m)^    #     (reservations:)', '        $1'
-                $composeContent = $composeContent -replace '(?m)^    #       # Uncomment below[^\r\n]*\r?\n', ''
-                $composeContent = $composeContent -replace '(?m)^    #       # transcoding[^\r\n]*\r?\n', ''
-                $composeContent = $composeContent -replace '(?m)^    #       # https://docs\.nvidia[^\r\n]*\r?\n', ''
-                $composeContent = $composeContent -replace '(?m)^    #       (devices:)', '          $1'
-                $composeContent = $composeContent -replace '(?m)^    #         (- driver:)', '            $1'
-                $composeContent = $composeContent -replace '(?m)^    #           (count:)', '              $1'
-                $composeContent = $composeContent -replace '(?m)^    #           (capabilities:)', '              $1'
-                Set-Content "docker-compose.yml" $composeContent -NoNewline -Encoding UTF8
-                Write-Success "GPU acceleration enabled in docker-compose.yml"
+                Write-Info "Downloading docker-compose.gpu.yml..."
+                Get-RemoteFile -Url "$($script:BaseUrl)/docker-compose.gpu.yml" -OutFile "docker-compose.gpu.yml"
+                # Set COMPOSE_FILE so docker compose picks up both files automatically
+                $envContent = Get-Content ".env" -Raw -Encoding UTF8
+                if ($envContent -match "(?m)^COMPOSE_FILE=") {
+                    $envContent = $envContent -replace "(?m)^COMPOSE_FILE=.*", "COMPOSE_FILE=docker-compose.yml:docker-compose.gpu.yml"
+                } else {
+                    $envContent = $envContent.TrimEnd() + "`nCOMPOSE_FILE=docker-compose.yml:docker-compose.gpu.yml`n"
+                }
+                Set-Content ".env" $envContent -NoNewline -Encoding UTF8
+                Write-Success "GPU acceleration enabled (docker-compose.gpu.yml)"
                 Write-Host ""
                 Write-Warn "Make sure the NVIDIA Container Toolkit is installed on this host."
                 Write-Host "  Install guide: https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html" -ForegroundColor Cyan

--- a/rust-srec/docs/public/docker-install.sh
+++ b/rust-srec/docs/public/docker-install.sh
@@ -196,38 +196,19 @@ main() {
         read -p "Enable NVIDIA GPU hardware acceleration (NVENC/NVDEC)? [Y/n] " -n 1 -r < /dev/tty
         echo
         if [[ ! $REPLY =~ ^[Nn]$ ]]; then
-            info "Enabling GPU support in docker-compose.yml..."
-            # Uncomment the deploy block (lines starting with "    # " that form the deploy section)
-            if [[ "$OSTYPE" == "darwin"* ]]; then
-                sed -i '' 's/^    # \(deploy:\)/    \1/' docker-compose.yml
-                sed -i '' 's/^    #   \(resources:\)/      \1/' docker-compose.yml
-                sed -i '' 's/^    #     \(limits:\)/        \1/' docker-compose.yml
-                sed -i '' 's/^    #       \(cpus:.*\)/          \1/' docker-compose.yml
-                sed -i '' 's/^    #       \(memory:.*\)/          \1/' docker-compose.yml
-                sed -i '' 's/^    #     \(reservations:\)/        \1/' docker-compose.yml
-                sed -i '' '/^    #       # Uncomment below/d' docker-compose.yml
-                sed -i '' '/^    #       # transcoding/d' docker-compose.yml
-                sed -i '' '/^    #       # https:\/\/docs.nvidia.com/d' docker-compose.yml
-                sed -i '' 's/^    #       \(devices:\)/          \1/' docker-compose.yml
-                sed -i '' 's/^    #         \(- driver:.*\)/            \1/' docker-compose.yml
-                sed -i '' 's/^    #           \(count:.*\)/              \1/' docker-compose.yml
-                sed -i '' 's/^    #           \(capabilities:.*\)/              \1/' docker-compose.yml
+            info "Downloading docker-compose.gpu.yml..."
+            download "$BASE_URL/docker-compose.gpu.yml" "docker-compose.gpu.yml"
+            # Set COMPOSE_FILE so docker compose picks up both files automatically
+            if grep -q "^COMPOSE_FILE=" .env 2>/dev/null; then
+                if [[ "$OSTYPE" == "darwin"* ]]; then
+                    sed -i '' 's|^COMPOSE_FILE=.*|COMPOSE_FILE=docker-compose.yml:docker-compose.gpu.yml|' .env
+                else
+                    sed -i 's|^COMPOSE_FILE=.*|COMPOSE_FILE=docker-compose.yml:docker-compose.gpu.yml|' .env
+                fi
             else
-                sed -i 's/^    # \(deploy:\)/    \1/' docker-compose.yml
-                sed -i 's/^    #   \(resources:\)/      \1/' docker-compose.yml
-                sed -i 's/^    #     \(limits:\)/        \1/' docker-compose.yml
-                sed -i 's/^    #       \(cpus:.*\)/          \1/' docker-compose.yml
-                sed -i 's/^    #       \(memory:.*\)/          \1/' docker-compose.yml
-                sed -i 's/^    #     \(reservations:\)/        \1/' docker-compose.yml
-                sed -i '/^    #       # Uncomment below/d' docker-compose.yml
-                sed -i '/^    #       # transcoding/d' docker-compose.yml
-                sed -i '/^    #       # https:\/\/docs.nvidia.com/d' docker-compose.yml
-                sed -i 's/^    #       \(devices:\)/          \1/' docker-compose.yml
-                sed -i 's/^    #         \(- driver:.*\)/            \1/' docker-compose.yml
-                sed -i 's/^    #           \(count:.*\)/              \1/' docker-compose.yml
-                sed -i 's/^    #           \(capabilities:.*\)/              \1/' docker-compose.yml
+                echo "COMPOSE_FILE=docker-compose.yml:docker-compose.gpu.yml" >> .env
             fi
-            success "GPU acceleration enabled in docker-compose.yml"
+            success "GPU acceleration enabled (docker-compose.gpu.yml)"
             echo ""
             warn "Make sure the NVIDIA Container Toolkit is installed on this host."
             echo "  Install guide: ${BLUE}https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html${NC}"

--- a/rust-srec/docs/zh/getting-started/docker.md
+++ b/rust-srec/docs/zh/getting-started/docker.md
@@ -192,14 +192,29 @@ services:
      sudo systemctl restart docker
      ```
 
-### 在 docker-compose.yml 中启用 GPU
+### 在 docker-compose 中启用 GPU
 
-取消注释 `docker-compose.yml` 中的 `deploy` 部分，以授予容器 GPU 访问权限：
+下载 GPU compose 覆盖文件，放在 `docker-compose.yml` 同级目录：
+
+- <a :href="withBase('/docker-compose.gpu.yml')" download>docker-compose.gpu.yml</a>
+
+然后使用两个文件启动：
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.gpu.yml up -d
+```
+
+或者在 `.env` 中设置 `COMPOSE_FILE`，这样 `docker compose up -d` 会自动加载：
+
+```bash
+echo "COMPOSE_FILE=docker-compose.yml:docker-compose.gpu.yml" >> .env
+```
+
+覆盖文件会添加 NVIDIA 设备预留配置：
 
 ```yaml
 services:
   rust-srec:
-    # ...
     deploy:
       resources:
         reservations:


### PR DESCRIPTION
## Summary

Closes #458

- Bake `NVIDIA_VISIBLE_DEVICES` and `NVIDIA_DRIVER_CAPABILITIES` env vars into the Docker image runtime stage (industry-standard pattern used by Jellyfin, Plex, Frigate — safe no-ops without NVIDIA toolkit)
- Add `docker-compose.gpu.yml` override file for GPU device reservation (same pattern as Immich's `hwaccel.transcoding.yml`)
- Add NVIDIA GPU auto-detection to all 4 install scripts (bash EN/ZH, PowerShell EN/ZH) — downloads the override and sets `COMPOSE_FILE` in `.env`
- Add GPU Hardware Acceleration documentation section (EN + ZH) with prerequisites, setup, verification, and troubleshooting

## Test plan

- [ ] Build Docker image and verify `NVIDIA_VISIBLE_DEVICES` / `NVIDIA_DRIVER_CAPABILITIES` env vars are set
- [ ] Run `docker compose -f docker-compose.yml -f docker-compose.gpu.yml config` to validate merged YAML
- [ ] On a host with NVIDIA GPU + Container Toolkit, verify `docker exec rust-srec nvidia-smi` works
- [ ] Run install script on a machine with `nvidia-smi` available and confirm GPU prompt + `docker-compose.gpu.yml` download
- [ ] Run install script on a machine without NVIDIA GPU and confirm graceful skip
- [ ] Verify docs site builds and GPU section renders correctly in both locales