### PR TITLE
chore: update Node.js to 24 LTS

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
           cache: pnpm
           cache-dependency-path: rust-srec/docs/pnpm-lock.yaml
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -139,7 +139,7 @@ jobs:
           version: 10.28.1
       - uses: actions/setup-node@v6
         with:
-          node-version: '22'
+          node-version: '24'
           cache: 'pnpm'
           cache-dependency-path: rust-srec/frontend/pnpm-lock.yaml
       - name: Install dependencies
@@ -170,7 +170,7 @@ jobs:
           version: 10.28.1
       - uses: actions/setup-node@v6
         with:
-          node-version: '22'
+          node-version: '24'
           cache: 'pnpm'
           cache-dependency-path: rust-srec/frontend/pnpm-lock.yaml
 

--- a/.github/workflows/release-rust-srec.yml
+++ b/.github/workflows/release-rust-srec.yml
@@ -198,7 +198,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: '22'
+          node-version: '24'
           cache: 'pnpm'
           cache-dependency-path: rust-srec/frontend/pnpm-lock.yaml
 

--- a/rust-srec/frontend/Dockerfile
+++ b/rust-srec/frontend/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM node:22-alpine AS builder
+FROM node:24-alpine AS builder
 
 WORKDIR /app
 
@@ -23,7 +23,7 @@ COPY . .
 RUN pnpm run build
 
 # Runtime stage
-FROM node:22-alpine
+FROM node:24-alpine
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary
- Update Node.js from 22 to 24 LTS (active LTS, latest 24.14.1) across all CI workflows and Dockerfile
- Unify docs workflow from Node 20 to Node 24

## Files changed
- `.github/workflows/pr.yml` — 22 → 24
- `.github/workflows/release-rust-srec.yml` — 22 → 24
- `.github/workflows/deploy-docs.yml` — 20 → 24
- `rust-srec/frontend/Dockerfile` — `node:22-alpine` → `node:24-alpine`

## Test plan
- [x] Frontend build verified locally
- [ ] CI workflows pass on this PR