### PR TITLE
fix(downloader): make graceful stop timeout configurable

### DIFF
--- a/rust-srec/frontend/src/api/schemas/engine.ts
+++ b/rust-srec/frontend/src/api/schemas/engine.ts
@@ -37,6 +37,7 @@ export const FfmpegConfigSchema = z.object({
   input_args: z.array(z.string()).default([]),
   output_args: z.array(z.string()).default([]),
   timeout_secs: z.coerce.number().int().min(0).default(30),
+  graceful_stop_timeout_secs: z.coerce.number().int().min(0).default(60),
   user_agent: z
     .string()
     .nullable()
@@ -49,6 +50,7 @@ export const StreamlinkConfigSchema = z.object({
   binary_path: z.string().default('streamlink'),
   quality: z.string().default('best'),
   extra_args: z.array(z.string()).default([]),
+  graceful_stop_timeout_secs: z.coerce.number().int().min(0).default(60),
   // Twitch proxy playlist (ttv-lol)
   twitch_proxy_playlist: z
     .string()

--- a/rust-srec/frontend/src/components/config/engines/forms/ffmpeg-form.tsx
+++ b/rust-srec/frontend/src/components/config/engines/forms/ffmpeg-form.tsx
@@ -18,10 +18,13 @@ import {
   Shield,
   ArrowRightFromLine,
   ArrowLeftFromLine,
+  TimerOff,
 } from 'lucide-react';
 import { msg } from '@lingui/core/macro';
 import { Trans } from '@lingui/react/macro';
 import { useLingui } from '@lingui/react';
+
+import { InputWithUnit } from '@/components/ui/input-with-unit';
 
 interface FfmpegFormProps {
   control: Control<any>;
@@ -66,19 +69,42 @@ export function FfmpegForm({ control, basePath = 'config' }: FfmpegFormProps) {
                 <Trans>Timeout</Trans>
               </FormLabel>
               <FormControl>
-                <div className="relative">
-                  <Input
-                    type="number"
-                    {...field}
-                    className="pr-12 bg-background/50"
-                  />
-                  <span className="absolute right-3 top-2.5 text-xs text-muted-foreground">
-                    <Trans>secs</Trans>
-                  </span>
-                </div>
+                <InputWithUnit
+                  value={field.value}
+                  onChange={field.onChange}
+                  unitType="duration"
+                  className="bg-background/50"
+                />
               </FormControl>
               <FormDescription>
                 <Trans>Connection/activity timeout</Trans>
+              </FormDescription>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={control}
+          name={`${basePath}.graceful_stop_timeout_secs`}
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel className="flex items-center gap-2 text-xs uppercase tracking-wider text-muted-foreground font-semibold">
+                <TimerOff className="w-3.5 h-3.5 text-primary" />
+                <Trans>Graceful Stop Timeout</Trans>
+              </FormLabel>
+              <FormControl>
+                <InputWithUnit
+                  value={field.value}
+                  onChange={field.onChange}
+                  unitType="duration"
+                  className="bg-background/50"
+                />
+              </FormControl>
+              <FormDescription>
+                <Trans>
+                  Time to wait for ffmpeg to finalize the file before
+                  force-killing it
+                </Trans>
               </FormDescription>
               <FormMessage />
             </FormItem>

--- a/rust-srec/frontend/src/components/config/engines/forms/streamlink-form.tsx
+++ b/rust-srec/frontend/src/components/config/engines/forms/streamlink-form.tsx
@@ -11,10 +11,12 @@ import { Input } from '@/components/ui/input';
 import { ListInput } from '@/components/ui/list-input';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Separator } from '@/components/ui/separator';
-import { Terminal, Settings, Command } from 'lucide-react';
+import { Terminal, Settings, Command, TimerOff } from 'lucide-react';
 import { msg } from '@lingui/core/macro';
 import { Trans } from '@lingui/react/macro';
 import { useLingui } from '@lingui/react';
+
+import { InputWithUnit } from '@/components/ui/input-with-unit';
 
 interface StreamlinkFormProps {
   control: Control<any>;
@@ -70,6 +72,33 @@ export function StreamlinkForm({
               </FormControl>
               <FormDescription>
                 <Trans>e.g. 'best', 'worst', '720p', 'audio_only'</Trans>
+              </FormDescription>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={control}
+          name={`${basePath}.graceful_stop_timeout_secs`}
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel className="flex items-center gap-2 text-xs uppercase tracking-wider text-muted-foreground font-semibold">
+                <TimerOff className="w-3.5 h-3.5 text-primary" />
+                <Trans>Graceful Stop Timeout</Trans>
+              </FormLabel>
+              <FormControl>
+                <InputWithUnit
+                  value={field.value}
+                  onChange={field.onChange}
+                  unitType="duration"
+                  className="bg-background/50"
+                />
+              </FormControl>
+              <FormDescription>
+                <Trans>
+                  Time to wait for ffmpeg to finalize the file before
+                  force-killing it
+                </Trans>
               </FormDescription>
               <FormMessage />
             </FormItem>

--- a/rust-srec/frontend/src/locales/en/messages.po
+++ b/rust-srec/frontend/src/locales/en/messages.po
@@ -23,7 +23,7 @@ msgstr " - Session: {0}"
 msgid "--flag value"
 msgstr "--flag value"
 
-#: src/components/config/engines/forms/streamlink-form.tsx:156
+#: src/components/config/engines/forms/streamlink-form.tsx:185
 msgid "--hls-live-edge 3"
 msgstr "--hls-live-edge 3"
 
@@ -31,11 +31,11 @@ msgstr "--hls-live-edge 3"
 msgid "-1001234567890"
 msgstr "-1001234567890"
 
-#: src/components/config/engines/forms/ffmpeg-form.tsx:164
+#: src/components/config/engines/forms/ffmpeg-form.tsx:190
 msgid "-c copy"
 msgstr "-c copy"
 
-#: src/components/config/engines/forms/ffmpeg-form.tsx:133
+#: src/components/config/engines/forms/ffmpeg-form.tsx:159
 msgid "-reconnect 1"
 msgstr "-reconnect 1"
 
@@ -129,7 +129,7 @@ msgstr "* * * * * *"
 msgid "/path/to/rclone.conf"
 msgstr "/path/to/rclone.conf"
 
-#: src/components/config/engines/forms/ffmpeg-form.tsx:48
+#: src/components/config/engines/forms/ffmpeg-form.tsx:51
 msgid "/usr/bin/ffmpeg or ffmpeg"
 msgstr "/usr/bin/ffmpeg or ffmpeg"
 
@@ -197,11 +197,11 @@ msgstr "A unique ID used by other steps to reference this one."
 msgid "A unique name for this configuration template."
 msgstr "A unique name for this configuration template."
 
-#: src/components/config/engines/forms/ffmpeg-form.tsx:53
+#: src/components/config/engines/forms/ffmpeg-form.tsx:56
 msgid "Absolute path or 'ffmpeg' if in PATH"
 msgstr "Absolute path or 'ffmpeg' if in PATH"
 
-#: src/components/config/engines/forms/streamlink-form.tsx:49
+#: src/components/config/engines/forms/streamlink-form.tsx:51
 msgid "Absolute path or 'streamlink' in PATH"
 msgstr "Absolute path or 'streamlink' in PATH"
 
@@ -459,7 +459,7 @@ msgstr "Allowed Extensions"
 msgid "An error occurred"
 msgstr "An error occurred"
 
-#: src/components/config/engines/forms/streamlink-form.tsx:161
+#: src/components/config/engines/forms/streamlink-form.tsx:190
 msgid "Any additional command line arguments to pass to Streamlink"
 msgstr "Any additional command line arguments to pass to Streamlink"
 
@@ -532,11 +532,11 @@ msgstr "Are you sure you want to delete this session? This action cannot be undo
 msgid "Are you sure you want to delete this streamer?"
 msgstr "Are you sure you want to delete this streamer?"
 
-#: src/components/config/engines/forms/ffmpeg-form.tsx:138
+#: src/components/config/engines/forms/ffmpeg-form.tsx:164
 msgid "Args inserted before -i input_url"
 msgstr "Args inserted before -i input_url"
 
-#: src/components/config/engines/forms/ffmpeg-form.tsx:169
+#: src/components/config/engines/forms/ffmpeg-form.tsx:195
 msgid "Args used for processing/encoding"
 msgstr "Args used for processing/encoding"
 
@@ -783,7 +783,7 @@ msgstr "Batch Window (ms)"
 msgid "Bearer Token"
 msgstr "Bearer Token"
 
-#: src/components/config/engines/forms/streamlink-form.tsx:67
+#: src/components/config/engines/forms/streamlink-form.tsx:69
 msgid "best"
 msgstr "best"
 
@@ -795,8 +795,8 @@ msgstr "BETA"
 msgid "Bilibili QR Login"
 msgstr "Bilibili QR Login"
 
-#: src/components/config/engines/forms/ffmpeg-form.tsx:43
-#: src/components/config/engines/forms/streamlink-form.tsx:39
+#: src/components/config/engines/forms/ffmpeg-form.tsx:46
+#: src/components/config/engines/forms/streamlink-form.tsx:41
 #: src/components/pipeline/presets/processors/danmaku-factory-config-form.tsx:59
 msgid "Binary Path"
 msgstr "Binary Path"
@@ -987,7 +987,7 @@ msgstr "Channel deleted"
 msgid "Channel updated"
 msgstr "Channel updated"
 
-#: src/components/config/engines/forms/streamlink-form.tsx:123
+#: src/components/config/engines/forms/streamlink-form.tsx:152
 msgid "channel1,channel2"
 msgstr "channel1,channel2"
 
@@ -1102,7 +1102,7 @@ msgstr "Closest to bitrate"
 msgid "Collapsible"
 msgstr "Collapsible"
 
-#: src/components/config/engines/forms/streamlink-form.tsx:128
+#: src/components/config/engines/forms/streamlink-form.tsx:157
 msgid "Comma-separated list of channels to exclude from proxy"
 msgstr "Comma-separated list of channels to exclude from proxy"
 
@@ -1298,7 +1298,7 @@ msgstr "Connection Error"
 msgid "Connection Instability"
 msgstr "Connection Instability"
 
-#: src/components/config/engines/forms/ffmpeg-form.tsx:81
+#: src/components/config/engines/forms/ffmpeg-form.tsx:80
 msgid "Connection/activity timeout"
 msgstr "Connection/activity timeout"
 
@@ -1617,7 +1617,7 @@ msgstr "Custom Headers"
 msgid "Custom imported theme is active."
 msgstr "Custom imported theme is active."
 
-#: src/components/config/engines/forms/streamlink-form.tsx:106
+#: src/components/config/engines/forms/streamlink-form.tsx:135
 msgid "Custom proxy URL for Twitch playlists"
 msgstr "Custom proxy URL for Twitch playlists"
 
@@ -1625,7 +1625,7 @@ msgstr "Custom proxy URL for Twitch playlists"
 msgid "Custom Tags"
 msgstr "Custom Tags"
 
-#: src/components/config/engines/forms/ffmpeg-form.tsx:106
+#: src/components/config/engines/forms/ffmpeg-form.tsx:132
 msgid "Custom User-Agent string (Optional)"
 msgstr "Custom User-Agent string (Optional)"
 
@@ -2095,7 +2095,7 @@ msgstr "Duration limit"
 msgid "e.g. --namespace my_account"
 msgstr "e.g. --namespace my_account"
 
-#: src/components/config/engines/forms/streamlink-form.tsx:72
+#: src/components/config/engines/forms/streamlink-form.tsx:74
 msgid "e.g. 'best', 'worst', '720p', 'audio_only'"
 msgstr "e.g. 'best', 'worst', '720p', 'audio_only'"
 
@@ -2546,7 +2546,7 @@ msgstr "Export Configuration"
 msgid "Exports include all global settings, platforms, templates, streamers, engines, and notification channels. Sensitive data like passwords might be redacted or encrypted depending on platform settings."
 msgstr "Exports include all global settings, platforms, templates, streamers, engines, and notification channels. Sensitive data like passwords might be redacted or encrypted depending on platform settings."
 
-#: src/components/config/engines/forms/streamlink-form.tsx:143
+#: src/components/config/engines/forms/streamlink-form.tsx:172
 #: src/components/pipeline/presets/processors/danmaku-factory-config-form.tsx:111
 #: src/components/pipeline/presets/processors/rclone-config-form.tsx:264
 msgid "Extra Arguments"
@@ -3236,6 +3236,11 @@ msgstr "Go to page {p}"
 msgid "Go to previous page"
 msgstr "Go to previous page"
 
+#: src/components/config/engines/forms/ffmpeg-form.tsx:93
+#: src/components/config/engines/forms/streamlink-form.tsx:87
+msgid "Graceful Stop Timeout"
+msgstr "Graceful Stop Timeout"
+
 #: src/components/pipeline/workflows/pipeline-workflow-editor.tsx:86
 #: src/components/pipeline/workflows/pipeline-workflow-editor.tsx:89
 #: src/components/pipeline/workflows/workflow-editor.tsx:382
@@ -3405,7 +3410,7 @@ msgstr "https://api.example.com/webhook"
 msgid "https://discord.com/api/webhooks/..."
 msgstr "https://discord.com/api/webhooks/..."
 
-#: src/components/config/engines/forms/streamlink-form.tsx:101
+#: src/components/config/engines/forms/streamlink-form.tsx:130
 msgid "https://lb-eu.cdn-perfprod.com"
 msgstr "https://lb-eu.cdn-perfprod.com"
 
@@ -3547,7 +3552,7 @@ msgstr "Inline: {stepName}"
 msgid "Input"
 msgstr "Input"
 
-#: src/components/config/engines/forms/ffmpeg-form.tsx:120
+#: src/components/config/engines/forms/ffmpeg-form.tsx:146
 msgid "Input Arguments"
 msgstr "Input Arguments"
 
@@ -4265,7 +4270,7 @@ msgstr "Move Files"
 msgid "Move the file to another location. Removes the original file."
 msgstr "Move the file to another location. Removes the original file."
 
-#: src/components/config/engines/forms/ffmpeg-form.tsx:101
+#: src/components/config/engines/forms/ffmpeg-form.tsx:127
 msgid "Mozilla/5.0..."
 msgstr "Mozilla/5.0..."
 
@@ -4854,7 +4859,7 @@ msgstr "Out of Space"
 msgid "Output"
 msgstr "Output"
 
-#: src/components/config/engines/forms/ffmpeg-form.tsx:151
+#: src/components/config/engines/forms/ffmpeg-form.tsx:177
 msgid "Output Arguments"
 msgstr "Output Arguments"
 
@@ -5584,7 +5589,7 @@ msgstr "QR code expired"
 msgid "QR Login"
 msgstr "QR Login"
 
-#: src/components/config/engines/forms/streamlink-form.tsx:62
+#: src/components/config/engines/forms/streamlink-form.tsx:64
 #: src/components/player/stream-info-card.tsx:170
 msgid "Quality"
 msgstr "Quality"
@@ -6192,10 +6197,6 @@ msgstr "Secondary"
 #: src/components/notifications/forms/webhook-form.tsx:394
 msgid "secret"
 msgstr "secret"
-
-#: src/components/config/engines/forms/ffmpeg-form.tsx:76
-msgid "secs"
-msgstr "secs"
 
 #: src/components/config/platforms/tabs/specific-configs/douyin-config-fields.tsx:179
 msgid "Security & Identity"
@@ -6806,7 +6807,7 @@ msgstr "Streaming services"
 msgid "Streaming Threshold (bytes)"
 msgstr "Streaming Threshold (bytes)"
 
-#: src/components/config/engines/forms/streamlink-form.tsx:44
+#: src/components/config/engines/forms/streamlink-form.tsx:46
 msgid "streamlink"
 msgstr "streamlink"
 
@@ -7171,12 +7172,17 @@ msgstr "Time Placeholders (Local Time)"
 msgid "Time Range"
 msgstr "Time Range"
 
+#: src/components/config/engines/forms/ffmpeg-form.tsx:104
+#: src/components/config/engines/forms/streamlink-form.tsx:98
+msgid "Time to wait for ffmpeg to finalize the file before force-killing it"
+msgstr "Time to wait for ffmpeg to finalize the file before force-killing it"
+
 #: src/components/sessions/danmu-stats-panel.tsx:192
 #: src/routes/_authed/_dashboard/sessions/$sessionId.lazy.tsx:248
 msgid "Timeline"
 msgstr "Timeline"
 
-#: src/components/config/engines/forms/ffmpeg-form.tsx:66
+#: src/components/config/engines/forms/ffmpeg-form.tsx:69
 msgid "Timeout"
 msgstr "Timeout"
 
@@ -7412,7 +7418,7 @@ msgstr "Try Again"
 msgid "TTWID Management Mode"
 msgstr "TTWID Management Mode"
 
-#: src/components/config/engines/forms/streamlink-form.tsx:86
+#: src/components/config/engines/forms/streamlink-form.tsx:115
 msgid "Twitch (ttv-lol)"
 msgstr "Twitch (ttv-lol)"
 
@@ -7420,11 +7426,11 @@ msgstr "Twitch (ttv-lol)"
 msgid "Twitch OAuth token for subscriber-only and high-quality streams."
 msgstr "Twitch OAuth token for subscriber-only and high-quality streams."
 
-#: src/components/config/engines/forms/streamlink-form.tsx:96
+#: src/components/config/engines/forms/streamlink-form.tsx:125
 msgid "Twitch Proxy Playlist"
 msgstr "Twitch Proxy Playlist"
 
-#: src/components/config/engines/forms/streamlink-form.tsx:118
+#: src/components/config/engines/forms/streamlink-form.tsx:147
 msgid "Twitch Proxy Playlist Exclude"
 msgstr "Twitch Proxy Playlist Exclude"
 
@@ -7589,7 +7595,7 @@ msgstr "Use TLS"
 msgid "Used for Desktop login (fallback); points to Telegram Desktop folder containing `tdata`."
 msgstr "Used for Desktop login (fallback); points to Telegram Desktop folder containing `tdata`."
 
-#: src/components/config/engines/forms/ffmpeg-form.tsx:96
+#: src/components/config/engines/forms/ffmpeg-form.tsx:122
 #: src/components/config/engines/forms/mesio-hls-form.tsx:736
 msgid "User Agent"
 msgstr "User Agent"

--- a/rust-srec/frontend/src/locales/zh-CN/messages.po
+++ b/rust-srec/frontend/src/locales/zh-CN/messages.po
@@ -23,7 +23,7 @@ msgstr " - 会话：{0}"
 msgid "--flag value"
 msgstr "--flag value"
 
-#: src/components/config/engines/forms/streamlink-form.tsx:156
+#: src/components/config/engines/forms/streamlink-form.tsx:185
 msgid "--hls-live-edge 3"
 msgstr "--hls-live-edge 3"
 
@@ -31,11 +31,11 @@ msgstr "--hls-live-edge 3"
 msgid "-1001234567890"
 msgstr "-1001234567890"
 
-#: src/components/config/engines/forms/ffmpeg-form.tsx:164
+#: src/components/config/engines/forms/ffmpeg-form.tsx:190
 msgid "-c copy"
 msgstr "-c copy"
 
-#: src/components/config/engines/forms/ffmpeg-form.tsx:133
+#: src/components/config/engines/forms/ffmpeg-form.tsx:159
 msgid "-reconnect 1"
 msgstr "-reconnect 1"
 
@@ -129,7 +129,7 @@ msgstr "* * * * * *"
 msgid "/path/to/rclone.conf"
 msgstr "/path/to/rclone.conf"
 
-#: src/components/config/engines/forms/ffmpeg-form.tsx:48
+#: src/components/config/engines/forms/ffmpeg-form.tsx:51
 msgid "/usr/bin/ffmpeg or ffmpeg"
 msgstr "/usr/bin/ffmpeg 或 ffmpeg"
 
@@ -197,11 +197,11 @@ msgstr "一个唯一的 ID，用于供其他步骤引用此步骤。"
 msgid "A unique name for this configuration template."
 msgstr "为此配置模板提供一个唯一的名称。"
 
-#: src/components/config/engines/forms/ffmpeg-form.tsx:53
+#: src/components/config/engines/forms/ffmpeg-form.tsx:56
 msgid "Absolute path or 'ffmpeg' if in PATH"
 msgstr "绝对路径，或在 PATH 中时填写“ffmpeg”"
 
-#: src/components/config/engines/forms/streamlink-form.tsx:49
+#: src/components/config/engines/forms/streamlink-form.tsx:51
 msgid "Absolute path or 'streamlink' in PATH"
 msgstr "绝对路径，或在 PATH 中时填写“streamlink”"
 
@@ -459,7 +459,7 @@ msgstr "允许的扩展名"
 msgid "An error occurred"
 msgstr "发生错误"
 
-#: src/components/config/engines/forms/streamlink-form.tsx:161
+#: src/components/config/engines/forms/streamlink-form.tsx:190
 msgid "Any additional command line arguments to pass to Streamlink"
 msgstr "传递给 Streamlink 的其他命令行参数"
 
@@ -532,11 +532,11 @@ msgstr "确定要删除此会话吗？此操作无法撤销。"
 msgid "Are you sure you want to delete this streamer?"
 msgstr "确定要删除此主播吗？"
 
-#: src/components/config/engines/forms/ffmpeg-form.tsx:138
+#: src/components/config/engines/forms/ffmpeg-form.tsx:164
 msgid "Args inserted before -i input_url"
 msgstr "插入到 -i input_url 之前的参数"
 
-#: src/components/config/engines/forms/ffmpeg-form.tsx:169
+#: src/components/config/engines/forms/ffmpeg-form.tsx:195
 msgid "Args used for processing/encoding"
 msgstr "用于处理/编码的参数"
 
@@ -783,7 +783,7 @@ msgstr "批处理窗口（毫秒）"
 msgid "Bearer Token"
 msgstr "Bearer Token"
 
-#: src/components/config/engines/forms/streamlink-form.tsx:67
+#: src/components/config/engines/forms/streamlink-form.tsx:69
 msgid "best"
 msgstr "最佳"
 
@@ -795,8 +795,8 @@ msgstr "测试版"
 msgid "Bilibili QR Login"
 msgstr "哔哩哔哩扫码登录"
 
-#: src/components/config/engines/forms/ffmpeg-form.tsx:43
-#: src/components/config/engines/forms/streamlink-form.tsx:39
+#: src/components/config/engines/forms/ffmpeg-form.tsx:46
+#: src/components/config/engines/forms/streamlink-form.tsx:41
 #: src/components/pipeline/presets/processors/danmaku-factory-config-form.tsx:59
 msgid "Binary Path"
 msgstr "可执行文件路径"
@@ -987,7 +987,7 @@ msgstr "渠道已删除"
 msgid "Channel updated"
 msgstr "渠道已更新"
 
-#: src/components/config/engines/forms/streamlink-form.tsx:123
+#: src/components/config/engines/forms/streamlink-form.tsx:152
 msgid "channel1,channel2"
 msgstr "频道1,频道2"
 
@@ -1102,7 +1102,7 @@ msgstr "最接近目标码率"
 msgid "Collapsible"
 msgstr "折叠方式"
 
-#: src/components/config/engines/forms/streamlink-form.tsx:128
+#: src/components/config/engines/forms/streamlink-form.tsx:157
 msgid "Comma-separated list of channels to exclude from proxy"
 msgstr "用于排除代理的频道列表（逗号分隔）"
 
@@ -1298,7 +1298,7 @@ msgstr "连接错误"
 msgid "Connection Instability"
 msgstr "连接不稳定"
 
-#: src/components/config/engines/forms/ffmpeg-form.tsx:81
+#: src/components/config/engines/forms/ffmpeg-form.tsx:80
 msgid "Connection/activity timeout"
 msgstr "连接/活动超时"
 
@@ -1617,7 +1617,7 @@ msgstr "自定义请求头"
 msgid "Custom imported theme is active."
 msgstr "自定义导入主题已激活。"
 
-#: src/components/config/engines/forms/streamlink-form.tsx:106
+#: src/components/config/engines/forms/streamlink-form.tsx:135
 msgid "Custom proxy URL for Twitch playlists"
 msgstr "Twitch 播放列表的自定义代理 URL"
 
@@ -1625,7 +1625,7 @@ msgstr "Twitch 播放列表的自定义代理 URL"
 msgid "Custom Tags"
 msgstr "自定义标签"
 
-#: src/components/config/engines/forms/ffmpeg-form.tsx:106
+#: src/components/config/engines/forms/ffmpeg-form.tsx:132
 msgid "Custom User-Agent string (Optional)"
 msgstr "自定义 User-Agent 字符串（可选）"
 
@@ -2095,7 +2095,7 @@ msgstr "时长限制"
 msgid "e.g. --namespace my_account"
 msgstr "例如 --namespace my_account"
 
-#: src/components/config/engines/forms/streamlink-form.tsx:72
+#: src/components/config/engines/forms/streamlink-form.tsx:74
 msgid "e.g. 'best', 'worst', '720p', 'audio_only'"
 msgstr "例如 'best'、'worst'、'720p'、'audio_only'"
 
@@ -2546,7 +2546,7 @@ msgstr "导出配置"
 msgid "Exports include all global settings, platforms, templates, streamers, engines, and notification channels. Sensitive data like passwords might be redacted or encrypted depending on platform settings."
 msgstr "导出内容包含所有全局设置、平台、模板、主播、引擎和通知渠道。敏感数据（如密码）可能会根据平台设置被脱敏或加密。"
 
-#: src/components/config/engines/forms/streamlink-form.tsx:143
+#: src/components/config/engines/forms/streamlink-form.tsx:172
 #: src/components/pipeline/presets/processors/danmaku-factory-config-form.tsx:111
 #: src/components/pipeline/presets/processors/rclone-config-form.tsx:264
 msgid "Extra Arguments"
@@ -3236,6 +3236,11 @@ msgstr "跳转到第 {p} 页"
 msgid "Go to previous page"
 msgstr "上一页"
 
+#: src/components/config/engines/forms/ffmpeg-form.tsx:93
+#: src/components/config/engines/forms/streamlink-form.tsx:87
+msgid "Graceful Stop Timeout"
+msgstr "优雅停止超时"
+
 #: src/components/pipeline/workflows/pipeline-workflow-editor.tsx:86
 #: src/components/pipeline/workflows/pipeline-workflow-editor.tsx:89
 #: src/components/pipeline/workflows/workflow-editor.tsx:382
@@ -3405,7 +3410,7 @@ msgstr "https://api.example.com/webhook"
 msgid "https://discord.com/api/webhooks/..."
 msgstr "https://discord.com/api/webhooks/..."
 
-#: src/components/config/engines/forms/streamlink-form.tsx:101
+#: src/components/config/engines/forms/streamlink-form.tsx:130
 msgid "https://lb-eu.cdn-perfprod.com"
 msgstr "https://lb-eu.cdn-perfprod.com"
 
@@ -3547,7 +3552,7 @@ msgstr "内联：{stepName}"
 msgid "Input"
 msgstr "输入"
 
-#: src/components/config/engines/forms/ffmpeg-form.tsx:120
+#: src/components/config/engines/forms/ffmpeg-form.tsx:146
 msgid "Input Arguments"
 msgstr "输入参数"
 
@@ -4265,7 +4270,7 @@ msgstr "移动文件"
 msgid "Move the file to another location. Removes the original file."
 msgstr "将文件移动到其他位置，并移除原始文件。"
 
-#: src/components/config/engines/forms/ffmpeg-form.tsx:101
+#: src/components/config/engines/forms/ffmpeg-form.tsx:127
 msgid "Mozilla/5.0..."
 msgstr "Mozilla/5.0..."
 
@@ -4854,7 +4859,7 @@ msgstr "空间不足"
 msgid "Output"
 msgstr "输出"
 
-#: src/components/config/engines/forms/ffmpeg-form.tsx:151
+#: src/components/config/engines/forms/ffmpeg-form.tsx:177
 msgid "Output Arguments"
 msgstr "输出参数"
 
@@ -5584,7 +5589,7 @@ msgstr "二维码已过期"
 msgid "QR Login"
 msgstr "扫码登录"
 
-#: src/components/config/engines/forms/streamlink-form.tsx:62
+#: src/components/config/engines/forms/streamlink-form.tsx:64
 #: src/components/player/stream-info-card.tsx:170
 msgid "Quality"
 msgstr "质量"
@@ -6192,10 +6197,6 @@ msgstr "次要"
 #: src/components/notifications/forms/webhook-form.tsx:394
 msgid "secret"
 msgstr "secret"
-
-#: src/components/config/engines/forms/ffmpeg-form.tsx:76
-msgid "secs"
-msgstr "秒"
 
 #: src/components/config/platforms/tabs/specific-configs/douyin-config-fields.tsx:179
 msgid "Security & Identity"
@@ -6806,7 +6807,7 @@ msgstr "流媒体服务"
 msgid "Streaming Threshold (bytes)"
 msgstr "流式传输阈值（字节）"
 
-#: src/components/config/engines/forms/streamlink-form.tsx:44
+#: src/components/config/engines/forms/streamlink-form.tsx:46
 msgid "streamlink"
 msgstr "streamlink"
 
@@ -7171,12 +7172,17 @@ msgstr "时间占位符（本地时间）"
 msgid "Time Range"
 msgstr "时间范围"
 
+#: src/components/config/engines/forms/ffmpeg-form.tsx:104
+#: src/components/config/engines/forms/streamlink-form.tsx:98
+msgid "Time to wait for ffmpeg to finalize the file before force-killing it"
+msgstr "等待 ffmpeg 完成文件写入的时间，超时后将强制终止进程"
+
 #: src/components/sessions/danmu-stats-panel.tsx:192
 #: src/routes/_authed/_dashboard/sessions/$sessionId.lazy.tsx:248
 msgid "Timeline"
 msgstr "时间线"
 
-#: src/components/config/engines/forms/ffmpeg-form.tsx:66
+#: src/components/config/engines/forms/ffmpeg-form.tsx:69
 msgid "Timeout"
 msgstr "超时"
 
@@ -7412,7 +7418,7 @@ msgstr "重试"
 msgid "TTWID Management Mode"
 msgstr "TTWID 管理模式"
 
-#: src/components/config/engines/forms/streamlink-form.tsx:86
+#: src/components/config/engines/forms/streamlink-form.tsx:115
 msgid "Twitch (ttv-lol)"
 msgstr "Twitch (ttv-lol)"
 
@@ -7420,11 +7426,11 @@ msgstr "Twitch (ttv-lol)"
 msgid "Twitch OAuth token for subscriber-only and high-quality streams."
 msgstr "用于订阅者专享和高质量流的 Twitch OAuth 令牌。"
 
-#: src/components/config/engines/forms/streamlink-form.tsx:96
+#: src/components/config/engines/forms/streamlink-form.tsx:125
 msgid "Twitch Proxy Playlist"
 msgstr "Twitch 代理播放列表"
 
-#: src/components/config/engines/forms/streamlink-form.tsx:118
+#: src/components/config/engines/forms/streamlink-form.tsx:147
 msgid "Twitch Proxy Playlist Exclude"
 msgstr "Twitch 代理播放列表排除"
 
@@ -7589,7 +7595,7 @@ msgstr "启用 TLS"
 msgid "Used for Desktop login (fallback); points to Telegram Desktop folder containing `tdata`."
 msgstr "用于桌面登录（备选）；指向包含 `tdata` 的 Telegram Desktop 文件夹。"
 
-#: src/components/config/engines/forms/ffmpeg-form.tsx:96
+#: src/components/config/engines/forms/ffmpeg-form.tsx:122
 #: src/components/config/engines/forms/mesio-hls-form.tsx:736
 msgid "User Agent"
 msgstr "User-Agent"

--- a/rust-srec/src/database/models/engine.rs
+++ b/rust-srec/src/database/models/engine.rs
@@ -95,6 +95,10 @@ pub struct FfmpegEngineConfig {
     /// User agent string
     #[serde(skip_serializing_if = "Option::is_none")]
     pub user_agent: Option<String>,
+    /// How long to wait for ffmpeg to exit gracefully before killing it (seconds).
+    /// Increase this on slow hardware to prevent unplayable files missing the moov atom.
+    #[serde(default = "default_graceful_stop_timeout")]
+    pub graceful_stop_timeout_secs: u32,
 }
 
 fn default_ffmpeg_path() -> String {
@@ -105,6 +109,10 @@ fn default_timeout() -> u32 {
     30
 }
 
+fn default_graceful_stop_timeout() -> u32 {
+    60
+}
+
 impl Default for FfmpegEngineConfig {
     fn default() -> Self {
         Self {
@@ -113,6 +121,7 @@ impl Default for FfmpegEngineConfig {
             output_args: Vec::new(),
             timeout_secs: default_timeout(),
             user_agent: None,
+            graceful_stop_timeout_secs: default_graceful_stop_timeout(),
         }
     }
 }
@@ -135,6 +144,10 @@ pub struct StreamlinkEngineConfig {
     /// Twitch proxy playlist exclude (ttv-lol)
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub twitch_proxy_playlist_exclude: Option<String>,
+    /// How long to wait for ffmpeg to exit gracefully before killing it (seconds).
+    /// Increase this on slow hardware to prevent unplayable files missing the moov atom.
+    #[serde(default = "default_graceful_stop_timeout")]
+    pub graceful_stop_timeout_secs: u32,
 }
 
 fn default_streamlink_path() -> String {
@@ -153,6 +166,7 @@ impl Default for StreamlinkEngineConfig {
             extra_args: Vec::new(),
             twitch_proxy_playlist: None,
             twitch_proxy_playlist_exclude: None,
+            graceful_stop_timeout_secs: default_graceful_stop_timeout(),
         }
     }
 }

--- a/rust-srec/src/downloader/engine/ffmpeg.rs
+++ b/rust-srec/src/downloader/engine/ffmpeg.rs
@@ -216,10 +216,11 @@ impl DownloadEngine for FfmpegEngine {
         let (exit_tx, exit_rx) = tokio::sync::oneshot::channel::<Option<i32>>();
         let cancellation_token = handle.cancellation_token.clone();
         let started_instant = Instant::now();
+        let graceful_stop_timeout_secs = self.config.graceful_stop_timeout_secs;
         tokio::spawn(async move {
             use tokio::io::AsyncWriteExt;
 
-            const GRACEFUL_STOP_TIMEOUT: Duration = Duration::from_secs(10);
+            let graceful_stop_timeout = Duration::from_secs(graceful_stop_timeout_secs as u64);
 
             let exit_code = tokio::select! {
                 status = child.wait() => {
@@ -239,7 +240,7 @@ impl DownloadEngine for FfmpegEngine {
                         let _ = stdin.shutdown().await;
                     }
 
-                    match tokio::time::timeout(GRACEFUL_STOP_TIMEOUT, child.wait()).await {
+                    match tokio::time::timeout(graceful_stop_timeout, child.wait()).await {
                         Ok(Ok(exit_status)) => exit_status.code(),
                         Ok(Err(e)) => {
                             error!("Error waiting for ffmpeg after stop request: {}", e);

--- a/rust-srec/src/downloader/engine/streamlink.rs
+++ b/rust-srec/src/downloader/engine/streamlink.rs
@@ -300,6 +300,7 @@ impl DownloadEngine for StreamlinkEngine {
 
         let cancellation_token = handle.cancellation_token.clone();
         let started_instant = Instant::now();
+        let graceful_stop_timeout_secs = self.config.graceful_stop_timeout_secs;
 
         // 2. Spawn a waiter task for both processes.
         //
@@ -309,7 +310,7 @@ impl DownloadEngine for StreamlinkEngine {
         let cancellation_token_wait = cancellation_token.clone();
         tokio::spawn(async move {
             const STREAMLINK_KILL_TIMEOUT: Duration = Duration::from_secs(2);
-            const FFMPEG_STOP_TIMEOUT: Duration = Duration::from_secs(10);
+            let ffmpeg_stop_timeout = Duration::from_secs(graceful_stop_timeout_secs as u64);
 
             // Ensure streamlink terminates promptly when cancellation is requested.
             tokio::select! {
@@ -325,7 +326,7 @@ impl DownloadEngine for StreamlinkEngine {
                 }
             }
 
-            let exit_code = match tokio::time::timeout(FFMPEG_STOP_TIMEOUT, ffmpeg.wait()).await {
+            let exit_code = match tokio::time::timeout(ffmpeg_stop_timeout, ffmpeg.wait()).await {
                 Ok(Ok(exit_status)) => exit_status.code(),
                 Ok(Err(e)) => {
                     error!("Error waiting for ffmpeg process: {}", e);


### PR DESCRIPTION
## Summary
- Add configurable `graceful_stop_timeout_secs` field to `FfmpegEngineConfig` and `StreamlinkEngineConfig` (default 60s, up from hardcoded 10s)
- Wire the configured timeout through to the spawned process-wait tasks in both FFmpeg and Streamlink engines
- Expose the setting in the frontend engine configuration forms using the existing `InputWithUnit` component
- Add zh-CN translations for the new UI strings

## Context
On low-end hardware (e.g. Intel J1900 NAS), the hardcoded 10-second graceful stop timeout was too short for ffmpeg to finalize MP4 files — it would be force-killed before writing the moov atom, producing unplayable files with `moov atom not found` errors.

Closes #476

## Test plan
- [ ] Verify existing engine configs without `graceful_stop_timeout_secs` deserialize correctly (serde default kicks in at 60s)
- [ ] Verify the new field appears in FFmpeg and Streamlink engine config forms
- [ ] Verify changing the value persists and is used when stopping a download
- [ ] Verify `cargo clippy`, `oxlint`, `oxfmt`, and `lingui extract` all pass cleanly