### PR TITLE
fix(frontend): use container queries for pipeline timeout grid layout

### DIFF
--- a/rust-srec/frontend/src/components/config/global/concurrency-card.tsx
+++ b/rust-srec/frontend/src/components/config/global/concurrency-card.tsx
@@ -152,7 +152,7 @@ export const ConcurrencyCard = memo(({ control }: ConcurrencyCardProps) => {
 
         <Separator />
 
-        <div className="space-y-4">
+        <div className="@container space-y-4">
           <div className="flex items-center gap-2">
             <Timer className="h-4 w-4 text-sky-500" />
             <h3 className="text-sm font-semibold">
@@ -195,7 +195,7 @@ export const ConcurrencyCard = memo(({ control }: ConcurrencyCardProps) => {
             </Tooltip>
           </div>
 
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+          <div className="grid grid-cols-1 @md:grid-cols-3 gap-6">
             <FormField
               control={control}
               name="pipeline_cpu_job_timeout_secs"


### PR DESCRIPTION
## Summary
- Fixes #493 — pipeline timeout input fields compressed/invisible when sidebar is expanded on scaled displays
- Replaces viewport-based `md:grid-cols-3` with Tailwind v4 container-query-based `@md:grid-cols-3` in the concurrency card's pipeline timeout section
- Adds `@container` to the section wrapper so the 3-column grid responds to the card's actual width instead of the viewport width

## Test plan
- [ ] 1920x1080 at 125% scaling with sidebar expanded — inputs should stack to 1 column
- [ ] 1920x1080 at 100% with sidebar expanded — inputs should show in 3 columns
- [ ] Narrow viewport (~768px) — inputs should stack to 1 column
- [ ] Desktop with sidebar collapsed — inputs should show in 3 columns