### PR TITLE
feat(notifications): add Gotify channel and migrate priority to integers

### DIFF
--- a/rust-srec/frontend/src/api/schemas/notifications.ts
+++ b/rust-srec/frontend/src/api/schemas/notifications.ts
@@ -32,6 +32,7 @@ const TimestampMsSchema = z
 export const ChannelTypeSchema = z.enum([
   'Discord',
   'Email',
+  'Gotify',
   'Telegram',
   'Webhook',
 ]);
@@ -42,7 +43,7 @@ export const DiscordSettingsSchema = z.object({
   webhook_url: z.url(),
   username: z.string().optional(),
   avatar_url: z.url().optional(),
-  min_priority: z.enum(['Low', 'Normal', 'High', 'Critical']).default('Normal'),
+  min_priority: z.number().int().min(0).max(10).default(5),
   enabled: z.boolean().default(true),
 });
 
@@ -54,7 +55,7 @@ export const EmailSettingsSchema = z.object({
   from_address: z.email(),
   to_addresses: z.array(z.email()).min(1),
   use_tls: z.boolean().default(true),
-  min_priority: z.enum(['Low', 'Normal', 'High', 'Critical']).default('High'),
+  min_priority: z.number().int().min(0).max(10).default(8),
   enabled: z.boolean().default(true),
 });
 
@@ -82,7 +83,7 @@ export const WebhookSettingsSchema = z.object({
   headers: z.array(z.tuple([z.string(), z.string()])).optional(),
   method: z.string().default('POST'),
   auth: WebhookAuthSchema.optional(),
-  min_priority: z.enum(['Low', 'Normal', 'High', 'Critical']).default('Low'),
+  min_priority: z.number().int().min(0).max(10).default(2),
   enabled: z.boolean().default(true),
   timeout_secs: z.number().int().positive().default(30),
 });
@@ -91,8 +92,16 @@ export const TelegramSettingsSchema = z.object({
   bot_token: z.string().min(1),
   chat_id: z.string().min(1),
   parse_mode: z.enum(['HTML', 'Markdown', 'MarkdownV2']).default('HTML'),
-  min_priority: z.enum(['Low', 'Normal', 'High', 'Critical']).default('Normal'),
+  min_priority: z.number().int().min(0).max(10).default(5),
   enabled: z.boolean().default(true),
+});
+
+export const GotifySettingsSchema = z.object({
+  server_url: z.string().url(),
+  app_token: z.string().min(1),
+  min_priority: z.number().int().min(0).max(10).default(5),
+  enabled: z.boolean().default(true),
+  timeout_secs: z.number().int().positive().default(30),
 });
 
 export const NotificationChannelSchema = z.object({
@@ -122,7 +131,7 @@ export type UpdateChannelRequest = z.infer<typeof UpdateChannelRequestSchema>;
 export const NotificationEventTypeInfoSchema = z.object({
   event_type: z.string(),
   label: z.string(),
-  priority: z.enum(['Low', 'Normal', 'High', 'Critical']),
+  priority: z.number().int(),
 });
 
 export type NotificationEventTypeInfo = z.infer<
@@ -132,7 +141,7 @@ export type NotificationEventTypeInfo = z.infer<
 export const NotificationEventLogSchema = z.object({
   id: z.uuid(),
   event_type: z.string(),
-  priority: z.string(),
+  priority: z.number().int(),
   payload: z.string(),
   streamer_id: z.string().optional().nullable(),
   created_at: TimestampMsSchema,
@@ -143,7 +152,7 @@ export type NotificationEventLog = z.infer<typeof NotificationEventLogSchema>;
 export const WebPushSubscriptionSchema = z.object({
   id: z.uuid(),
   endpoint: z.string().url(),
-  min_priority: z.string(),
+  min_priority: z.number().int(),
   created_at: TimestampMsSchema,
   updated_at: TimestampMsSchema,
 });
@@ -170,6 +179,12 @@ export const EmailChannelFormSchema = z.object({
   settings: EmailSettingsSchema,
 });
 
+export const GotifyChannelFormSchema = z.object({
+  name: z.string().min(1, 'Name is required'),
+  channel_type: z.literal('Gotify'),
+  settings: GotifySettingsSchema,
+});
+
 export const WebhookChannelFormSchema = z.object({
   name: z.string().min(1, 'Name is required'),
   channel_type: z.literal('Webhook'),
@@ -186,6 +201,7 @@ export const TelegramChannelFormSchema = z.object({
 export const ChannelFormSchema = z.discriminatedUnion('channel_type', [
   DiscordChannelFormSchema,
   EmailChannelFormSchema,
+  GotifyChannelFormSchema,
   TelegramChannelFormSchema,
   WebhookChannelFormSchema,
 ]);

--- a/rust-srec/frontend/src/components/notifications/browser-channel-dialog.tsx
+++ b/rust-srec/frontend/src/components/notifications/browser-channel-dialog.tsx
@@ -29,9 +29,9 @@ interface BrowserChannelDialogProps {
   webPushEnabled: boolean;
   webPushPermission: NotificationPermission;
   webPushStatusText: string;
-  webPushMinPriority: string;
+  webPushMinPriority: number;
   onWebPushToggle: (checked: boolean) => void;
-  onWebPushPriorityChange: (value: string) => void;
+  onWebPushPriorityChange: (value: number) => void;
   browserNotificationsEnabled: boolean;
   onBrowserNotificationsToggle: (enabled: boolean) => void;
 }
@@ -138,24 +138,24 @@ export function BrowserChannelDialog({
                   <Trans>Priority Filter</Trans>
                 </span>
                 <Select
-                  value={webPushMinPriority}
-                  onValueChange={onWebPushPriorityChange}
+                  value={String(webPushMinPriority)}
+                  onValueChange={(val) => onWebPushPriorityChange(Number(val))}
                   disabled={!webPushSupported}
                 >
                   <SelectTrigger className="h-7 w-32 bg-background/40 border-border/20 text-[10px]">
                     <SelectValue />
                   </SelectTrigger>
                   <SelectContent>
-                    <SelectItem value="critical" className="text-[10px]">
+                    <SelectItem value="10" className="text-[10px]">
                       {i18n._(msg`Critical Only`)}
                     </SelectItem>
-                    <SelectItem value="high" className="text-[10px]">
+                    <SelectItem value="8" className="text-[10px]">
                       {i18n._(msg`High+`)}
                     </SelectItem>
-                    <SelectItem value="normal" className="text-[10px]">
+                    <SelectItem value="5" className="text-[10px]">
                       {i18n._(msg`Normal+`)}
                     </SelectItem>
-                    <SelectItem value="low" className="text-[10px]">
+                    <SelectItem value="2" className="text-[10px]">
                       {i18n._(msg`All`)}
                     </SelectItem>
                   </SelectContent>

--- a/rust-srec/frontend/src/components/notifications/browser-notification-listener.tsx
+++ b/rust-srec/frontend/src/components/notifications/browser-notification-listener.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { listEvents } from '@/server/functions/notifications';
 import type { NotificationEventLog } from '@/api/schemas/notifications';
+import { priorityLabel } from '@/lib/priority';
 import {
   getBrowserNotificationsEnabled,
   getLastNotifiedCriticalMs,
@@ -41,7 +42,7 @@ function formatBrowserNotification(log: NotificationEventLog): {
   const bodyParts: string[] = [];
   if (streamer) bodyParts.push(String(streamer));
   if (error) bodyParts.push(String(error));
-  if (bodyParts.length === 0) bodyParts.push(log.priority);
+  if (bodyParts.length === 0) bodyParts.push(priorityLabel(log.priority));
 
   return { title: baseTitle, body: bodyParts.join(' — ').slice(0, 200) };
 }
@@ -70,7 +71,7 @@ export function BrowserNotificationListener() {
   const { data: events } = useQuery({
     queryKey: ['notification-events', 'browser', 'critical'],
     queryFn: () =>
-      listEvents({ data: { limit: 50, offset: 0, priority: 'critical' } }),
+      listEvents({ data: { limit: 50, offset: 0, priority: '10' } }),
     enabled: shouldPoll,
     refetchInterval: 60_000,
     refetchOnWindowFocus: true,

--- a/rust-srec/frontend/src/components/notifications/channel-card.tsx
+++ b/rust-srec/frontend/src/components/notifications/channel-card.tsx
@@ -22,6 +22,7 @@ import {
   MoreHorizontal,
   Edit,
   Trash2,
+  Bell,
   BellRing,
   Activity,
   Webhook,
@@ -42,6 +43,7 @@ interface ChannelCardProps {
 const CHANNEL_ICONS = {
   Discord: MessageSquare,
   Email: Mail,
+  Gotify: Bell,
   Telegram: Send,
   Webhook: Webhook,
 };
@@ -49,6 +51,7 @@ const CHANNEL_ICONS = {
 const CHANNEL_COLORS = {
   Discord: 'bg-indigo-500/10 text-indigo-500 border-indigo-500/20',
   Email: 'bg-blue-500/10 text-blue-500 border-blue-500/20',
+  Gotify: 'bg-green-500/10 text-green-500 border-green-500/20',
   Telegram: 'bg-sky-500/10 text-sky-500 border-sky-500/20',
   Webhook: 'bg-orange-500/10 text-orange-500 border-orange-500/20',
 };
@@ -122,6 +125,17 @@ export function ChannelCard({
               </span>
             </div>
           </>
+        );
+      case 'Gotify':
+        return (
+          <div className="flex flex-col gap-0.5 bg-muted/30 rounded-md px-2 py-1.5 border border-transparent group-hover:border-primary/5 transition-colors">
+            <span className="text-[9px] uppercase tracking-wider opacity-50">
+              <Trans>Server URL</Trans>
+            </span>
+            <span className="text-[11px] font-medium truncate text-foreground/80">
+              {configObj.server_url || '...'}
+            </span>
+          </div>
         );
       case 'Webhook':
         return (

--- a/rust-srec/frontend/src/components/notifications/channel-form.tsx
+++ b/rust-srec/frontend/src/components/notifications/channel-form.tsx
@@ -41,6 +41,7 @@ import { toast } from 'sonner';
 import { Loader2, Box } from 'lucide-react';
 import { DiscordForm } from './forms/discord-form';
 import { EmailForm } from './forms/email-form';
+import { GotifyForm } from './forms/gotify-form';
 import { TelegramForm } from './forms/telegram-form';
 import { WebhookForm } from './forms/webhook-form';
 import { removeEmpty } from '@/lib/format';
@@ -68,7 +69,7 @@ export function ChannelForm({ channel, open, onOpenChange }: ChannelFormProps) {
         url: '',
         method: 'POST',
         auth: { type: 'None' },
-        min_priority: 'Low',
+        min_priority: 2,
         enabled: true,
         timeout_secs: 30,
         headers: [],
@@ -102,7 +103,7 @@ export function ChannelForm({ channel, open, onOpenChange }: ChannelFormProps) {
             webhook_url: settings.webhook_url || '',
             username: settings.username,
             avatar_url: settings.avatar_url,
-            min_priority: settings.min_priority || 'Normal',
+            min_priority: settings.min_priority ?? 5,
             enabled: settings.enabled !== false,
           },
         });
@@ -118,7 +119,7 @@ export function ChannelForm({ channel, open, onOpenChange }: ChannelFormProps) {
             from_address: settings.from_address || '',
             to_addresses: settings.to_addresses || [],
             use_tls: settings.use_tls ?? true,
-            min_priority: settings.min_priority || 'High',
+            min_priority: settings.min_priority ?? 8,
             enabled: settings.enabled !== false,
           },
         });
@@ -130,8 +131,20 @@ export function ChannelForm({ channel, open, onOpenChange }: ChannelFormProps) {
             bot_token: settings.bot_token || '',
             chat_id: settings.chat_id || '',
             parse_mode: settings.parse_mode || 'HTML',
-            min_priority: settings.min_priority || 'Normal',
+            min_priority: settings.min_priority ?? 5,
             enabled: settings.enabled !== false,
+          },
+        });
+      } else if (channel.channel_type === 'Gotify') {
+        form.reset({
+          name: channel.name,
+          channel_type: 'Gotify',
+          settings: {
+            server_url: settings.server_url || '',
+            app_token: settings.app_token || '',
+            min_priority: settings.min_priority ?? 5,
+            enabled: settings.enabled !== false,
+            timeout_secs: settings.timeout_secs || 30,
           },
         });
       } else if (channel.channel_type === 'Webhook') {
@@ -171,7 +184,7 @@ export function ChannelForm({ channel, open, onOpenChange }: ChannelFormProps) {
             url: settings.url || '',
             method: settings.method || 'POST',
             auth,
-            min_priority: settings.min_priority || 'Low',
+            min_priority: settings.min_priority ?? 2,
             enabled: settings.enabled !== false,
             timeout_secs: settings.timeout_secs || 30,
             headers,
@@ -186,7 +199,7 @@ export function ChannelForm({ channel, open, onOpenChange }: ChannelFormProps) {
           url: '',
           method: 'POST',
           auth: { type: 'None' },
-          min_priority: 'Low',
+          min_priority: 2,
           enabled: true,
           timeout_secs: 30,
           headers: [],
@@ -343,6 +356,7 @@ export function ChannelForm({ channel, open, onOpenChange }: ChannelFormProps) {
                         <SelectContent>
                           <SelectItem value="Webhook">Webhook</SelectItem>
                           <SelectItem value="Telegram">Telegram</SelectItem>
+                          <SelectItem value="Gotify">Gotify</SelectItem>
                           <SelectItem value="Discord">
                             Discord (Coming Soon)
                           </SelectItem>
@@ -373,6 +387,7 @@ export function ChannelForm({ channel, open, onOpenChange }: ChannelFormProps) {
               {selectedType === 'Webhook' && <WebhookForm />}
               {selectedType === 'Discord' && <DiscordForm />}
               {selectedType === 'Email' && <EmailForm />}
+              {selectedType === 'Gotify' && <GotifyForm />}
               {selectedType === 'Telegram' && <TelegramForm />}
             </div>
 

--- a/rust-srec/frontend/src/components/notifications/desktop-channel-dialog.tsx
+++ b/rust-srec/frontend/src/components/notifications/desktop-channel-dialog.tsx
@@ -25,10 +25,7 @@ import { Checkbox } from '@/components/ui/checkbox';
 import { cn } from '@/lib/utils';
 
 import type { NotificationEventTypeInfo } from '@/api/schemas/notifications';
-import type {
-  DesktopNotificationConfig,
-  DesktopNotificationMinPriority,
-} from '@/desktop/desktop-notifications';
+import type { DesktopNotificationConfig } from '@/desktop/desktop-notifications';
 
 interface DesktopChannelDialogProps {
   open: boolean;
@@ -49,17 +46,11 @@ export function DesktopChannelDialog({
 }: DesktopChannelDialogProps) {
   const { i18n } = useLingui();
 
-  const priorityLabel = (p: DesktopNotificationMinPriority) => {
-    switch (p) {
-      case 'critical':
-        return i18n._(msg`Critical Only`);
-      case 'high':
-        return i18n._(msg`High+`);
-      case 'normal':
-        return i18n._(msg`Normal+`);
-      case 'low':
-        return i18n._(msg`All`);
-    }
+  const priorityLabel = (p: number) => {
+    if (p >= 10) return i18n._(msg`Critical Only`);
+    if (p >= 7) return i18n._(msg`High+`);
+    if (p >= 4) return i18n._(msg`Normal+`);
+    return i18n._(msg`All`);
   };
 
   const toggleEventType = (eventType: string, checked: boolean) => {
@@ -140,11 +131,11 @@ export function DesktopChannelDialog({
                 <Trans>Minimum Priority</Trans>
               </span>
               <Select
-                value={config.minPriority}
-                onValueChange={(minPriority) =>
+                value={String(config.minPriority)}
+                onValueChange={(val) =>
                   onConfigChange({
                     ...config,
-                    minPriority: minPriority as DesktopNotificationMinPriority,
+                    minPriority: Number(val),
                   })
                 }
               >
@@ -152,17 +143,17 @@ export function DesktopChannelDialog({
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
-                  <SelectItem value="critical" className="text-[10px]">
-                    {priorityLabel('critical')}
+                  <SelectItem value="10" className="text-[10px]">
+                    {priorityLabel(10)}
                   </SelectItem>
-                  <SelectItem value="high" className="text-[10px]">
-                    {priorityLabel('high')}
+                  <SelectItem value="8" className="text-[10px]">
+                    {priorityLabel(8)}
                   </SelectItem>
-                  <SelectItem value="normal" className="text-[10px]">
-                    {priorityLabel('normal')}
+                  <SelectItem value="5" className="text-[10px]">
+                    {priorityLabel(5)}
                   </SelectItem>
-                  <SelectItem value="low" className="text-[10px]">
-                    {priorityLabel('low')}
+                  <SelectItem value="2" className="text-[10px]">
+                    {priorityLabel(2)}
                   </SelectItem>
                 </SelectContent>
               </Select>

--- a/rust-srec/frontend/src/components/notifications/events/event-card.tsx
+++ b/rust-srec/frontend/src/components/notifications/events/event-card.tsx
@@ -7,70 +7,63 @@ import { Trans } from '@lingui/react/macro';
 import { Button } from '@/components/ui/button';
 import { EventIcon } from './event-icon';
 import { PayloadPreview } from './payload-preview';
+import { priorityLabel } from '@/lib/priority';
 
-export const getPriorityStyles = (priority: string) => {
-  switch (priority.toLowerCase()) {
-    case 'critical':
-      return {
-        bg: 'bg-destructive/5 dark:bg-destructive/10',
-        border: 'border-destructive/20 group-hover:border-destructive/40',
-        text: 'text-destructive',
-        badge: 'bg-destructive/10 text-destructive border-destructive/20',
-        icon: 'bg-destructive/10 text-destructive',
-        glow: 'group-hover:shadow-[0_0_20px_rgba(239,68,68,0.15)]',
-        flare: 'from-destructive/20 to-transparent',
-      };
-    case 'high':
-      return {
-        bg: 'bg-orange-500/5 dark:bg-orange-500/10',
-        border: 'border-orange-500/20 group-hover:border-orange-500/40',
-        text: 'text-orange-600 dark:text-orange-400',
-        badge:
-          'bg-orange-500/10 text-orange-600 dark:text-orange-400 border-orange-500/20',
-        icon: 'bg-orange-500/10 text-orange-600 dark:text-orange-400',
-        glow: 'group-hover:shadow-[0_0_20px_rgba(249,115,22,0.15)]',
-        flare: 'from-orange-500/20 to-transparent',
-      };
-    case 'normal':
-      return {
-        bg: 'bg-blue-500/5 dark:bg-blue-500/10',
-        border: 'border-blue-500/20 group-hover:border-blue-500/40',
-        text: 'text-blue-600 dark:text-blue-400',
-        badge:
-          'bg-blue-500/10 text-blue-600 dark:text-blue-400 border-blue-500/20',
-        icon: 'bg-blue-500/10 text-blue-600 dark:text-blue-400',
-        glow: 'group-hover:shadow-[0_0_20px_rgba(59,130,246,0.15)]',
-        flare: 'from-blue-500/20 to-transparent',
-      };
-    case 'low':
-      return {
-        bg: 'bg-slate-500/5 dark:bg-slate-500/10',
-        border: 'border-slate-500/20 group-hover:border-slate-500/40',
-        text: 'text-slate-600 dark:text-slate-400',
-        badge:
-          'bg-slate-500/10 text-slate-600 dark:text-slate-400 border-slate-500/20',
-        icon: 'bg-slate-500/10 text-slate-600 dark:text-slate-400',
-        glow: 'group-hover:shadow-[0_0_20px_rgba(100,116,139,0.15)]',
-        flare: 'from-slate-500/20 to-transparent',
-      };
-    default:
-      return {
-        bg: 'bg-slate-500/5 dark:bg-slate-500/10',
-        border: 'border-slate-500/20 group-hover:border-slate-500/40',
-        text: 'text-slate-600 dark:text-slate-400',
-        badge:
-          'bg-slate-500/10 text-slate-600 dark:text-slate-400 border-slate-500/20',
-        icon: 'bg-slate-500/10 text-slate-600 dark:text-slate-400',
-        glow: 'group-hover:shadow-[0_0_20px_rgba(100,116,139,0.15)]',
-        flare: 'from-slate-500/20 to-transparent',
-      };
+export const getPriorityStyles = (priority: number) => {
+  if (priority >= 10) {
+    // Critical
+    return {
+      bg: 'bg-destructive/5 dark:bg-destructive/10',
+      border: 'border-destructive/20 group-hover:border-destructive/40',
+      text: 'text-destructive',
+      badge: 'bg-destructive/10 text-destructive border-destructive/20',
+      icon: 'bg-destructive/10 text-destructive',
+      glow: 'group-hover:shadow-[0_0_20px_rgba(239,68,68,0.15)]',
+      flare: 'from-destructive/20 to-transparent',
+    };
+  } else if (priority >= 7) {
+    // High
+    return {
+      bg: 'bg-orange-500/5 dark:bg-orange-500/10',
+      border: 'border-orange-500/20 group-hover:border-orange-500/40',
+      text: 'text-orange-600 dark:text-orange-400',
+      badge:
+        'bg-orange-500/10 text-orange-600 dark:text-orange-400 border-orange-500/20',
+      icon: 'bg-orange-500/10 text-orange-600 dark:text-orange-400',
+      glow: 'group-hover:shadow-[0_0_20px_rgba(249,115,22,0.15)]',
+      flare: 'from-orange-500/20 to-transparent',
+    };
+  } else if (priority >= 4) {
+    // Normal
+    return {
+      bg: 'bg-blue-500/5 dark:bg-blue-500/10',
+      border: 'border-blue-500/20 group-hover:border-blue-500/40',
+      text: 'text-blue-600 dark:text-blue-400',
+      badge:
+        'bg-blue-500/10 text-blue-600 dark:text-blue-400 border-blue-500/20',
+      icon: 'bg-blue-500/10 text-blue-600 dark:text-blue-400',
+      glow: 'group-hover:shadow-[0_0_20px_rgba(59,130,246,0.15)]',
+      flare: 'from-blue-500/20 to-transparent',
+    };
+  } else {
+    // Low
+    return {
+      bg: 'bg-slate-500/5 dark:bg-slate-500/10',
+      border: 'border-slate-500/20 group-hover:border-slate-500/40',
+      text: 'text-slate-600 dark:text-slate-400',
+      badge:
+        'bg-slate-500/10 text-slate-600 dark:text-slate-400 border-slate-500/20',
+      icon: 'bg-slate-500/10 text-slate-600 dark:text-slate-400',
+      glow: 'group-hover:shadow-[0_0_20px_rgba(100,116,139,0.15)]',
+      flare: 'from-slate-500/20 to-transparent',
+    };
   }
 };
 
 export interface NotificationEvent {
   id: string;
   event_type: string;
-  priority: string;
+  priority: number;
   payload: string;
   created_at: number;
   streamer_id?: string | null;
@@ -135,7 +128,7 @@ export const EventCard = memo(({ event, onViewDetails }: EventCardProps) => {
                   styles.badge,
                 )}
               >
-                {event.priority}
+                {priorityLabel(event.priority)}
               </Badge>
             </div>
             <h4 className="text-[13px] font-bold leading-none tracking-tight text-foreground/90 group-hover:text-primary transition-colors">

--- a/rust-srec/frontend/src/components/notifications/forms/discord-form.tsx
+++ b/rust-srec/frontend/src/components/notifications/forms/discord-form.tsx
@@ -10,6 +10,7 @@ import { Trans } from '@lingui/react/macro';
 import { useLingui } from '@lingui/react';
 import { msg } from '@lingui/core/macro';
 import { Globe, User } from 'lucide-react';
+import { priorityOptions } from '@/lib/priority';
 import {
   Select,
   SelectContent,
@@ -97,25 +98,21 @@ export function DiscordForm() {
               <FormLabel>
                 <Trans>Min Priority</Trans>
               </FormLabel>
-              <Select onValueChange={field.onChange} defaultValue={field.value}>
+              <Select
+                onValueChange={(val) => field.onChange(Number(val))}
+                defaultValue={String(field.value)}
+              >
                 <FormControl>
                   <SelectTrigger className="bg-background/50">
                     <SelectValue />
                   </SelectTrigger>
                 </FormControl>
                 <SelectContent>
-                  <SelectItem value="Low">
-                    <Trans>Low</Trans>
-                  </SelectItem>
-                  <SelectItem value="Normal">
-                    <Trans>Normal</Trans>
-                  </SelectItem>
-                  <SelectItem value="High">
-                    <Trans>High</Trans>
-                  </SelectItem>
-                  <SelectItem value="Critical">
-                    <Trans>Critical</Trans>
-                  </SelectItem>
+                  {priorityOptions().map((opt) => (
+                    <SelectItem key={opt.value} value={opt.value}>
+                      <Trans>{opt.label}</Trans>
+                    </SelectItem>
+                  ))}
                 </SelectContent>
               </Select>
               <FormMessage />

--- a/rust-srec/frontend/src/components/notifications/forms/email-form.tsx
+++ b/rust-srec/frontend/src/components/notifications/forms/email-form.tsx
@@ -11,6 +11,7 @@ import { Trans } from '@lingui/react/macro';
 import { useLingui } from '@lingui/react';
 import { msg } from '@lingui/core/macro';
 import { Globe, Hash, User, Shield, Mail } from 'lucide-react';
+import { priorityOptions } from '@/lib/priority';
 import {
   Select,
   SelectContent,
@@ -174,25 +175,21 @@ export function EmailForm() {
               <FormLabel>
                 <Trans>Min Priority</Trans>
               </FormLabel>
-              <Select onValueChange={field.onChange} defaultValue={field.value}>
+              <Select
+                onValueChange={(val) => field.onChange(Number(val))}
+                defaultValue={String(field.value)}
+              >
                 <FormControl>
                   <SelectTrigger className="bg-background/50">
                     <SelectValue />
                   </SelectTrigger>
                 </FormControl>
                 <SelectContent>
-                  <SelectItem value="Low">
-                    <Trans>Low</Trans>
-                  </SelectItem>
-                  <SelectItem value="Normal">
-                    <Trans>Normal</Trans>
-                  </SelectItem>
-                  <SelectItem value="High">
-                    <Trans>High</Trans>
-                  </SelectItem>
-                  <SelectItem value="Critical">
-                    <Trans>Critical</Trans>
-                  </SelectItem>
+                  {priorityOptions().map((opt) => (
+                    <SelectItem key={opt.value} value={opt.value}>
+                      <Trans>{opt.label}</Trans>
+                    </SelectItem>
+                  ))}
                 </SelectContent>
               </Select>
               <FormMessage />

--- a/rust-srec/frontend/src/components/notifications/forms/gotify-form.tsx
+++ b/rust-srec/frontend/src/components/notifications/forms/gotify-form.tsx
@@ -8,8 +8,7 @@ import {
 import { Trans } from '@lingui/react/macro';
 import { useLingui } from '@lingui/react';
 import { msg } from '@lingui/core/macro';
-import { KeyRound, Hash } from 'lucide-react';
-import { priorityOptions } from '@/lib/priority';
+import { Globe, KeyRound, Timer } from 'lucide-react';
 import {
   Select,
   SelectContent,
@@ -20,8 +19,9 @@ import {
 import { useFormContext } from 'react-hook-form';
 import { IconInput } from '@/components/ui/icon-input';
 import { SwitchCard } from '@/components/ui/switch-card';
+import { priorityOptions } from '@/lib/priority';
 
-export function TelegramForm() {
+export function GotifyForm() {
   const { i18n } = useLingui();
   const form = useFormContext();
 
@@ -29,17 +29,16 @@ export function TelegramForm() {
     <div className="space-y-4 rounded-xl border border-primary/10 bg-primary/5 p-4">
       <FormField
         control={form.control}
-        name="settings.bot_token"
+        name="settings.server_url"
         render={({ field }) => (
           <FormItem>
             <FormLabel>
-              <Trans>Bot Token</Trans>
+              <Trans>Server URL</Trans>
             </FormLabel>
             <FormControl>
               <IconInput
-                icon={KeyRound}
-                type="password"
-                placeholder={i18n._(msg`123456:ABC-DEF...`)}
+                icon={Globe}
+                placeholder={i18n._(msg`https://gotify.example.com`)}
                 className="bg-background/50"
                 {...field}
               />
@@ -50,16 +49,17 @@ export function TelegramForm() {
       />
       <FormField
         control={form.control}
-        name="settings.chat_id"
+        name="settings.app_token"
         render={({ field }) => (
           <FormItem>
             <FormLabel>
-              <Trans>Chat ID</Trans>
+              <Trans>App Token</Trans>
             </FormLabel>
             <FormControl>
               <IconInput
-                icon={Hash}
-                placeholder={i18n._(msg`-1001234567890`)}
+                icon={KeyRound}
+                type="password"
+                placeholder={i18n._(msg`Gotify application token`)}
                 className="bg-background/50"
                 {...field}
               />
@@ -69,30 +69,6 @@ export function TelegramForm() {
         )}
       />
       <div className="pt-2 grid grid-cols-3 gap-4">
-        <FormField
-          control={form.control}
-          name="settings.parse_mode"
-          render={({ field }) => (
-            <FormItem>
-              <FormLabel>
-                <Trans>Parse Mode</Trans>
-              </FormLabel>
-              <Select onValueChange={field.onChange} defaultValue={field.value}>
-                <FormControl>
-                  <SelectTrigger className="bg-background/50">
-                    <SelectValue />
-                  </SelectTrigger>
-                </FormControl>
-                <SelectContent>
-                  <SelectItem value="HTML">HTML</SelectItem>
-                  <SelectItem value="Markdown">Markdown</SelectItem>
-                  <SelectItem value="MarkdownV2">MarkdownV2</SelectItem>
-                </SelectContent>
-              </Select>
-              <FormMessage />
-            </FormItem>
-          )}
-        />
         <FormField
           control={form.control}
           name="settings.min_priority"
@@ -118,6 +94,30 @@ export function TelegramForm() {
                   ))}
                 </SelectContent>
               </Select>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="settings.timeout_secs"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>
+                <Trans>Timeout (s)</Trans>
+              </FormLabel>
+              <FormControl>
+                <IconInput
+                  icon={Timer}
+                  type="number"
+                  min={1}
+                  max={300}
+                  placeholder="30"
+                  className="bg-background/50"
+                  {...field}
+                  onChange={(e) => field.onChange(e.target.valueAsNumber)}
+                />
+              </FormControl>
               <FormMessage />
             </FormItem>
           )}

--- a/rust-srec/frontend/src/components/notifications/forms/webhook-form.tsx
+++ b/rust-srec/frontend/src/components/notifications/forms/webhook-form.tsx
@@ -37,6 +37,7 @@ import { motion, AnimatePresence } from 'motion/react';
 import { IconInput } from '@/components/ui/icon-input';
 import { SwitchCard } from '@/components/ui/switch-card';
 import { CardHeaderWithIcon } from '@/components/ui/card-header-with-icon';
+import { priorityOptions } from '@/lib/priority';
 
 export const WebhookForm = memo(function WebhookForm() {
   const { i18n } = useLingui();
@@ -143,8 +144,8 @@ export const WebhookForm = memo(function WebhookForm() {
                   <Trans>Minimum Priority</Trans>
                 </FormLabel>
                 <Select
-                  onValueChange={field.onChange}
-                  defaultValue={field.value}
+                  onValueChange={(val) => field.onChange(Number(val))}
+                  defaultValue={String(field.value)}
                 >
                   <FormControl>
                     <SelectTrigger>
@@ -152,18 +153,11 @@ export const WebhookForm = memo(function WebhookForm() {
                     </SelectTrigger>
                   </FormControl>
                   <SelectContent>
-                    <SelectItem value="Low">
-                      <Trans>Low</Trans>
-                    </SelectItem>
-                    <SelectItem value="Normal">
-                      <Trans>Normal</Trans>
-                    </SelectItem>
-                    <SelectItem value="High">
-                      <Trans>High</Trans>
-                    </SelectItem>
-                    <SelectItem value="Critical">
-                      <Trans>Critical</Trans>
-                    </SelectItem>
+                    {priorityOptions().map((opt) => (
+                      <SelectItem key={opt.value} value={opt.value}>
+                        <Trans>{opt.label}</Trans>
+                      </SelectItem>
+                    ))}
                   </SelectContent>
                 </Select>
                 <FormDescription className="text-xs">

--- a/rust-srec/frontend/src/components/notifications/subscription-manager.tsx
+++ b/rust-srec/frontend/src/components/notifications/subscription-manager.tsx
@@ -24,6 +24,7 @@ import { NotificationChannel } from '@/api/schemas';
 import { Trans } from '@lingui/react/macro';
 import { msg } from '@lingui/core/macro';
 import { useLingui } from '@lingui/react';
+import { priorityLabel } from '@/lib/priority';
 import {
   Loader2,
   BellRing,
@@ -401,7 +402,7 @@ export function SubscriptionManager({
                               variant="outline"
                               className={`text-[10px] h-5 transition-colors ${isSelected ? 'bg-primary/10 border-primary/20 text-primary' : 'text-muted-foreground'}`}
                             >
-                              {type.priority}
+                              {priorityLabel(type.priority)}
                             </Badge>
                           </div>
                           <p className="text-xs text-muted-foreground/80 leading-relaxed font-mono">

--- a/rust-srec/frontend/src/desktop/desktop-notifications.ts
+++ b/rust-srec/frontend/src/desktop/desktop-notifications.ts
@@ -1,13 +1,31 @@
 import { z } from 'zod';
 
+import {
+  PRIORITY_LOW,
+  PRIORITY_NORMAL,
+  PRIORITY_HIGH,
+  PRIORITY_CRITICAL,
+} from '@/lib/priority';
 import { isTauriRuntime } from '@/utils/tauri';
 
-export const DesktopNotificationMinPrioritySchema = z.enum([
-  'low',
-  'normal',
-  'high',
-  'critical',
-]);
+// Accepts integer (new) or legacy string ("low"/"normal"/"high"/"critical").
+export const DesktopNotificationMinPrioritySchema = z
+  .union([z.number().int().min(0).max(10), z.string()])
+  .transform((v) => {
+    if (typeof v === 'number') return v;
+    switch (v.trim().toLowerCase()) {
+      case 'low':
+        return PRIORITY_LOW;
+      case 'normal':
+        return PRIORITY_NORMAL;
+      case 'high':
+        return PRIORITY_HIGH;
+      case 'critical':
+        return PRIORITY_CRITICAL;
+      default:
+        return PRIORITY_NORMAL;
+    }
+  });
 
 export type DesktopNotificationMinPriority = z.infer<
   typeof DesktopNotificationMinPrioritySchema

--- a/rust-srec/frontend/src/hooks/use-notification-dot.ts
+++ b/rust-srec/frontend/src/hooks/use-notification-dot.ts
@@ -14,7 +14,7 @@ export function useNotificationDot() {
 
       // Server filters by priority=critical, so all returned events are critical
       const events = await listEvents({
-        data: { limit: 50, priority: 'critical' },
+        data: { limit: 50, priority: '10' },
       });
       // 7 days cutoff - critical events shouldn't vanish too quickly
       const cutoff = Date.now() - 7 * 24 * 60 * 60 * 1000;

--- a/rust-srec/frontend/src/lib/priority.ts
+++ b/rust-srec/frontend/src/lib/priority.ts
@@ -1,0 +1,28 @@
+export const PRIORITY_LOW = 2;
+export const PRIORITY_NORMAL = 5;
+export const PRIORITY_HIGH = 8;
+export const PRIORITY_CRITICAL = 10;
+
+export type PriorityLevel =
+  | typeof PRIORITY_LOW
+  | typeof PRIORITY_NORMAL
+  | typeof PRIORITY_HIGH
+  | typeof PRIORITY_CRITICAL;
+
+export function priorityLabel(value: number): string {
+  if (value <= 3) return 'Low';
+  if (value <= 6) return 'Normal';
+  if (value <= 9) return 'High';
+  return 'Critical';
+}
+
+const PRIORITY_OPTIONS = [
+  { value: String(PRIORITY_LOW), label: 'Low' },
+  { value: String(PRIORITY_NORMAL), label: 'Normal' },
+  { value: String(PRIORITY_HIGH), label: 'High' },
+  { value: String(PRIORITY_CRITICAL), label: 'Critical' },
+] as const;
+
+export function priorityOptions() {
+  return PRIORITY_OPTIONS;
+}

--- a/rust-srec/frontend/src/locales/en/messages.po
+++ b/rust-srec/frontend/src/locales/en/messages.po
@@ -27,7 +27,7 @@ msgstr "--flag value"
 msgid "--hls-live-edge 3"
 msgstr "--hls-live-edge 3"
 
-#: src/components/notifications/forms/telegram-form.tsx:61
+#: src/components/notifications/forms/telegram-form.tsx:62
 msgid "-1001234567890"
 msgstr "-1001234567890"
 
@@ -94,10 +94,16 @@ msgid "{0, plural, one {file} other {files}}"
 msgstr "{0, plural, one {file} other {files}}"
 
 #. placeholder {0}: day.full
+#. placeholder {0}: opt.label
 #. placeholder {0}: p.label
 #: src/components/filters/forms/TimeBasedFilterForm.tsx:158
 #: src/components/filters/forms/TimeBasedFilterForm.tsx:191
 #: src/components/filters/forms/TimeBasedFilterForm.tsx:235
+#: src/components/notifications/forms/discord-form.tsx:113
+#: src/components/notifications/forms/email-form.tsx:190
+#: src/components/notifications/forms/gotify-form.tsx:92
+#: src/components/notifications/forms/telegram-form.tsx:116
+#: src/components/notifications/forms/webhook-form.tsx:158
 msgid "{0}"
 msgstr "{0}"
 
@@ -117,7 +123,7 @@ msgstr "{0} stream(s) added successfully"
 msgid "{0}/{1} steps"
 msgstr "{0}/{1} steps"
 
-#: src/components/notifications/channel-form.tsx:326
+#: src/components/notifications/channel-form.tsx:339
 msgid "{val} channel support is coming soon!"
 msgstr "{val} channel support is coming soon!"
 
@@ -161,7 +167,7 @@ msgstr "0:v:0"
 msgid "1 (best) - 31 (worst)"
 msgstr "1 (best) - 31 (worst)"
 
-#: src/components/notifications/forms/telegram-form.tsx:41
+#: src/components/notifications/forms/telegram-form.tsx:42
 msgid "123456:ABC-DEF..."
 msgstr "123456:ABC-DEF..."
 
@@ -181,7 +187,7 @@ msgstr "404"
 msgid "44100"
 msgstr "44100"
 
-#: src/components/notifications/forms/email-form.tsx:66
+#: src/components/notifications/forms/email-form.tsx:67
 msgid "587"
 msgstr "587"
 
@@ -217,10 +223,10 @@ msgstr "Action"
 msgid "Actions"
 msgstr "Actions"
 
-#: src/components/notifications/forms/webhook-form.tsx:116
+#: src/components/notifications/forms/webhook-form.tsx:117
 #: src/components/streamers/edit/streamer-meta-form.tsx:226
 #: src/routes/_authed/_dashboard/config/language.lazy.tsx:108
-#: src/routes/_authed/_dashboard/notifications/index.lazy.tsx:482
+#: src/routes/_authed/_dashboard/notifications/index.lazy.tsx:475
 msgid "Active"
 msgstr "Active"
 
@@ -240,7 +246,7 @@ msgstr "Active Recordings"
 msgid "Adaptive Refresh (Default: On)"
 msgstr "Adaptive Refresh (Default: On)"
 
-#: src/components/notifications/forms/webhook-form.tsx:429
+#: src/components/notifications/forms/webhook-form.tsx:423
 msgid "Add"
 msgstr "Add"
 
@@ -268,7 +274,7 @@ msgstr "Add argument template"
 msgid "Add at least one step"
 msgstr "Add at least one step"
 
-#: src/routes/_authed/_dashboard/notifications/index.lazy.tsx:413
+#: src/routes/_authed/_dashboard/notifications/index.lazy.tsx:406
 msgid "Add Channel"
 msgstr "Add Channel"
 
@@ -276,7 +282,7 @@ msgstr "Add Channel"
 msgid "Add Custom Tag"
 msgstr "Add Custom Tag"
 
-#: src/components/notifications/forms/email-form.tsx:156
+#: src/components/notifications/forms/email-form.tsx:157
 msgid "Add email and press Enter"
 msgstr "Add email and press Enter"
 
@@ -417,15 +423,15 @@ msgstr "AFTER: {0}"
 msgid "Album"
 msgstr "Album"
 
-#: src/components/notifications/subscription-manager.tsx:169
+#: src/components/notifications/subscription-manager.tsx:170
 msgid "Alerts when disk space is running low."
 msgstr "Alerts when disk space is running low."
 
 #: src/components/notifications/browser-channel-dialog.tsx:159
-#: src/components/notifications/desktop-channel-dialog.tsx:61
+#: src/components/notifications/desktop-channel-dialog.tsx:53
 #: src/components/pipeline/workflows/step-library.tsx:291
 #: src/routes/_authed/_dashboard/notifications/events.lazy.tsx:159
-#: src/routes/_authed/_dashboard/notifications/index.lazy.tsx:342
+#: src/routes/_authed/_dashboard/notifications/index.lazy.tsx:339
 #: src/routes/_authed/_dashboard/pipeline/jobs/index.lazy.tsx:102
 #: src/routes/_authed/_dashboard/pipeline/outputs.lazy.tsx:203
 #: src/routes/_authed/_dashboard/pipeline/presets/index.lazy.tsx:283
@@ -470,6 +476,10 @@ msgstr "API protocol to use for live stream extraction. WUP is the standard prot
 #: src/components/config/platforms/tabs/specific-configs/douyu-config-fields.tsx:138
 msgid "API Request Retries"
 msgstr "API Request Retries"
+
+#: src/components/notifications/forms/gotify-form.tsx:56
+msgid "App Token"
+msgstr "App Token"
 
 #: src/routes/_authed/_dashboard/config/route.lazy.tsx:75
 msgid "Appearance & style"
@@ -612,13 +622,13 @@ msgstr "Audio Properties"
 msgid "Audio Settings"
 msgstr "Audio Settings"
 
-#: src/components/notifications/forms/webhook-form.tsx:217
+#: src/components/notifications/forms/webhook-form.tsx:211
 msgid "Auth Type"
 msgstr "Auth Type"
 
 #: src/components/config/platforms/tabs/specific-configs/twitch-config-fields.tsx:29
 #: src/components/config/shared/network-settings-card.tsx:162
-#: src/components/notifications/forms/webhook-form.tsx:206
+#: src/components/notifications/forms/webhook-form.tsx:200
 msgid "Authentication"
 msgstr "Authentication"
 
@@ -667,11 +677,11 @@ msgstr "Automate your stream recordings with ease and reliability."
 msgid "Automatically generate a thumbnail for the first segment of each session."
 msgstr "Automatically generate a thumbnail for the first segment of each session."
 
-#: src/components/notifications/subscription-manager.tsx:426
+#: src/components/notifications/subscription-manager.tsx:427
 msgid "available"
 msgstr "available"
 
-#: src/components/notifications/forms/discord-form.tsx:77
+#: src/components/notifications/forms/discord-form.tsx:78
 msgid "Avatar URL (Optional)"
 msgstr "Avatar URL (Optional)"
 
@@ -745,7 +755,7 @@ msgstr "Base delay between retries"
 msgid "Base path for remote storage."
 msgstr "Base path for remote storage."
 
-#: src/components/notifications/forms/webhook-form.tsx:258
+#: src/components/notifications/forms/webhook-form.tsx:252
 msgid "Basic Auth"
 msgstr "Basic Auth"
 
@@ -783,7 +793,7 @@ msgstr "Batch URLs"
 msgid "Batch Window (ms)"
 msgstr "Batch Window (ms)"
 
-#: src/components/notifications/forms/webhook-form.tsx:255
+#: src/components/notifications/forms/webhook-form.tsx:249
 msgid "Bearer Token"
 msgstr "Bearer Token"
 
@@ -825,12 +835,12 @@ msgstr "Blocked by browser"
 msgid "Border Radius"
 msgstr "Border Radius"
 
-#: src/components/notifications/forms/discord-form.tsx:62
+#: src/components/notifications/forms/discord-form.tsx:63
 msgid "Bot Name"
 msgstr "Bot Name"
 
-#: src/components/notifications/channel-card.tsx:108
-#: src/components/notifications/forms/telegram-form.tsx:35
+#: src/components/notifications/channel-card.tsx:111
+#: src/components/notifications/forms/telegram-form.tsx:36
 msgid "Bot Token"
 msgstr "Bot Token"
 
@@ -851,7 +861,7 @@ msgid "Browse generated media artifacts from pipeline jobs"
 msgstr "Browse generated media artifacts from pipeline jobs"
 
 #: src/components/notifications/browser-channel-dialog.tsx:64
-#: src/routes/_authed/_dashboard/notifications/index.lazy.tsx:491
+#: src/routes/_authed/_dashboard/notifications/index.lazy.tsx:484
 msgid "Browser Notifications"
 msgstr "Browser Notifications"
 
@@ -887,9 +897,9 @@ msgstr "Caching"
 #: src/components/config/global/backup-restore-card.tsx:580
 #: src/components/config/templates/template-card.tsx:196
 #: src/components/filters/FilterDialog.tsx:247
-#: src/components/notifications/channel-card.tsx:212
-#: src/components/notifications/channel-form.tsx:385
-#: src/components/notifications/subscription-manager.tsx:434
+#: src/components/notifications/channel-card.tsx:226
+#: src/components/notifications/channel-form.tsx:400
+#: src/components/notifications/subscription-manager.tsx:435
 #: src/components/pipeline/jobs/pipeline-summary-card.tsx:174
 #: src/components/pipeline/jobs/pipeline-summary-card.tsx:197
 #: src/components/pipeline/jobs/pipeline-summary-card.tsx:234
@@ -979,7 +989,7 @@ msgstr "Changing Password..."
 msgid "Channel buffer size multiplier for processed segments."
 msgstr "Channel buffer size multiplier for processed segments."
 
-#: src/components/notifications/channel-form.tsx:201
+#: src/components/notifications/channel-form.tsx:214
 msgid "Channel created"
 msgstr "Channel created"
 
@@ -987,7 +997,7 @@ msgstr "Channel created"
 msgid "Channel deleted"
 msgstr "Channel deleted"
 
-#: src/components/notifications/channel-form.tsx:215
+#: src/components/notifications/channel-form.tsx:228
 msgid "Channel updated"
 msgstr "Channel updated"
 
@@ -995,7 +1005,7 @@ msgstr "Channel updated"
 msgid "channel1,channel2"
 msgstr "channel1,channel2"
 
-#: src/routes/_authed/_dashboard/notifications/index.lazy.tsx:386
+#: src/routes/_authed/_dashboard/notifications/index.lazy.tsx:379
 msgid "channels"
 msgstr "channels"
 
@@ -1007,8 +1017,8 @@ msgstr "channels"
 msgid "Channels"
 msgstr "Channels"
 
-#: src/components/notifications/channel-card.tsx:118
-#: src/components/notifications/forms/telegram-form.tsx:56
+#: src/components/notifications/channel-card.tsx:121
+#: src/components/notifications/forms/telegram-form.tsx:57
 msgid "Chat ID"
 msgstr "Chat ID"
 
@@ -1062,7 +1072,7 @@ msgid "Cleanup"
 msgstr "Cleanup"
 
 #: src/components/logging/log-viewer.tsx:407
-#: src/components/notifications/desktop-channel-dialog.tsx:190
+#: src/components/notifications/desktop-channel-dialog.tsx:181
 #: src/routes/_authed/_dashboard/config/theme.lazy.tsx:229
 msgid "Clear"
 msgstr "Clear"
@@ -1101,7 +1111,7 @@ msgstr "Cloning..."
 
 #: src/components/config/global/backup-restore-card.tsx:571
 #: src/components/notifications/browser-channel-dialog.tsx:203
-#: src/components/notifications/desktop-channel-dialog.tsx:244
+#: src/components/notifications/desktop-channel-dialog.tsx:235
 #: src/components/pipeline/presets/processors/tdl-login-dialog.tsx:686
 msgid "Close"
 msgstr "Close"
@@ -1200,7 +1210,7 @@ msgstr "Config"
 msgid "Config Path (Optional)"
 msgstr "Config Path (Optional)"
 
-#: src/components/notifications/channel-form.tsx:367
+#: src/components/notifications/channel-form.tsx:381
 #: src/components/pipeline/presets/editor/preset-config-form.tsx:46
 #: src/components/pipeline/workflows/step-config-dialog.tsx:326
 #: src/components/pipeline/workflows/workflow-editor.tsx:299
@@ -1249,7 +1259,7 @@ msgstr "Configure how you receive alerts in this browser and via system push not
 msgid "Configure how you want to import data from the selected backup file."
 msgstr "Configure how you want to import data from the selected backup file."
 
-#: src/components/notifications/desktop-channel-dialog.tsx:91
+#: src/components/notifications/desktop-channel-dialog.tsx:82
 msgid "Configure native OS notifications for important events while running the desktop app."
 msgstr "Configure native OS notifications for important events while running the desktop app."
 
@@ -1261,7 +1271,7 @@ msgstr "Configure proxy strategies and connection details."
 msgid "Configure recording rules for this streamer."
 msgstr "Configure recording rules for this streamer."
 
-#: src/routes/_authed/_dashboard/notifications/index.lazy.tsx:561
+#: src/routes/_authed/_dashboard/notifications/index.lazy.tsx:554
 msgid "Configure Settings"
 msgstr "Configure Settings"
 
@@ -1269,11 +1279,11 @@ msgstr "Configure Settings"
 msgid "Configure Step"
 msgstr "Configure Step"
 
-#: src/components/notifications/channel-form.tsx:278
+#: src/components/notifications/channel-form.tsx:291
 msgid "Configure where and how you receive notifications."
 msgstr "Configure where and how you receive notifications."
 
-#: src/routes/_authed/_dashboard/notifications/index.lazy.tsx:516
+#: src/routes/_authed/_dashboard/notifications/index.lazy.tsx:509
 msgid "Configured Events"
 msgstr "Configured Events"
 
@@ -1458,8 +1468,8 @@ msgstr "Create a template to define reusable download configurations."
 msgid "Create a ZIP archive of the file. Good for bundling with metadata."
 msgstr "Create a ZIP archive of the file. Good for bundling with metadata."
 
-#: src/components/notifications/channel-form.tsx:275
-#: src/components/notifications/channel-form.tsx:395
+#: src/components/notifications/channel-form.tsx:288
+#: src/components/notifications/channel-form.tsx:410
 msgid "Create Channel"
 msgstr "Create Channel"
 
@@ -1555,25 +1565,21 @@ msgstr "CRF (0-51)"
 msgid "CRF (Constant Rate Factor)"
 msgstr "CRF (Constant Rate Factor)"
 
-#: src/components/notifications/forms/discord-form.tsx:117
-#: src/components/notifications/forms/email-form.tsx:194
-#: src/components/notifications/forms/telegram-form.tsx:120
-#: src/components/notifications/forms/webhook-form.tsx:165
 #: src/routes/_authed/_dashboard/notifications/events.lazy.tsx:162
 msgid "Critical"
 msgstr "Critical"
 
-#: src/components/notifications/subscription-manager.tsx:173
+#: src/components/notifications/subscription-manager.tsx:174
 msgid "Critical alert when the processing queue is full."
 msgstr "Critical alert when the processing queue is full."
 
 #: src/components/notifications/browser-channel-dialog.tsx:150
-#: src/components/notifications/desktop-channel-dialog.tsx:55
-#: src/routes/_authed/_dashboard/notifications/index.lazy.tsx:338
+#: src/components/notifications/desktop-channel-dialog.tsx:50
+#: src/routes/_authed/_dashboard/notifications/index.lazy.tsx:336
 msgid "Critical Only"
 msgstr "Critical Only"
 
-#: src/components/notifications/subscription-manager.tsx:167
+#: src/components/notifications/subscription-manager.tsx:168
 msgid "Critical system errors or streamer failures."
 msgstr "Critical system errors or streamer failures."
 
@@ -1622,11 +1628,11 @@ msgstr "Custom FFmpeg"
 msgid "Custom Flags"
 msgstr "Custom Flags"
 
-#: src/components/notifications/forms/webhook-form.tsx:261
+#: src/components/notifications/forms/webhook-form.tsx:255
 msgid "Custom Header"
 msgstr "Custom Header"
 
-#: src/components/notifications/forms/webhook-form.tsx:413
+#: src/components/notifications/forms/webhook-form.tsx:407
 msgid "Custom Headers"
 msgstr "Custom Headers"
 
@@ -1810,8 +1816,8 @@ msgstr "Delays, proxy, and retention policies."
 #: src/components/config/templates/template-card.tsx:128
 #: src/components/config/templates/template-card.tsx:202
 #: src/components/filters/FilterCard.tsx:316
-#: src/components/notifications/channel-card.tsx:195
-#: src/components/notifications/channel-card.tsx:218
+#: src/components/notifications/channel-card.tsx:209
+#: src/components/notifications/channel-card.tsx:232
 #: src/components/pipeline/jobs/pipeline-summary-card.tsx:216
 #: src/components/pipeline/jobs/pipeline-summary-card.tsx:240
 #: src/components/pipeline/presets/editor/preset-meta-form.tsx:65
@@ -1826,7 +1832,7 @@ msgstr "Delays, proxy, and retention policies."
 msgid "Delete"
 msgstr "Delete"
 
-#: src/components/notifications/channel-card.tsx:201
+#: src/components/notifications/channel-card.tsx:215
 msgid "Delete Channel?"
 msgstr "Delete Channel?"
 
@@ -1898,7 +1904,7 @@ msgstr "Deleted"
 msgid "Deletes all existing configurations before importing. This action cannot be undone."
 msgstr "Deletes all existing configurations before importing. This action cannot be undone."
 
-#: src/components/notifications/forms/webhook-form.tsx:132
+#: src/components/notifications/forms/webhook-form.tsx:133
 msgid "Delivery Policy"
 msgstr "Delivery Policy"
 
@@ -1919,7 +1925,7 @@ msgstr "Description"
 msgid "Description is managed by the system"
 msgstr "Description is managed by the system"
 
-#: src/components/notifications/subscription-manager.tsx:341
+#: src/components/notifications/subscription-manager.tsx:342
 msgid "Deselect All"
 msgstr "Deselect All"
 
@@ -1927,12 +1933,12 @@ msgstr "Deselect All"
 msgid "Design your automation pipeline step by step"
 msgstr "Design your automation pipeline step by step"
 
-#: src/components/notifications/desktop-channel-dialog.tsx:87
-#: src/routes/_authed/_dashboard/notifications/index.lazy.tsx:489
+#: src/components/notifications/desktop-channel-dialog.tsx:78
+#: src/routes/_authed/_dashboard/notifications/index.lazy.tsx:482
 msgid "Desktop Notifications"
 msgstr "Desktop Notifications"
 
-#: src/components/notifications/desktop-channel-dialog.tsx:128
+#: src/components/notifications/desktop-channel-dialog.tsx:119
 msgid "Desktop notifications are shown by the operating system even when the app is minimized."
 msgstr "Desktop notifications are shown by the operating system even when the app is minimized."
 
@@ -1974,9 +1980,9 @@ msgstr "Disable"
 
 #: src/components/config/engines/forms/mesio-hls-form.tsx:202
 #: src/components/streamers/card/use-streamer-status.tsx:46
-#: src/routes/_authed/_dashboard/notifications/index.lazy.tsx:509
-#: src/routes/_authed/_dashboard/notifications/index.lazy.tsx:541
-#: src/routes/_authed/_dashboard/notifications/index.lazy.tsx:551
+#: src/routes/_authed/_dashboard/notifications/index.lazy.tsx:502
+#: src/routes/_authed/_dashboard/notifications/index.lazy.tsx:534
+#: src/routes/_authed/_dashboard/notifications/index.lazy.tsx:544
 #: src/routes/_authed/_dashboard/streamers/index.lazy.tsx:74
 msgid "Disabled"
 msgstr "Disabled"
@@ -2196,7 +2202,7 @@ msgstr "e.g., Standard Processing"
 #: src/components/config/templates/template-card.tsx:116
 #: src/components/filters/FilterCard.tsx:305
 #: src/components/layout/site-header.tsx:54
-#: src/components/notifications/channel-card.tsx:180
+#: src/components/notifications/channel-card.tsx:194
 #: src/components/pipeline/presets/preset-card.tsx:176
 #: src/components/pipeline/workflows/workflow-card.tsx:170
 #: src/components/sidebar/navbar.tsx:48
@@ -2204,7 +2210,7 @@ msgstr "e.g., Standard Processing"
 msgid "Edit"
 msgstr "Edit"
 
-#: src/components/notifications/channel-form.tsx:274
+#: src/components/notifications/channel-form.tsx:287
 msgid "Edit Channel"
 msgstr "Edit Channel"
 
@@ -2250,7 +2256,7 @@ msgstr "Enable advanced HLS segment reconstruction"
 msgid "Enable Monitoring"
 msgstr "Enable Monitoring"
 
-#: src/components/notifications/forms/webhook-form.tsx:117
+#: src/components/notifications/forms/webhook-form.tsx:118
 msgid "Enable or disable this webhook"
 msgstr "Enable or disable this webhook"
 
@@ -2270,13 +2276,14 @@ msgstr "Enable Proxy"
 msgid "Enable recording of danmu/chat messages along with the video."
 msgstr "Enable recording of danmu/chat messages along with the video."
 
-#: src/components/notifications/desktop-channel-dialog.tsx:111
-#: src/components/notifications/forms/discord-form.tsx:130
-#: src/components/notifications/forms/email-form.tsx:219
-#: src/components/notifications/forms/telegram-form.tsx:133
-#: src/routes/_authed/_dashboard/notifications/index.lazy.tsx:508
-#: src/routes/_authed/_dashboard/notifications/index.lazy.tsx:540
-#: src/routes/_authed/_dashboard/notifications/index.lazy.tsx:550
+#: src/components/notifications/desktop-channel-dialog.tsx:102
+#: src/components/notifications/forms/discord-form.tsx:127
+#: src/components/notifications/forms/email-form.tsx:216
+#: src/components/notifications/forms/gotify-form.tsx:130
+#: src/components/notifications/forms/telegram-form.tsx:130
+#: src/routes/_authed/_dashboard/notifications/index.lazy.tsx:501
+#: src/routes/_authed/_dashboard/notifications/index.lazy.tsx:533
+#: src/routes/_authed/_dashboard/notifications/index.lazy.tsx:543
 msgid "Enabled"
 msgstr "Enabled"
 
@@ -2320,7 +2327,7 @@ msgstr "End Time"
 msgid "Ended"
 msgstr "Ended"
 
-#: src/components/notifications/forms/webhook-form.tsx:61
+#: src/components/notifications/forms/webhook-form.tsx:62
 msgid "Endpoint Configuration"
 msgstr "Endpoint Configuration"
 
@@ -2464,13 +2471,13 @@ msgstr "Event Hooks"
 msgid "Event Type"
 msgstr "Event Type"
 
-#: src/components/notifications/desktop-channel-dialog.tsx:174
+#: src/components/notifications/desktop-channel-dialog.tsx:165
 msgid "Event Types"
 msgstr "Event Types"
 
 #: src/components/layout/site-header.tsx:38
 #: src/components/sidebar/navbar.tsx:32
-#: src/routes/_authed/_dashboard/notifications/index.lazy.tsx:391
+#: src/routes/_authed/_dashboard/notifications/index.lazy.tsx:384
 msgid "Events"
 msgstr "Events"
 
@@ -2602,7 +2609,7 @@ msgstr "Extraction API Mode"
 msgid "Extraction Settings"
 msgstr "Extraction Settings"
 
-#: src/components/notifications/forms/webhook-form.tsx:291
+#: src/components/notifications/forms/webhook-form.tsx:285
 msgid "ey..."
 msgstr "ey..."
 
@@ -2654,7 +2661,7 @@ msgstr "Failed to clone template: {0}"
 msgid "Failed to copy"
 msgstr "Failed to copy"
 
-#: src/components/notifications/channel-form.tsx:208
+#: src/components/notifications/channel-form.tsx:221
 msgid "Failed to create channel"
 msgstr "Failed to create channel"
 
@@ -2844,7 +2851,7 @@ msgstr "Failed to start login: {0}"
 msgid "Failed to trigger check"
 msgstr "Failed to trigger check"
 
-#: src/components/notifications/channel-form.tsx:222
+#: src/components/notifications/channel-form.tsx:235
 msgid "Failed to update channel"
 msgstr "Failed to update channel"
 
@@ -2880,7 +2887,7 @@ msgstr "Failed to update settings"
 msgid "Failed to update streamer"
 msgstr "Failed to update streamer"
 
-#: src/components/notifications/subscription-manager.tsx:230
+#: src/components/notifications/subscription-manager.tsx:231
 msgid "Failed to update subscriptions"
 msgstr "Failed to update subscriptions"
 
@@ -3002,7 +3009,7 @@ msgstr "Filter created successfully"
 msgid "Filter deleted successfully"
 msgstr "Filter deleted successfully"
 
-#: src/components/notifications/forms/webhook-form.tsx:170
+#: src/components/notifications/forms/webhook-form.tsx:164
 msgid "Filter events below this priority"
 msgstr "Filter events below this priority"
 
@@ -3135,7 +3142,7 @@ msgstr "Format"
 msgid "Framerate (FPS)"
 msgstr "Framerate (FPS)"
 
-#: src/components/notifications/forms/email-form.tsx:128
+#: src/components/notifications/forms/email-form.tsx:129
 msgid "From Address"
 msgstr "From Address"
 
@@ -3263,6 +3270,10 @@ msgstr "Go to page {p}"
 msgid "Go to previous page"
 msgstr "Go to previous page"
 
+#: src/components/notifications/forms/gotify-form.tsx:62
+msgid "Gotify application token"
+msgstr "Gotify application token"
+
 #: src/components/pipeline/presets/default-presets-i18n.ts:110
 msgid "GPU HQ Archive"
 msgstr "GPU HQ Archive"
@@ -3310,7 +3321,7 @@ msgstr "Hardware Acceleration"
 msgid "HD Thumbnail"
 msgstr "HD Thumbnail"
 
-#: src/components/notifications/forms/webhook-form.tsx:369
+#: src/components/notifications/forms/webhook-form.tsx:363
 msgid "Header Key"
 msgstr "Header Key"
 
@@ -3318,7 +3329,7 @@ msgstr "Header Key"
 msgid "Header received"
 msgstr "Header received"
 
-#: src/components/notifications/forms/webhook-form.tsx:388
+#: src/components/notifications/forms/webhook-form.tsx:382
 msgid "Header Value"
 msgstr "Header Value"
 
@@ -3343,10 +3354,6 @@ msgstr "Height"
 msgid "Hide password"
 msgstr "Hide password"
 
-#: src/components/notifications/forms/discord-form.tsx:114
-#: src/components/notifications/forms/email-form.tsx:191
-#: src/components/notifications/forms/telegram-form.tsx:117
-#: src/components/notifications/forms/webhook-form.tsx:162
 #: src/components/streamers/config/streamer-general-settings.tsx:229
 #: src/components/streamers/edit/streamer-meta-form.tsx:204
 msgid "High"
@@ -3381,9 +3388,9 @@ msgid "High Quality MP3"
 msgstr "High Quality MP3"
 
 #: src/components/notifications/browser-channel-dialog.tsx:153
-#: src/components/notifications/desktop-channel-dialog.tsx:57
+#: src/components/notifications/desktop-channel-dialog.tsx:51
 #: src/routes/_authed/_dashboard/notifications/events.lazy.tsx:168
-#: src/routes/_authed/_dashboard/notifications/index.lazy.tsx:340
+#: src/routes/_authed/_dashboard/notifications/index.lazy.tsx:337
 msgid "High+"
 msgstr "High+"
 
@@ -3453,17 +3460,21 @@ msgstr "HTTP/1.1 Only"
 msgid "HTTP/2 Only"
 msgstr "HTTP/2 Only"
 
-#: src/components/notifications/forms/discord-form.tsx:81
+#: src/components/notifications/forms/discord-form.tsx:82
 msgid "https://..."
 msgstr "https://..."
 
-#: src/components/notifications/forms/webhook-form.tsx:75
+#: src/components/notifications/forms/webhook-form.tsx:76
 msgid "https://api.example.com/webhook"
 msgstr "https://api.example.com/webhook"
 
-#: src/components/notifications/forms/discord-form.tsx:41
+#: src/components/notifications/forms/discord-form.tsx:42
 msgid "https://discord.com/api/webhooks/..."
 msgstr "https://discord.com/api/webhooks/..."
+
+#: src/components/notifications/forms/gotify-form.tsx:41
+msgid "https://gotify.example.com"
+msgstr "https://gotify.example.com"
 
 #: src/components/config/engines/forms/streamlink-form.tsx:130
 msgid "https://lb-eu.cdn-perfprod.com"
@@ -3558,7 +3569,7 @@ msgstr "Importing..."
 msgid "In active"
 msgstr "In active"
 
-#: src/routes/_authed/_dashboard/notifications/index.lazy.tsx:483
+#: src/routes/_authed/_dashboard/notifications/index.lazy.tsx:476
 msgid "Inactive"
 msgstr "Inactive"
 
@@ -3633,7 +3644,7 @@ msgstr "Inset"
 msgid "Inspecting"
 msgstr "Inspecting"
 
-#: src/components/notifications/events/event-card.tsx:179
+#: src/components/notifications/events/event-card.tsx:172
 msgid "Interact"
 msgstr "Interact"
 
@@ -3645,7 +3656,7 @@ msgstr "Interactive 24-hour timeline selection."
 msgid "Interactive password entry via this API is not supported on Windows. Please use \"Desktop Login\" (import tdata) or log in once in a regular terminal."
 msgstr "Interactive password entry via this API is not supported on Windows. Please use \"Desktop Login\" (import tdata) or log in once in a regular terminal."
 
-#: src/routes/_authed/_dashboard/notifications/index.lazy.tsx:495
+#: src/routes/_authed/_dashboard/notifications/index.lazy.tsx:488
 msgid "Internal"
 msgstr "Internal"
 
@@ -3756,7 +3767,7 @@ msgstr "Keep Running"
 msgid "Keep uploading other files if one fails"
 msgstr "Keep uploading other files if one fails"
 
-#: src/components/notifications/forms/webhook-form.tsx:447
+#: src/components/notifications/forms/webhook-form.tsx:441
 #: src/components/pipeline/presets/processors/metadata-config-form.tsx:72
 #: src/components/pipeline/presets/processors/remux-config-form.tsx:1025
 #: src/components/pipeline/presets/processors/tdl-config-form.tsx:93
@@ -3853,7 +3864,7 @@ msgid "Live Gap Strategy"
 msgstr "Live Gap Strategy"
 
 #: src/components/notifications/browser-channel-dialog.tsx:82
-#: src/routes/_authed/_dashboard/notifications/index.lazy.tsx:536
+#: src/routes/_authed/_dashboard/notifications/index.lazy.tsx:529
 msgid "Live Polling"
 msgstr "Live Polling"
 
@@ -3981,10 +3992,6 @@ msgstr "Loop Protection"
 msgid "Lossless Split"
 msgstr "Lossless Split"
 
-#: src/components/notifications/forms/discord-form.tsx:108
-#: src/components/notifications/forms/email-form.tsx:185
-#: src/components/notifications/forms/telegram-form.tsx:111
-#: src/components/notifications/forms/webhook-form.tsx:156
 #: src/components/streamers/config/streamer-general-settings.tsx:235
 #: src/components/streamers/edit/streamer-meta-form.tsx:210
 msgid "Low"
@@ -4022,11 +4029,11 @@ msgstr "Manage specialized extraction and identification options."
 msgid "Manage storage paths and file formats."
 msgstr "Manage storage paths and file formats."
 
-#: src/components/notifications/subscription-manager.tsx:295
+#: src/components/notifications/subscription-manager.tsx:296
 msgid "Manage Subscriptions"
 msgstr "Manage Subscriptions"
 
-#: src/routes/_authed/_dashboard/notifications/index.lazy.tsx:380
+#: src/routes/_authed/_dashboard/notifications/index.lazy.tsx:373
 msgid "Manage where system notifications are sent"
 msgstr "Manage where system notifications are sent"
 
@@ -4247,7 +4254,7 @@ msgstr "Metadata Tags"
 msgid "Metadata Variables"
 msgstr "Metadata Variables"
 
-#: src/components/notifications/forms/webhook-form.tsx:91
+#: src/components/notifications/forms/webhook-form.tsx:92
 msgid "Method"
 msgstr "Method"
 
@@ -4263,10 +4270,11 @@ msgstr "Min Interval (ms)"
 msgid "Min Interval (s)"
 msgstr "Min Interval (s)"
 
-#: src/components/notifications/forms/discord-form.tsx:98
-#: src/components/notifications/forms/email-form.tsx:175
-#: src/components/notifications/forms/telegram-form.tsx:101
-#: src/routes/_authed/_dashboard/notifications/index.lazy.tsx:524
+#: src/components/notifications/forms/discord-form.tsx:99
+#: src/components/notifications/forms/email-form.tsx:176
+#: src/components/notifications/forms/gotify-form.tsx:78
+#: src/components/notifications/forms/telegram-form.tsx:102
+#: src/routes/_authed/_dashboard/notifications/index.lazy.tsx:517
 msgid "Min Priority"
 msgstr "Min Priority"
 
@@ -4279,8 +4287,8 @@ msgstr "Min Segment Size"
 msgid "Min size to keep."
 msgstr "Min size to keep."
 
-#: src/components/notifications/desktop-channel-dialog.tsx:140
-#: src/components/notifications/forms/webhook-form.tsx:143
+#: src/components/notifications/desktop-channel-dialog.tsx:131
+#: src/components/notifications/forms/webhook-form.tsx:144
 msgid "Minimum Priority"
 msgstr "Minimum Priority"
 
@@ -4353,11 +4361,11 @@ msgstr "Multiplier for exponential backoff."
 msgid "My Archiving Workflow"
 msgstr "My Archiving Workflow"
 
-#: src/components/notifications/channel-form.tsx:302
+#: src/components/notifications/channel-form.tsx:315
 msgid "My Channel"
 msgstr "My Channel"
 
-#: src/components/notifications/channel-form.tsx:296
+#: src/components/notifications/channel-form.tsx:309
 #: src/components/pipeline/presets/editor/preset-meta-form.tsx:215
 #: src/components/pipeline/workflows/workflow-editor.tsx:309
 #: src/components/streamers/config/streamer-general-settings.tsx:92
@@ -4382,7 +4390,7 @@ msgstr "name@example.com"
 msgid "Namespace"
 msgstr "Namespace"
 
-#: src/components/notifications/desktop-channel-dialog.tsx:117
+#: src/components/notifications/desktop-channel-dialog.tsx:108
 msgid "Native"
 msgstr "Native"
 
@@ -4460,7 +4468,7 @@ msgstr "No configuration."
 msgid "No credentials found."
 msgstr "No credentials found."
 
-#: src/components/notifications/forms/webhook-form.tsx:436
+#: src/components/notifications/forms/webhook-form.tsx:430
 msgid "No custom headers configured"
 msgstr "No custom headers configured"
 
@@ -4534,7 +4542,7 @@ msgstr "No logs available for this execution."
 msgid "No logs to display"
 msgstr "No logs to display"
 
-#: src/components/notifications/subscription-manager.tsx:360
+#: src/components/notifications/subscription-manager.tsx:361
 msgid "No matching events found"
 msgstr "No matching events found"
 
@@ -4677,7 +4685,7 @@ msgstr "No workflows found"
 msgid "No workflows yet"
 msgstr "No workflows yet"
 
-#: src/components/notifications/forms/webhook-form.tsx:252
+#: src/components/notifications/forms/webhook-form.tsx:246
 #: src/routes/_authed/_dashboard/config/theme.lazy.tsx:333
 #: src/routes/_authed/_dashboard/sessions/index.lazy.tsx:466
 msgid "None"
@@ -4691,10 +4699,6 @@ msgstr "None (Default)"
 msgid "None (Strip Audio)"
 msgstr "None (Strip Audio)"
 
-#: src/components/notifications/forms/discord-form.tsx:111
-#: src/components/notifications/forms/email-form.tsx:188
-#: src/components/notifications/forms/telegram-form.tsx:114
-#: src/components/notifications/forms/webhook-form.tsx:159
 #: src/components/pipeline/presets/processors/tdl-login-dialog.tsx:647
 #: src/components/streamers/config/streamer-general-settings.tsx:232
 #: src/components/streamers/edit/streamer-meta-form.tsx:207
@@ -4702,9 +4706,9 @@ msgid "Normal"
 msgstr "Normal"
 
 #: src/components/notifications/browser-channel-dialog.tsx:156
-#: src/components/notifications/desktop-channel-dialog.tsx:59
+#: src/components/notifications/desktop-channel-dialog.tsx:52
 #: src/routes/_authed/_dashboard/notifications/events.lazy.tsx:174
-#: src/routes/_authed/_dashboard/notifications/index.lazy.tsx:345
+#: src/routes/_authed/_dashboard/notifications/index.lazy.tsx:338
 msgid "Normal+"
 msgstr "Normal+"
 
@@ -4744,11 +4748,11 @@ msgstr "Notification Service"
 #: src/components/layout/site-header.tsx:37
 #: src/components/sidebar/navbar.tsx:31
 #: src/lib/menu-list.ts:124
-#: src/routes/_authed/_dashboard/notifications/index.lazy.tsx:377
+#: src/routes/_authed/_dashboard/notifications/index.lazy.tsx:370
 msgid "Notifications"
 msgstr "Notifications"
 
-#: src/components/notifications/forms/email-form.tsx:133
+#: src/components/notifications/forms/email-form.tsx:134
 msgid "notifier@example.com"
 msgstr "notifier@example.com"
 
@@ -4894,7 +4898,7 @@ msgstr "Only supported for MP4/MOV/M4V"
 
 #: src/components/config/platforms/platform-card.tsx:83
 #: src/components/config/templates/template-card.tsx:110
-#: src/components/notifications/channel-card.tsx:174
+#: src/components/notifications/channel-card.tsx:188
 #: src/components/pipeline/jobs/pipeline-summary-card.tsx:150
 #: src/components/pipeline/outputs/output-card.tsx:128
 #: src/components/pipeline/presets/preset-card.tsx:170
@@ -5105,7 +5109,7 @@ msgstr "Parse Batch"
 msgid "Parse error: {0}"
 msgstr "Parse error: {0}"
 
-#: src/components/notifications/forms/telegram-form.tsx:77
+#: src/components/notifications/forms/telegram-form.tsx:78
 msgid "Parse Mode"
 msgstr "Parse Mode"
 
@@ -5128,10 +5132,10 @@ msgid "Passthrough Inputs"
 msgstr "Passthrough Inputs"
 
 #: src/components/config/shared/proxy-settings-card.tsx:197
-#: src/components/notifications/forms/email-form.tsx:105
-#: src/components/notifications/forms/email-form.tsx:111
+#: src/components/notifications/forms/email-form.tsx:106
+#: src/components/notifications/forms/email-form.tsx:112
+#: src/components/notifications/forms/webhook-form.tsx:330
 #: src/components/notifications/forms/webhook-form.tsx:336
-#: src/components/notifications/forms/webhook-form.tsx:342
 #: src/routes/_public/login.lazy.tsx:188
 msgid "Password"
 msgstr "Password"
@@ -5427,7 +5431,7 @@ msgstr "Podcast Extraction"
 msgid "Pool Idle Timeout (ms)"
 msgstr "Pool Idle Timeout (ms)"
 
-#: src/components/notifications/forms/email-form.tsx:60
+#: src/components/notifications/forms/email-form.tsx:61
 msgid "Port"
 msgstr "Port"
 
@@ -5536,7 +5540,7 @@ msgstr "Presets"
 msgid "Presets Available"
 msgstr "Presets Available"
 
-#: src/components/notifications/forms/email-form.tsx:161
+#: src/components/notifications/forms/email-form.tsx:162
 msgid "Press Enter to add recipient"
 msgstr "Press Enter to add recipient"
 
@@ -5777,11 +5781,11 @@ msgstr "Real-time status of all system components and resources."
 msgid "Reason"
 msgstr "Reason"
 
-#: src/components/notifications/subscription-manager.tsx:137
+#: src/components/notifications/subscription-manager.tsx:138
 msgid "Receive a notification when a stream ends."
 msgstr "Receive a notification when a stream ends."
 
-#: src/components/notifications/subscription-manager.tsx:135
+#: src/components/notifications/subscription-manager.tsx:136
 msgid "Receive a notification when a streamer goes live."
 msgstr "Receive a notification when a streamer goes live."
 
@@ -5930,7 +5934,7 @@ msgstr "Replace output files"
 msgid "Replace output files if they already exist"
 msgstr "Replace output files if they already exist"
 
-#: src/components/notifications/forms/webhook-form.tsx:193
+#: src/components/notifications/forms/webhook-form.tsx:187
 msgid "Request timeout duration"
 msgstr "Request timeout duration"
 
@@ -6159,7 +6163,7 @@ msgstr "Sanitized streamer name"
 #: src/components/config/platforms/platform-editor.tsx:159
 #: src/components/config/templates/template-editor.tsx:213
 #: src/components/filters/FilterDialog.tsx:260
-#: src/components/notifications/subscription-manager.tsx:444
+#: src/components/notifications/subscription-manager.tsx:445
 #: src/components/pipeline/presets/editor/preset-save-fab.tsx:37
 #: src/components/pipeline/workflows/step-config-dialog.tsx:543
 #: src/components/streamers/edit/streamer-save-fab.tsx:53
@@ -6232,7 +6236,7 @@ msgstr "Search by name or description..."
 msgid "Search engines..."
 msgstr "Search engines..."
 
-#: src/components/notifications/subscription-manager.tsx:326
+#: src/components/notifications/subscription-manager.tsx:327
 msgid "Search events..."
 msgstr "Search events..."
 
@@ -6285,7 +6289,7 @@ msgstr "Second (00-59)"
 msgid "Secondary"
 msgstr "Secondary"
 
-#: src/components/notifications/forms/webhook-form.tsx:394
+#: src/components/notifications/forms/webhook-form.tsx:388
 msgid "secret"
 msgstr "secret"
 
@@ -6331,8 +6335,8 @@ msgstr "Select a session"
 msgid "Select a streamer"
 msgstr "Select a streamer"
 
-#: src/components/notifications/desktop-channel-dialog.tsx:190
-#: src/components/notifications/subscription-manager.tsx:344
+#: src/components/notifications/desktop-channel-dialog.tsx:181
+#: src/components/notifications/subscription-manager.tsx:345
 msgid "Select All"
 msgstr "Select All"
 
@@ -6399,7 +6403,7 @@ msgid "Select the days required for this filter to apply."
 msgstr "Select the days required for this filter to apply."
 
 #. placeholder {0}: channel.name
-#: src/components/notifications/subscription-manager.tsx:298
+#: src/components/notifications/subscription-manager.tsx:299
 msgid "Select the events that should trigger notifications for <0>{0}</0>."
 msgstr "Select the events that should trigger notifications for <0>{0}</0>."
 
@@ -6412,7 +6416,7 @@ msgid "Select the steps that must complete successfully before this step runs."
 msgstr "Select the steps that must complete successfully before this step runs."
 
 #: src/components/config/engines/engine-editor.tsx:240
-#: src/components/notifications/channel-form.tsx:339
+#: src/components/notifications/channel-form.tsx:352
 #: src/components/pipeline/presets/editor/preset-meta-form.tsx:161
 msgid "Select type"
 msgstr "Select type"
@@ -6421,7 +6425,7 @@ msgstr "Select type"
 msgid "Select your preferred color scheme."
 msgstr "Select your preferred color scheme."
 
-#: src/components/notifications/subscription-manager.tsx:423
+#: src/components/notifications/subscription-manager.tsx:424
 msgid "selected"
 msgstr "selected"
 
@@ -6444,6 +6448,11 @@ msgstr "Separate multiple paths with commas."
 #: src/routes/_authed/_dashboard/notifications/index.lazy.tsx:328
 msgid "Server not configured"
 msgstr "Server not configured"
+
+#: src/components/notifications/channel-card.tsx:133
+#: src/components/notifications/forms/gotify-form.tsx:36
+msgid "Server URL"
+msgstr "Server URL"
 
 #: src/components/config/global/pipeline-config-card.tsx:259
 #: src/components/config/shared-config-editor.tsx:484
@@ -6634,11 +6643,11 @@ msgstr "Skip Interactive Games"
 msgid "Skipped {skippedCount} duplicate stream(s)"
 msgstr "Skipped {skippedCount} duplicate stream(s)"
 
-#: src/components/notifications/forms/email-form.tsx:39
+#: src/components/notifications/forms/email-form.tsx:40
 msgid "SMTP Host"
 msgstr "SMTP Host"
 
-#: src/components/notifications/forms/email-form.tsx:44
+#: src/components/notifications/forms/email-form.tsx:45
 msgid "smtp.gmail.com"
 msgstr "smtp.gmail.com"
 
@@ -6744,7 +6753,7 @@ msgid "Starting tdl process..."
 msgstr "Starting tdl process..."
 
 #: src/routes/_authed/_dashboard/config/theme.lazy.tsx:481
-#: src/routes/_authed/_dashboard/notifications/index.lazy.tsx:504
+#: src/routes/_authed/_dashboard/notifications/index.lazy.tsx:497
 #: src/routes/_authed/_dashboard/pipeline/executions.$pipelineId.lazy.tsx:437
 #: src/routes/_authed/_dashboard/system/health.lazy.tsx:148
 #: src/routes/_authed/_dashboard/system/health.lazy.tsx:218
@@ -6906,11 +6915,11 @@ msgstr "streamlink"
 msgid "Streams & Metadata"
 msgstr "Streams & Metadata"
 
-#: src/components/notifications/channel-card.tsx:183
+#: src/components/notifications/channel-card.tsx:197
 msgid "Subscriptions"
 msgstr "Subscriptions"
 
-#: src/components/notifications/subscription-manager.tsx:223
+#: src/components/notifications/subscription-manager.tsx:224
 msgid "Subscriptions updated"
 msgstr "Subscriptions updated"
 
@@ -6965,7 +6974,7 @@ msgstr "Sync"
 msgid "System"
 msgstr "System"
 
-#: src/components/notifications/events/event-card.tsx:161
+#: src/components/notifications/events/event-card.tsx:154
 msgid "SYSTEM"
 msgstr "SYSTEM"
 
@@ -7110,11 +7119,11 @@ msgstr "Templates"
 msgid "Temporarily Paused"
 msgstr "Temporarily Paused"
 
-#: src/components/notifications/desktop-channel-dialog.tsx:241
+#: src/components/notifications/desktop-channel-dialog.tsx:232
 msgid "Test"
 msgstr "Test"
 
-#: src/components/notifications/channel-card.tsx:187
+#: src/components/notifications/channel-card.tsx:201
 msgid "Test Notification"
 msgstr "Test Notification"
 
@@ -7161,7 +7170,7 @@ msgstr "Theme Mode"
 msgid "Theme Preset"
 msgstr "Theme Preset"
 
-#: src/components/notifications/desktop-channel-dialog.tsx:228
+#: src/components/notifications/desktop-channel-dialog.tsx:219
 msgid "These settings only apply to the desktop app. The server will still deliver channel notifications (Discord/Email/Webhook) normally."
 msgstr "These settings only apply to the desktop app. The server will still deliver channel notifications (Discord/Email/Webhook) normally."
 
@@ -7207,7 +7216,7 @@ msgid "This will cancel all pending and processing jobs in this pipeline."
 msgstr "This will cancel all pending and processing jobs in this pipeline."
 
 #. placeholder {0}: channel.name
-#: src/components/notifications/channel-card.tsx:204
+#: src/components/notifications/channel-card.tsx:218
 msgid "This will permanently delete the notification channel \"{0}\"."
 msgstr "This will permanently delete the notification channel \"{0}\"."
 
@@ -7281,7 +7290,11 @@ msgstr "Timeout"
 msgid "Timeout (ms)"
 msgstr "Timeout (ms)"
 
-#: src/components/notifications/forms/webhook-form.tsx:182
+#: src/components/notifications/forms/gotify-form.tsx:107
+msgid "Timeout (s)"
+msgstr "Timeout (s)"
+
+#: src/components/notifications/forms/webhook-form.tsx:176
 msgid "Timeout (seconds)"
 msgstr "Timeout (seconds)"
 
@@ -7314,11 +7327,11 @@ msgstr "Timing & Delays"
 msgid "Title"
 msgstr "Title"
 
-#: src/components/notifications/channel-card.tsx:95
+#: src/components/notifications/channel-card.tsx:98
 msgid "To"
 msgstr "To"
 
-#: src/components/notifications/forms/email-form.tsx:149
+#: src/components/notifications/forms/email-form.tsx:150
 msgid "To Addresses"
 msgstr "To Addresses"
 
@@ -7326,7 +7339,7 @@ msgstr "To Addresses"
 msgid "Today"
 msgstr "Today"
 
-#: src/components/notifications/forms/webhook-form.tsx:285
+#: src/components/notifications/forms/webhook-form.tsx:279
 msgid "Token"
 msgstr "Token"
 
@@ -7401,59 +7414,59 @@ msgstr "Triggered after each segment recording"
 msgid "Triggered after the entire session ends"
 msgstr "Triggered after the entire session ends"
 
-#: src/components/notifications/subscription-manager.tsx:143
+#: src/components/notifications/subscription-manager.tsx:144
 msgid "Triggered when a download fails with an error."
 msgstr "Triggered when a download fails with an error."
 
-#: src/components/notifications/subscription-manager.tsx:149
+#: src/components/notifications/subscription-manager.tsx:150
 msgid "Triggered when a download is manually cancelled."
 msgstr "Triggered when a download is manually cancelled."
 
-#: src/components/notifications/subscription-manager.tsx:152
+#: src/components/notifications/subscription-manager.tsx:153
 msgid "Triggered when a download is rejected (e.g., circuit breaker)."
 msgstr "Triggered when a download is rejected (e.g., circuit breaker)."
 
-#: src/components/notifications/subscription-manager.tsx:141
+#: src/components/notifications/subscription-manager.tsx:142
 msgid "Triggered when a download successfully completes."
 msgstr "Triggered when a download successfully completes."
 
-#: src/components/notifications/subscription-manager.tsx:147
+#: src/components/notifications/subscription-manager.tsx:148
 msgid "Triggered when a file segment is finished."
 msgstr "Triggered when a file segment is finished."
 
-#: src/components/notifications/subscription-manager.tsx:139
+#: src/components/notifications/subscription-manager.tsx:140
 msgid "Triggered when a new download recording begins."
 msgstr "Triggered when a new download recording begins."
 
-#: src/components/notifications/subscription-manager.tsx:145
+#: src/components/notifications/subscription-manager.tsx:146
 msgid "Triggered when a new file segment is created."
 msgstr "Triggered when a new file segment is created."
 
-#: src/components/notifications/subscription-manager.tsx:163
+#: src/components/notifications/subscription-manager.tsx:164
 msgid "Triggered when a pipeline job fails."
 msgstr "Triggered when a pipeline job fails."
 
-#: src/components/notifications/subscription-manager.tsx:161
+#: src/components/notifications/subscription-manager.tsx:162
 msgid "Triggered when a pipeline job finishes successfully."
 msgstr "Triggered when a pipeline job finishes successfully."
 
-#: src/components/notifications/subscription-manager.tsx:165
+#: src/components/notifications/subscription-manager.tsx:166
 msgid "Triggered when a pipeline job is cancelled."
 msgstr "Triggered when a pipeline job is cancelled."
 
-#: src/components/notifications/subscription-manager.tsx:159
+#: src/components/notifications/subscription-manager.tsx:160
 msgid "Triggered when a post-processing pipeline job starts."
 msgstr "Triggered when a post-processing pipeline job starts."
 
-#: src/components/notifications/subscription-manager.tsx:156
+#: src/components/notifications/subscription-manager.tsx:157
 msgid "Triggered when streamer configuration is dynamically updated."
 msgstr "Triggered when streamer configuration is dynamically updated."
 
-#: src/components/notifications/subscription-manager.tsx:177
+#: src/components/notifications/subscription-manager.tsx:178
 msgid "Triggered when the application shuts down."
 msgstr "Triggered when the application shuts down."
 
-#: src/components/notifications/subscription-manager.tsx:175
+#: src/components/notifications/subscription-manager.tsx:176
 msgid "Triggered when the application starts up."
 msgstr "Triggered when the application starts up."
 
@@ -7525,7 +7538,7 @@ msgstr "Twitch Proxy Playlist"
 msgid "Twitch Proxy Playlist Exclude"
 msgstr "Twitch Proxy Playlist Exclude"
 
-#: src/components/notifications/channel-form.tsx:319
+#: src/components/notifications/channel-form.tsx:332
 msgid "Type"
 msgstr "Type"
 
@@ -7588,7 +7601,7 @@ msgstr "Untitled Stream"
 msgid "UPDATE"
 msgstr "UPDATE"
 
-#: src/components/notifications/channel-form.tsx:394
+#: src/components/notifications/channel-form.tsx:409
 msgid "Update Channel"
 msgstr "Update Channel"
 
@@ -7639,7 +7652,7 @@ msgstr "Upload file to cloud storage using rclone. Configure remote in rclone co
 msgid "Uptime"
 msgstr "Uptime"
 
-#: src/components/notifications/channel-card.tsx:130
+#: src/components/notifications/channel-card.tsx:144
 #: src/components/streamers/config/streamer-general-settings.tsx:66
 #: src/components/streamers/edit/streamer-meta-form.tsx:116
 #: src/components/streamers/progress-indicator.tsx:152
@@ -7678,7 +7691,7 @@ msgstr "Use QR Login"
 msgid "Use System Proxy"
 msgstr "Use System Proxy"
 
-#: src/components/notifications/forms/email-form.tsx:207
+#: src/components/notifications/forms/email-form.tsx:204
 msgid "Use TLS"
 msgstr "Use TLS"
 
@@ -7692,15 +7705,15 @@ msgid "User Agent"
 msgstr "User Agent"
 
 #: src/components/config/shared/proxy-settings-card.tsx:179
-#: src/components/notifications/forms/email-form.tsx:85
-#: src/components/notifications/forms/email-form.tsx:90
-#: src/components/notifications/forms/webhook-form.tsx:317
-#: src/components/notifications/forms/webhook-form.tsx:322
+#: src/components/notifications/forms/email-form.tsx:86
+#: src/components/notifications/forms/email-form.tsx:91
+#: src/components/notifications/forms/webhook-form.tsx:311
+#: src/components/notifications/forms/webhook-form.tsx:316
 #: src/routes/_public/login.lazy.tsx:168
 msgid "Username"
 msgstr "Username"
 
-#: src/components/notifications/forms/discord-form.tsx:57
+#: src/components/notifications/forms/discord-form.tsx:58
 msgid "Username (Optional)"
 msgstr "Username (Optional)"
 
@@ -7726,7 +7739,7 @@ msgid "Validation service unavailable"
 msgstr "Validation service unavailable"
 
 #: src/components/config/engines/forms/mesio-hls-form.tsx:582
-#: src/components/notifications/forms/webhook-form.tsx:459
+#: src/components/notifications/forms/webhook-form.tsx:453
 #: src/components/pipeline/presets/processors/metadata-config-form.tsx:78
 #: src/components/pipeline/presets/processors/remux-config-form.tsx:1036
 #: src/components/pipeline/presets/processors/tdl-config-form.tsx:99
@@ -7840,7 +7853,7 @@ msgstr "Wait time before starting."
 msgid "Waiting for connection..."
 msgstr "Waiting for connection..."
 
-#: src/components/notifications/subscription-manager.tsx:171
+#: src/components/notifications/subscription-manager.tsx:172
 msgid "Warning when the processing queue gets too long."
 msgstr "Warning when the processing queue gets too long."
 
@@ -7857,7 +7870,7 @@ msgid "Web Optimize"
 msgstr "Web Optimize"
 
 #: src/components/notifications/browser-channel-dialog.tsx:119
-#: src/routes/_authed/_dashboard/notifications/index.lazy.tsx:546
+#: src/routes/_authed/_dashboard/notifications/index.lazy.tsx:539
 msgid "Web Push"
 msgstr "Web Push"
 
@@ -7885,9 +7898,9 @@ msgstr "Web Push is not supported in this browser"
 msgid "Web Push priority updated"
 msgstr "Web Push priority updated"
 
-#: src/components/notifications/channel-card.tsx:83
-#: src/components/notifications/forms/discord-form.tsx:36
-#: src/components/notifications/forms/webhook-form.tsx:70
+#: src/components/notifications/channel-card.tsx:86
+#: src/components/notifications/forms/discord-form.tsx:37
+#: src/components/notifications/forms/webhook-form.tsx:71
 msgid "Webhook URL"
 msgstr "Webhook URL"
 
@@ -7972,7 +7985,7 @@ msgstr "Write Timeout (ms)"
 msgid "WUP"
 msgstr "WUP"
 
-#: src/components/notifications/forms/webhook-form.tsx:374
+#: src/components/notifications/forms/webhook-form.tsx:368
 msgid "X-Auth-Key"
 msgstr "X-Auth-Key"
 

--- a/rust-srec/frontend/src/locales/zh-CN/messages.po
+++ b/rust-srec/frontend/src/locales/zh-CN/messages.po
@@ -27,7 +27,7 @@ msgstr "--flag value"
 msgid "--hls-live-edge 3"
 msgstr "--hls-live-edge 3"
 
-#: src/components/notifications/forms/telegram-form.tsx:61
+#: src/components/notifications/forms/telegram-form.tsx:62
 msgid "-1001234567890"
 msgstr "-1001234567890"
 
@@ -94,10 +94,16 @@ msgid "{0, plural, one {file} other {files}}"
 msgstr "{0, plural, other {个文件}}"
 
 #. placeholder {0}: day.full
+#. placeholder {0}: opt.label
 #. placeholder {0}: p.label
 #: src/components/filters/forms/TimeBasedFilterForm.tsx:158
 #: src/components/filters/forms/TimeBasedFilterForm.tsx:191
 #: src/components/filters/forms/TimeBasedFilterForm.tsx:235
+#: src/components/notifications/forms/discord-form.tsx:113
+#: src/components/notifications/forms/email-form.tsx:190
+#: src/components/notifications/forms/gotify-form.tsx:92
+#: src/components/notifications/forms/telegram-form.tsx:116
+#: src/components/notifications/forms/webhook-form.tsx:158
 msgid "{0}"
 msgstr "{0}"
 
@@ -117,7 +123,7 @@ msgstr "成功添加 {0} 个流"
 msgid "{0}/{1} steps"
 msgstr "{0}/{1} 步"
 
-#: src/components/notifications/channel-form.tsx:326
+#: src/components/notifications/channel-form.tsx:339
 msgid "{val} channel support is coming soon!"
 msgstr "即将支持 {val} 渠道！"
 
@@ -161,7 +167,7 @@ msgstr "0:v:0"
 msgid "1 (best) - 31 (worst)"
 msgstr "1（最佳）- 31（最差）"
 
-#: src/components/notifications/forms/telegram-form.tsx:41
+#: src/components/notifications/forms/telegram-form.tsx:42
 msgid "123456:ABC-DEF..."
 msgstr "123456:ABC-DEF..."
 
@@ -181,7 +187,7 @@ msgstr "404"
 msgid "44100"
 msgstr "44100"
 
-#: src/components/notifications/forms/email-form.tsx:66
+#: src/components/notifications/forms/email-form.tsx:67
 msgid "587"
 msgstr "587"
 
@@ -217,10 +223,10 @@ msgstr "操作"
 msgid "Actions"
 msgstr "操作"
 
-#: src/components/notifications/forms/webhook-form.tsx:116
+#: src/components/notifications/forms/webhook-form.tsx:117
 #: src/components/streamers/edit/streamer-meta-form.tsx:226
 #: src/routes/_authed/_dashboard/config/language.lazy.tsx:108
-#: src/routes/_authed/_dashboard/notifications/index.lazy.tsx:482
+#: src/routes/_authed/_dashboard/notifications/index.lazy.tsx:475
 msgid "Active"
 msgstr "启用"
 
@@ -240,7 +246,7 @@ msgstr "正在录制"
 msgid "Adaptive Refresh (Default: On)"
 msgstr "自适应刷新（默认：开）"
 
-#: src/components/notifications/forms/webhook-form.tsx:429
+#: src/components/notifications/forms/webhook-form.tsx:423
 msgid "Add"
 msgstr "添加"
 
@@ -268,7 +274,7 @@ msgstr "添加参数模板"
 msgid "Add at least one step"
 msgstr "至少添加一个步骤"
 
-#: src/routes/_authed/_dashboard/notifications/index.lazy.tsx:413
+#: src/routes/_authed/_dashboard/notifications/index.lazy.tsx:406
 msgid "Add Channel"
 msgstr "添加渠道"
 
@@ -276,7 +282,7 @@ msgstr "添加渠道"
 msgid "Add Custom Tag"
 msgstr "添加自定义标签"
 
-#: src/components/notifications/forms/email-form.tsx:156
+#: src/components/notifications/forms/email-form.tsx:157
 msgid "Add email and press Enter"
 msgstr "添加邮箱地址并按 Enter"
 
@@ -417,15 +423,15 @@ msgstr "在: {0} 之后"
 msgid "Album"
 msgstr "专辑"
 
-#: src/components/notifications/subscription-manager.tsx:169
+#: src/components/notifications/subscription-manager.tsx:170
 msgid "Alerts when disk space is running low."
 msgstr "磁盘空间不足时发出警报。"
 
 #: src/components/notifications/browser-channel-dialog.tsx:159
-#: src/components/notifications/desktop-channel-dialog.tsx:61
+#: src/components/notifications/desktop-channel-dialog.tsx:53
 #: src/components/pipeline/workflows/step-library.tsx:291
 #: src/routes/_authed/_dashboard/notifications/events.lazy.tsx:159
-#: src/routes/_authed/_dashboard/notifications/index.lazy.tsx:342
+#: src/routes/_authed/_dashboard/notifications/index.lazy.tsx:339
 #: src/routes/_authed/_dashboard/pipeline/jobs/index.lazy.tsx:102
 #: src/routes/_authed/_dashboard/pipeline/outputs.lazy.tsx:203
 #: src/routes/_authed/_dashboard/pipeline/presets/index.lazy.tsx:283
@@ -470,6 +476,10 @@ msgstr "用于直播流提取的 API 协议。WUP 是 PC 客户端的标准协�
 #: src/components/config/platforms/tabs/specific-configs/douyu-config-fields.tsx:138
 msgid "API Request Retries"
 msgstr "API 请求重试次数"
+
+#: src/components/notifications/forms/gotify-form.tsx:56
+msgid "App Token"
+msgstr "应用令牌"
 
 #: src/routes/_authed/_dashboard/config/route.lazy.tsx:75
 msgid "Appearance & style"
@@ -612,13 +622,13 @@ msgstr "音频属性"
 msgid "Audio Settings"
 msgstr "音频设置"
 
-#: src/components/notifications/forms/webhook-form.tsx:217
+#: src/components/notifications/forms/webhook-form.tsx:211
 msgid "Auth Type"
 msgstr "认证类型"
 
 #: src/components/config/platforms/tabs/specific-configs/twitch-config-fields.tsx:29
 #: src/components/config/shared/network-settings-card.tsx:162
-#: src/components/notifications/forms/webhook-form.tsx:206
+#: src/components/notifications/forms/webhook-form.tsx:200
 msgid "Authentication"
 msgstr "认证"
 
@@ -667,11 +677,11 @@ msgstr "轻松自动化您的直播录制。"
 msgid "Automatically generate a thumbnail for the first segment of each session."
 msgstr "自动为每个会话的第一段生成封面图。"
 
-#: src/components/notifications/subscription-manager.tsx:426
+#: src/components/notifications/subscription-manager.tsx:427
 msgid "available"
 msgstr "可选"
 
-#: src/components/notifications/forms/discord-form.tsx:77
+#: src/components/notifications/forms/discord-form.tsx:78
 msgid "Avatar URL (Optional)"
 msgstr "头像 URL（可选）"
 
@@ -745,7 +755,7 @@ msgstr "重试之间的基础延迟"
 msgid "Base path for remote storage."
 msgstr "远程存储的基础路径。"
 
-#: src/components/notifications/forms/webhook-form.tsx:258
+#: src/components/notifications/forms/webhook-form.tsx:252
 msgid "Basic Auth"
 msgstr "Basic Auth"
 
@@ -783,7 +793,7 @@ msgstr "批量 URL"
 msgid "Batch Window (ms)"
 msgstr "批处理窗口（毫秒）"
 
-#: src/components/notifications/forms/webhook-form.tsx:255
+#: src/components/notifications/forms/webhook-form.tsx:249
 msgid "Bearer Token"
 msgstr "Bearer Token"
 
@@ -825,12 +835,12 @@ msgstr "被浏览器阻止"
 msgid "Border Radius"
 msgstr "圆角半径"
 
-#: src/components/notifications/forms/discord-form.tsx:62
+#: src/components/notifications/forms/discord-form.tsx:63
 msgid "Bot Name"
 msgstr "机器人名称"
 
-#: src/components/notifications/channel-card.tsx:108
-#: src/components/notifications/forms/telegram-form.tsx:35
+#: src/components/notifications/channel-card.tsx:111
+#: src/components/notifications/forms/telegram-form.tsx:36
 msgid "Bot Token"
 msgstr "机器人令牌"
 
@@ -851,7 +861,7 @@ msgid "Browse generated media artifacts from pipeline jobs"
 msgstr "浏览处理任务生成的媒体文件"
 
 #: src/components/notifications/browser-channel-dialog.tsx:64
-#: src/routes/_authed/_dashboard/notifications/index.lazy.tsx:491
+#: src/routes/_authed/_dashboard/notifications/index.lazy.tsx:484
 msgid "Browser Notifications"
 msgstr "浏览器通知"
 
@@ -887,9 +897,9 @@ msgstr "缓存"
 #: src/components/config/global/backup-restore-card.tsx:580
 #: src/components/config/templates/template-card.tsx:196
 #: src/components/filters/FilterDialog.tsx:247
-#: src/components/notifications/channel-card.tsx:212
-#: src/components/notifications/channel-form.tsx:385
-#: src/components/notifications/subscription-manager.tsx:434
+#: src/components/notifications/channel-card.tsx:226
+#: src/components/notifications/channel-form.tsx:400
+#: src/components/notifications/subscription-manager.tsx:435
 #: src/components/pipeline/jobs/pipeline-summary-card.tsx:174
 #: src/components/pipeline/jobs/pipeline-summary-card.tsx:197
 #: src/components/pipeline/jobs/pipeline-summary-card.tsx:234
@@ -979,7 +989,7 @@ msgstr "正在修改密码..."
 msgid "Channel buffer size multiplier for processed segments."
 msgstr "已处理分段的通道缓冲倍数。"
 
-#: src/components/notifications/channel-form.tsx:201
+#: src/components/notifications/channel-form.tsx:214
 msgid "Channel created"
 msgstr "渠道已创建"
 
@@ -987,7 +997,7 @@ msgstr "渠道已创建"
 msgid "Channel deleted"
 msgstr "渠道已删除"
 
-#: src/components/notifications/channel-form.tsx:215
+#: src/components/notifications/channel-form.tsx:228
 msgid "Channel updated"
 msgstr "渠道已更新"
 
@@ -995,7 +1005,7 @@ msgstr "渠道已更新"
 msgid "channel1,channel2"
 msgstr "频道1,频道2"
 
-#: src/routes/_authed/_dashboard/notifications/index.lazy.tsx:386
+#: src/routes/_authed/_dashboard/notifications/index.lazy.tsx:379
 msgid "channels"
 msgstr "个渠道"
 
@@ -1007,8 +1017,8 @@ msgstr "个渠道"
 msgid "Channels"
 msgstr "声道"
 
-#: src/components/notifications/channel-card.tsx:118
-#: src/components/notifications/forms/telegram-form.tsx:56
+#: src/components/notifications/channel-card.tsx:121
+#: src/components/notifications/forms/telegram-form.tsx:57
 msgid "Chat ID"
 msgstr "聊天 ID"
 
@@ -1062,7 +1072,7 @@ msgid "Cleanup"
 msgstr "清理"
 
 #: src/components/logging/log-viewer.tsx:407
-#: src/components/notifications/desktop-channel-dialog.tsx:190
+#: src/components/notifications/desktop-channel-dialog.tsx:181
 #: src/routes/_authed/_dashboard/config/theme.lazy.tsx:229
 msgid "Clear"
 msgstr "清空"
@@ -1101,7 +1111,7 @@ msgstr "正在克隆..."
 
 #: src/components/config/global/backup-restore-card.tsx:571
 #: src/components/notifications/browser-channel-dialog.tsx:203
-#: src/components/notifications/desktop-channel-dialog.tsx:244
+#: src/components/notifications/desktop-channel-dialog.tsx:235
 #: src/components/pipeline/presets/processors/tdl-login-dialog.tsx:686
 msgid "Close"
 msgstr "关闭"
@@ -1200,7 +1210,7 @@ msgstr "配置"
 msgid "Config Path (Optional)"
 msgstr "配置路径（可选）"
 
-#: src/components/notifications/channel-form.tsx:367
+#: src/components/notifications/channel-form.tsx:381
 #: src/components/pipeline/presets/editor/preset-config-form.tsx:46
 #: src/components/pipeline/workflows/step-config-dialog.tsx:326
 #: src/components/pipeline/workflows/workflow-editor.tsx:299
@@ -1249,7 +1259,7 @@ msgstr "配置如何在此浏览器中以及通过系统推送通知接收警报
 msgid "Configure how you want to import data from the selected backup file."
 msgstr "配置从所选备份文件导入数据的方式。"
 
-#: src/components/notifications/desktop-channel-dialog.tsx:91
+#: src/components/notifications/desktop-channel-dialog.tsx:82
 msgid "Configure native OS notifications for important events while running the desktop app."
 msgstr "在运行桌面应用时，配置重要事件的原生操作系统通知。"
 
@@ -1261,7 +1271,7 @@ msgstr "配置代理策略和连接详情。"
 msgid "Configure recording rules for this streamer."
 msgstr "配置此主播的录制规则。"
 
-#: src/routes/_authed/_dashboard/notifications/index.lazy.tsx:561
+#: src/routes/_authed/_dashboard/notifications/index.lazy.tsx:554
 msgid "Configure Settings"
 msgstr "配置设置"
 
@@ -1269,11 +1279,11 @@ msgstr "配置设置"
 msgid "Configure Step"
 msgstr "配置步骤"
 
-#: src/components/notifications/channel-form.tsx:278
+#: src/components/notifications/channel-form.tsx:291
 msgid "Configure where and how you receive notifications."
 msgstr "配置接收通知的位置和方式。"
 
-#: src/routes/_authed/_dashboard/notifications/index.lazy.tsx:516
+#: src/routes/_authed/_dashboard/notifications/index.lazy.tsx:509
 msgid "Configured Events"
 msgstr "已配置的事件"
 
@@ -1458,8 +1468,8 @@ msgstr "创建模板以定义可复用的录制配置。"
 msgid "Create a ZIP archive of the file. Good for bundling with metadata."
 msgstr "为文件创建 ZIP 压缩包，适合与元数据一起打包。"
 
-#: src/components/notifications/channel-form.tsx:275
-#: src/components/notifications/channel-form.tsx:395
+#: src/components/notifications/channel-form.tsx:288
+#: src/components/notifications/channel-form.tsx:410
 msgid "Create Channel"
 msgstr "创建渠道"
 
@@ -1555,25 +1565,21 @@ msgstr "CRF (0-51)"
 msgid "CRF (Constant Rate Factor)"
 msgstr "CRF（恒定码率因子）"
 
-#: src/components/notifications/forms/discord-form.tsx:117
-#: src/components/notifications/forms/email-form.tsx:194
-#: src/components/notifications/forms/telegram-form.tsx:120
-#: src/components/notifications/forms/webhook-form.tsx:165
 #: src/routes/_authed/_dashboard/notifications/events.lazy.tsx:162
 msgid "Critical"
 msgstr "严重"
 
-#: src/components/notifications/subscription-manager.tsx:173
+#: src/components/notifications/subscription-manager.tsx:174
 msgid "Critical alert when the processing queue is full."
 msgstr "处理队列已满时发出严重警报。"
 
 #: src/components/notifications/browser-channel-dialog.tsx:150
-#: src/components/notifications/desktop-channel-dialog.tsx:55
-#: src/routes/_authed/_dashboard/notifications/index.lazy.tsx:338
+#: src/components/notifications/desktop-channel-dialog.tsx:50
+#: src/routes/_authed/_dashboard/notifications/index.lazy.tsx:336
 msgid "Critical Only"
 msgstr "仅限严重"
 
-#: src/components/notifications/subscription-manager.tsx:167
+#: src/components/notifications/subscription-manager.tsx:168
 msgid "Critical system errors or streamer failures."
 msgstr "严重的系统错误或主播故障。"
 
@@ -1622,11 +1628,11 @@ msgstr "自定义 FFmpeg"
 msgid "Custom Flags"
 msgstr "自定义标志"
 
-#: src/components/notifications/forms/webhook-form.tsx:261
+#: src/components/notifications/forms/webhook-form.tsx:255
 msgid "Custom Header"
 msgstr "自定义 Header"
 
-#: src/components/notifications/forms/webhook-form.tsx:413
+#: src/components/notifications/forms/webhook-form.tsx:407
 msgid "Custom Headers"
 msgstr "自定义请求头"
 
@@ -1810,8 +1816,8 @@ msgstr "延迟、代理与保留策略。"
 #: src/components/config/templates/template-card.tsx:128
 #: src/components/config/templates/template-card.tsx:202
 #: src/components/filters/FilterCard.tsx:316
-#: src/components/notifications/channel-card.tsx:195
-#: src/components/notifications/channel-card.tsx:218
+#: src/components/notifications/channel-card.tsx:209
+#: src/components/notifications/channel-card.tsx:232
 #: src/components/pipeline/jobs/pipeline-summary-card.tsx:216
 #: src/components/pipeline/jobs/pipeline-summary-card.tsx:240
 #: src/components/pipeline/presets/editor/preset-meta-form.tsx:65
@@ -1826,7 +1832,7 @@ msgstr "延迟、代理与保留策略。"
 msgid "Delete"
 msgstr "删除"
 
-#: src/components/notifications/channel-card.tsx:201
+#: src/components/notifications/channel-card.tsx:215
 msgid "Delete Channel?"
 msgstr "删除渠道？"
 
@@ -1898,7 +1904,7 @@ msgstr "已删除"
 msgid "Deletes all existing configurations before importing. This action cannot be undone."
 msgstr "导入前删除所有现有配置。此操作无法撤销。"
 
-#: src/components/notifications/forms/webhook-form.tsx:132
+#: src/components/notifications/forms/webhook-form.tsx:133
 msgid "Delivery Policy"
 msgstr "投递策略"
 
@@ -1919,7 +1925,7 @@ msgstr "描述"
 msgid "Description is managed by the system"
 msgstr "描述由系统管理"
 
-#: src/components/notifications/subscription-manager.tsx:341
+#: src/components/notifications/subscription-manager.tsx:342
 msgid "Deselect All"
 msgstr "取消全选"
 
@@ -1927,12 +1933,12 @@ msgstr "取消全选"
 msgid "Design your automation pipeline step by step"
 msgstr "逐步设计你的自动化处理管道"
 
-#: src/components/notifications/desktop-channel-dialog.tsx:87
-#: src/routes/_authed/_dashboard/notifications/index.lazy.tsx:489
+#: src/components/notifications/desktop-channel-dialog.tsx:78
+#: src/routes/_authed/_dashboard/notifications/index.lazy.tsx:482
 msgid "Desktop Notifications"
 msgstr "桌面通知"
 
-#: src/components/notifications/desktop-channel-dialog.tsx:128
+#: src/components/notifications/desktop-channel-dialog.tsx:119
 msgid "Desktop notifications are shown by the operating system even when the app is minimized."
 msgstr "即使应用已最小化，操作系统仍会显示桌面通知。"
 
@@ -1974,9 +1980,9 @@ msgstr "禁用"
 
 #: src/components/config/engines/forms/mesio-hls-form.tsx:202
 #: src/components/streamers/card/use-streamer-status.tsx:46
-#: src/routes/_authed/_dashboard/notifications/index.lazy.tsx:509
-#: src/routes/_authed/_dashboard/notifications/index.lazy.tsx:541
-#: src/routes/_authed/_dashboard/notifications/index.lazy.tsx:551
+#: src/routes/_authed/_dashboard/notifications/index.lazy.tsx:502
+#: src/routes/_authed/_dashboard/notifications/index.lazy.tsx:534
+#: src/routes/_authed/_dashboard/notifications/index.lazy.tsx:544
 #: src/routes/_authed/_dashboard/streamers/index.lazy.tsx:74
 msgid "Disabled"
 msgstr "已禁用"
@@ -2196,7 +2202,7 @@ msgstr "例如：标准处理"
 #: src/components/config/templates/template-card.tsx:116
 #: src/components/filters/FilterCard.tsx:305
 #: src/components/layout/site-header.tsx:54
-#: src/components/notifications/channel-card.tsx:180
+#: src/components/notifications/channel-card.tsx:194
 #: src/components/pipeline/presets/preset-card.tsx:176
 #: src/components/pipeline/workflows/workflow-card.tsx:170
 #: src/components/sidebar/navbar.tsx:48
@@ -2204,7 +2210,7 @@ msgstr "例如：标准处理"
 msgid "Edit"
 msgstr "编辑"
 
-#: src/components/notifications/channel-form.tsx:274
+#: src/components/notifications/channel-form.tsx:287
 msgid "Edit Channel"
 msgstr "编辑渠道"
 
@@ -2250,7 +2256,7 @@ msgstr "启用高级 HLS 分段重建"
 msgid "Enable Monitoring"
 msgstr "启用监控"
 
-#: src/components/notifications/forms/webhook-form.tsx:117
+#: src/components/notifications/forms/webhook-form.tsx:118
 msgid "Enable or disable this webhook"
 msgstr "启用或禁用此 Webhook"
 
@@ -2270,13 +2276,14 @@ msgstr "启用代理"
 msgid "Enable recording of danmu/chat messages along with the video."
 msgstr "启用弹幕/聊天消息与视频一起录制。"
 
-#: src/components/notifications/desktop-channel-dialog.tsx:111
-#: src/components/notifications/forms/discord-form.tsx:130
-#: src/components/notifications/forms/email-form.tsx:219
-#: src/components/notifications/forms/telegram-form.tsx:133
-#: src/routes/_authed/_dashboard/notifications/index.lazy.tsx:508
-#: src/routes/_authed/_dashboard/notifications/index.lazy.tsx:540
-#: src/routes/_authed/_dashboard/notifications/index.lazy.tsx:550
+#: src/components/notifications/desktop-channel-dialog.tsx:102
+#: src/components/notifications/forms/discord-form.tsx:127
+#: src/components/notifications/forms/email-form.tsx:216
+#: src/components/notifications/forms/gotify-form.tsx:130
+#: src/components/notifications/forms/telegram-form.tsx:130
+#: src/routes/_authed/_dashboard/notifications/index.lazy.tsx:501
+#: src/routes/_authed/_dashboard/notifications/index.lazy.tsx:533
+#: src/routes/_authed/_dashboard/notifications/index.lazy.tsx:543
 msgid "Enabled"
 msgstr "启用"
 
@@ -2320,7 +2327,7 @@ msgstr "结束时间"
 msgid "Ended"
 msgstr "已结束"
 
-#: src/components/notifications/forms/webhook-form.tsx:61
+#: src/components/notifications/forms/webhook-form.tsx:62
 msgid "Endpoint Configuration"
 msgstr "端点配置"
 
@@ -2464,13 +2471,13 @@ msgstr "事件钩子"
 msgid "Event Type"
 msgstr "事件类型"
 
-#: src/components/notifications/desktop-channel-dialog.tsx:174
+#: src/components/notifications/desktop-channel-dialog.tsx:165
 msgid "Event Types"
 msgstr "事件类型"
 
 #: src/components/layout/site-header.tsx:38
 #: src/components/sidebar/navbar.tsx:32
-#: src/routes/_authed/_dashboard/notifications/index.lazy.tsx:391
+#: src/routes/_authed/_dashboard/notifications/index.lazy.tsx:384
 msgid "Events"
 msgstr "事件"
 
@@ -2602,7 +2609,7 @@ msgstr "API 模式"
 msgid "Extraction Settings"
 msgstr "提取设置"
 
-#: src/components/notifications/forms/webhook-form.tsx:291
+#: src/components/notifications/forms/webhook-form.tsx:285
 msgid "ey..."
 msgstr "ey..."
 
@@ -2654,7 +2661,7 @@ msgstr "克隆模板失败：{0}"
 msgid "Failed to copy"
 msgstr "复制失败"
 
-#: src/components/notifications/channel-form.tsx:208
+#: src/components/notifications/channel-form.tsx:221
 msgid "Failed to create channel"
 msgstr "创建渠道失败"
 
@@ -2844,7 +2851,7 @@ msgstr "启动登录失败：{0}"
 msgid "Failed to trigger check"
 msgstr "触发检查失败"
 
-#: src/components/notifications/channel-form.tsx:222
+#: src/components/notifications/channel-form.tsx:235
 msgid "Failed to update channel"
 msgstr "更新渠道失败"
 
@@ -2880,7 +2887,7 @@ msgstr "更新设置失败"
 msgid "Failed to update streamer"
 msgstr "更新主播失败"
 
-#: src/components/notifications/subscription-manager.tsx:230
+#: src/components/notifications/subscription-manager.tsx:231
 msgid "Failed to update subscriptions"
 msgstr "更新订阅失败"
 
@@ -3002,7 +3009,7 @@ msgstr "过滤器创建成功"
 msgid "Filter deleted successfully"
 msgstr "过滤器删除成功"
 
-#: src/components/notifications/forms/webhook-form.tsx:170
+#: src/components/notifications/forms/webhook-form.tsx:164
 msgid "Filter events below this priority"
 msgstr "过滤低于此优先级的事件"
 
@@ -3135,7 +3142,7 @@ msgstr "格式"
 msgid "Framerate (FPS)"
 msgstr "帧率（FPS）"
 
-#: src/components/notifications/forms/email-form.tsx:128
+#: src/components/notifications/forms/email-form.tsx:129
 msgid "From Address"
 msgstr "发件人地址"
 
@@ -3263,6 +3270,10 @@ msgstr "跳转到第 {p} 页"
 msgid "Go to previous page"
 msgstr "上一页"
 
+#: src/components/notifications/forms/gotify-form.tsx:62
+msgid "Gotify application token"
+msgstr "Gotify 应用令牌"
+
 #: src/components/pipeline/presets/default-presets-i18n.ts:110
 msgid "GPU HQ Archive"
 msgstr "GPU 高质量归档"
@@ -3310,7 +3321,7 @@ msgstr "硬件加速"
 msgid "HD Thumbnail"
 msgstr "高清缩略图"
 
-#: src/components/notifications/forms/webhook-form.tsx:369
+#: src/components/notifications/forms/webhook-form.tsx:363
 msgid "Header Key"
 msgstr "Header 键"
 
@@ -3318,7 +3329,7 @@ msgstr "Header 键"
 msgid "Header received"
 msgstr "收到头部"
 
-#: src/components/notifications/forms/webhook-form.tsx:388
+#: src/components/notifications/forms/webhook-form.tsx:382
 msgid "Header Value"
 msgstr "Header 值"
 
@@ -3343,10 +3354,6 @@ msgstr "高度"
 msgid "Hide password"
 msgstr "隐藏密码"
 
-#: src/components/notifications/forms/discord-form.tsx:114
-#: src/components/notifications/forms/email-form.tsx:191
-#: src/components/notifications/forms/telegram-form.tsx:117
-#: src/components/notifications/forms/webhook-form.tsx:162
 #: src/components/streamers/config/streamer-general-settings.tsx:229
 #: src/components/streamers/edit/streamer-meta-form.tsx:204
 msgid "High"
@@ -3381,9 +3388,9 @@ msgid "High Quality MP3"
 msgstr "高质量 MP3"
 
 #: src/components/notifications/browser-channel-dialog.tsx:153
-#: src/components/notifications/desktop-channel-dialog.tsx:57
+#: src/components/notifications/desktop-channel-dialog.tsx:51
 #: src/routes/_authed/_dashboard/notifications/events.lazy.tsx:168
-#: src/routes/_authed/_dashboard/notifications/index.lazy.tsx:340
+#: src/routes/_authed/_dashboard/notifications/index.lazy.tsx:337
 msgid "High+"
 msgstr "高+"
 
@@ -3453,17 +3460,21 @@ msgstr "仅 HTTP/1.1"
 msgid "HTTP/2 Only"
 msgstr "仅 HTTP/2"
 
-#: src/components/notifications/forms/discord-form.tsx:81
+#: src/components/notifications/forms/discord-form.tsx:82
 msgid "https://..."
 msgstr "https://..."
 
-#: src/components/notifications/forms/webhook-form.tsx:75
+#: src/components/notifications/forms/webhook-form.tsx:76
 msgid "https://api.example.com/webhook"
 msgstr "https://api.example.com/webhook"
 
-#: src/components/notifications/forms/discord-form.tsx:41
+#: src/components/notifications/forms/discord-form.tsx:42
 msgid "https://discord.com/api/webhooks/..."
 msgstr "https://discord.com/api/webhooks/..."
+
+#: src/components/notifications/forms/gotify-form.tsx:41
+msgid "https://gotify.example.com"
+msgstr "https://gotify.example.com"
 
 #: src/components/config/engines/forms/streamlink-form.tsx:130
 msgid "https://lb-eu.cdn-perfprod.com"
@@ -3558,7 +3569,7 @@ msgstr "正在导入..."
 msgid "In active"
 msgstr "进行中"
 
-#: src/routes/_authed/_dashboard/notifications/index.lazy.tsx:483
+#: src/routes/_authed/_dashboard/notifications/index.lazy.tsx:476
 msgid "Inactive"
 msgstr "未激活"
 
@@ -3633,7 +3644,7 @@ msgstr "嵌入"
 msgid "Inspecting"
 msgstr "检查中"
 
-#: src/components/notifications/events/event-card.tsx:179
+#: src/components/notifications/events/event-card.tsx:172
 msgid "Interact"
 msgstr "查看详情"
 
@@ -3645,7 +3656,7 @@ msgstr "24小时交互式时间线选择。"
 msgid "Interactive password entry via this API is not supported on Windows. Please use \"Desktop Login\" (import tdata) or log in once in a regular terminal."
 msgstr "Windows 不支持通过此 API 进行交互式密码输入。请使用“桌面登录”（导入 tdata）或在常规终端中登录一次。"
 
-#: src/routes/_authed/_dashboard/notifications/index.lazy.tsx:495
+#: src/routes/_authed/_dashboard/notifications/index.lazy.tsx:488
 msgid "Internal"
 msgstr "内部"
 
@@ -3756,7 +3767,7 @@ msgstr "保持运行"
 msgid "Keep uploading other files if one fails"
 msgstr "如果一个文件上传失败，继续上传其他文件"
 
-#: src/components/notifications/forms/webhook-form.tsx:447
+#: src/components/notifications/forms/webhook-form.tsx:441
 #: src/components/pipeline/presets/processors/metadata-config-form.tsx:72
 #: src/components/pipeline/presets/processors/remux-config-form.tsx:1025
 #: src/components/pipeline/presets/processors/tdl-config-form.tsx:93
@@ -3853,7 +3864,7 @@ msgid "Live Gap Strategy"
 msgstr "直播缺口策略"
 
 #: src/components/notifications/browser-channel-dialog.tsx:82
-#: src/routes/_authed/_dashboard/notifications/index.lazy.tsx:536
+#: src/routes/_authed/_dashboard/notifications/index.lazy.tsx:529
 msgid "Live Polling"
 msgstr "实时轮询"
 
@@ -3981,10 +3992,6 @@ msgstr "循环保护"
 msgid "Lossless Split"
 msgstr "无损分割"
 
-#: src/components/notifications/forms/discord-form.tsx:108
-#: src/components/notifications/forms/email-form.tsx:185
-#: src/components/notifications/forms/telegram-form.tsx:111
-#: src/components/notifications/forms/webhook-form.tsx:156
 #: src/components/streamers/config/streamer-general-settings.tsx:235
 #: src/components/streamers/edit/streamer-meta-form.tsx:210
 msgid "Low"
@@ -4022,11 +4029,11 @@ msgstr "管理专门的提取和识别选项。"
 msgid "Manage storage paths and file formats."
 msgstr "管理存储路径和文件格式。"
 
-#: src/components/notifications/subscription-manager.tsx:295
+#: src/components/notifications/subscription-manager.tsx:296
 msgid "Manage Subscriptions"
 msgstr "管理订阅"
 
-#: src/routes/_authed/_dashboard/notifications/index.lazy.tsx:380
+#: src/routes/_authed/_dashboard/notifications/index.lazy.tsx:373
 msgid "Manage where system notifications are sent"
 msgstr "管理系统通知发送到哪里"
 
@@ -4247,7 +4254,7 @@ msgstr "元数据标签"
 msgid "Metadata Variables"
 msgstr "元数据变量"
 
-#: src/components/notifications/forms/webhook-form.tsx:91
+#: src/components/notifications/forms/webhook-form.tsx:92
 msgid "Method"
 msgstr "请求方法"
 
@@ -4263,10 +4270,11 @@ msgstr "最小间隔（毫秒）"
 msgid "Min Interval (s)"
 msgstr "最小间隔（s）"
 
-#: src/components/notifications/forms/discord-form.tsx:98
-#: src/components/notifications/forms/email-form.tsx:175
-#: src/components/notifications/forms/telegram-form.tsx:101
-#: src/routes/_authed/_dashboard/notifications/index.lazy.tsx:524
+#: src/components/notifications/forms/discord-form.tsx:99
+#: src/components/notifications/forms/email-form.tsx:176
+#: src/components/notifications/forms/gotify-form.tsx:78
+#: src/components/notifications/forms/telegram-form.tsx:102
+#: src/routes/_authed/_dashboard/notifications/index.lazy.tsx:517
 msgid "Min Priority"
 msgstr "最低优先级"
 
@@ -4279,8 +4287,8 @@ msgstr "最小分段大小"
 msgid "Min size to keep."
 msgstr "保留的最小大小。"
 
-#: src/components/notifications/desktop-channel-dialog.tsx:140
-#: src/components/notifications/forms/webhook-form.tsx:143
+#: src/components/notifications/desktop-channel-dialog.tsx:131
+#: src/components/notifications/forms/webhook-form.tsx:144
 msgid "Minimum Priority"
 msgstr "最低优先级"
 
@@ -4353,11 +4361,11 @@ msgstr "指数退避的倍率。"
 msgid "My Archiving Workflow"
 msgstr "我的归档工作流"
 
-#: src/components/notifications/channel-form.tsx:302
+#: src/components/notifications/channel-form.tsx:315
 msgid "My Channel"
 msgstr "我的渠道"
 
-#: src/components/notifications/channel-form.tsx:296
+#: src/components/notifications/channel-form.tsx:309
 #: src/components/pipeline/presets/editor/preset-meta-form.tsx:215
 #: src/components/pipeline/workflows/workflow-editor.tsx:309
 #: src/components/streamers/config/streamer-general-settings.tsx:92
@@ -4382,7 +4390,7 @@ msgstr "name@example.com"
 msgid "Namespace"
 msgstr "命名空间"
 
-#: src/components/notifications/desktop-channel-dialog.tsx:117
+#: src/components/notifications/desktop-channel-dialog.tsx:108
 msgid "Native"
 msgstr "原生"
 
@@ -4460,7 +4468,7 @@ msgstr "无配置。"
 msgid "No credentials found."
 msgstr "未找到凭据。"
 
-#: src/components/notifications/forms/webhook-form.tsx:436
+#: src/components/notifications/forms/webhook-form.tsx:430
 msgid "No custom headers configured"
 msgstr "未配置自定义请求头"
 
@@ -4534,7 +4542,7 @@ msgstr "该执行记录暂无日志。"
 msgid "No logs to display"
 msgstr "暂无日志可显示"
 
-#: src/components/notifications/subscription-manager.tsx:360
+#: src/components/notifications/subscription-manager.tsx:361
 msgid "No matching events found"
 msgstr "未找到匹配的事件"
 
@@ -4677,7 +4685,7 @@ msgstr "未找到工作流"
 msgid "No workflows yet"
 msgstr "暂无工作流"
 
-#: src/components/notifications/forms/webhook-form.tsx:252
+#: src/components/notifications/forms/webhook-form.tsx:246
 #: src/routes/_authed/_dashboard/config/theme.lazy.tsx:333
 #: src/routes/_authed/_dashboard/sessions/index.lazy.tsx:466
 msgid "None"
@@ -4691,10 +4699,6 @@ msgstr "无（默认）"
 msgid "None (Strip Audio)"
 msgstr "无（剥离音频）"
 
-#: src/components/notifications/forms/discord-form.tsx:111
-#: src/components/notifications/forms/email-form.tsx:188
-#: src/components/notifications/forms/telegram-form.tsx:114
-#: src/components/notifications/forms/webhook-form.tsx:159
 #: src/components/pipeline/presets/processors/tdl-login-dialog.tsx:647
 #: src/components/streamers/config/streamer-general-settings.tsx:232
 #: src/components/streamers/edit/streamer-meta-form.tsx:207
@@ -4702,9 +4706,9 @@ msgid "Normal"
 msgstr "正常"
 
 #: src/components/notifications/browser-channel-dialog.tsx:156
-#: src/components/notifications/desktop-channel-dialog.tsx:59
+#: src/components/notifications/desktop-channel-dialog.tsx:52
 #: src/routes/_authed/_dashboard/notifications/events.lazy.tsx:174
-#: src/routes/_authed/_dashboard/notifications/index.lazy.tsx:345
+#: src/routes/_authed/_dashboard/notifications/index.lazy.tsx:338
 msgid "Normal+"
 msgstr "普通+"
 
@@ -4744,11 +4748,11 @@ msgstr "通知服务"
 #: src/components/layout/site-header.tsx:37
 #: src/components/sidebar/navbar.tsx:31
 #: src/lib/menu-list.ts:124
-#: src/routes/_authed/_dashboard/notifications/index.lazy.tsx:377
+#: src/routes/_authed/_dashboard/notifications/index.lazy.tsx:370
 msgid "Notifications"
 msgstr "通知"
 
-#: src/components/notifications/forms/email-form.tsx:133
+#: src/components/notifications/forms/email-form.tsx:134
 msgid "notifier@example.com"
 msgstr "notifier@example.com"
 
@@ -4894,7 +4898,7 @@ msgstr "仅支持 MP4/MOV/M4V"
 
 #: src/components/config/platforms/platform-card.tsx:83
 #: src/components/config/templates/template-card.tsx:110
-#: src/components/notifications/channel-card.tsx:174
+#: src/components/notifications/channel-card.tsx:188
 #: src/components/pipeline/jobs/pipeline-summary-card.tsx:150
 #: src/components/pipeline/outputs/output-card.tsx:128
 #: src/components/pipeline/presets/preset-card.tsx:170
@@ -5105,7 +5109,7 @@ msgstr "批量解析"
 msgid "Parse error: {0}"
 msgstr "解析失败：{0}"
 
-#: src/components/notifications/forms/telegram-form.tsx:77
+#: src/components/notifications/forms/telegram-form.tsx:78
 msgid "Parse Mode"
 msgstr "解析模式"
 
@@ -5128,10 +5132,10 @@ msgid "Passthrough Inputs"
 msgstr "透传输入"
 
 #: src/components/config/shared/proxy-settings-card.tsx:197
-#: src/components/notifications/forms/email-form.tsx:105
-#: src/components/notifications/forms/email-form.tsx:111
+#: src/components/notifications/forms/email-form.tsx:106
+#: src/components/notifications/forms/email-form.tsx:112
+#: src/components/notifications/forms/webhook-form.tsx:330
 #: src/components/notifications/forms/webhook-form.tsx:336
-#: src/components/notifications/forms/webhook-form.tsx:342
 #: src/routes/_public/login.lazy.tsx:188
 msgid "Password"
 msgstr "密码"
@@ -5427,7 +5431,7 @@ msgstr "播客提取"
 msgid "Pool Idle Timeout (ms)"
 msgstr "连接池空闲超时（毫秒）"
 
-#: src/components/notifications/forms/email-form.tsx:60
+#: src/components/notifications/forms/email-form.tsx:61
 msgid "Port"
 msgstr "端口"
 
@@ -5536,7 +5540,7 @@ msgstr "预设"
 msgid "Presets Available"
 msgstr "可用预设"
 
-#: src/components/notifications/forms/email-form.tsx:161
+#: src/components/notifications/forms/email-form.tsx:162
 msgid "Press Enter to add recipient"
 msgstr "按 Enter 添加收件人"
 
@@ -5777,11 +5781,11 @@ msgstr "所有系统组件与资源的实时状态。"
 msgid "Reason"
 msgstr "原因"
 
-#: src/components/notifications/subscription-manager.tsx:137
+#: src/components/notifications/subscription-manager.tsx:138
 msgid "Receive a notification when a stream ends."
 msgstr "当直播结束时接收通知。"
 
-#: src/components/notifications/subscription-manager.tsx:135
+#: src/components/notifications/subscription-manager.tsx:136
 msgid "Receive a notification when a streamer goes live."
 msgstr "当主播开播时接收通知。"
 
@@ -5930,7 +5934,7 @@ msgstr "替换输出文件"
 msgid "Replace output files if they already exist"
 msgstr "若输出文件已存在则替换"
 
-#: src/components/notifications/forms/webhook-form.tsx:193
+#: src/components/notifications/forms/webhook-form.tsx:187
 msgid "Request timeout duration"
 msgstr "请求超时时长"
 
@@ -6159,7 +6163,7 @@ msgstr "清理后的主播名称"
 #: src/components/config/platforms/platform-editor.tsx:159
 #: src/components/config/templates/template-editor.tsx:213
 #: src/components/filters/FilterDialog.tsx:260
-#: src/components/notifications/subscription-manager.tsx:444
+#: src/components/notifications/subscription-manager.tsx:445
 #: src/components/pipeline/presets/editor/preset-save-fab.tsx:37
 #: src/components/pipeline/workflows/step-config-dialog.tsx:543
 #: src/components/streamers/edit/streamer-save-fab.tsx:53
@@ -6232,7 +6236,7 @@ msgstr "按名称或描述搜索..."
 msgid "Search engines..."
 msgstr "搜索引擎..."
 
-#: src/components/notifications/subscription-manager.tsx:326
+#: src/components/notifications/subscription-manager.tsx:327
 msgid "Search events..."
 msgstr "搜索事件..."
 
@@ -6285,7 +6289,7 @@ msgstr "秒 (00-59)"
 msgid "Secondary"
 msgstr "次要"
 
-#: src/components/notifications/forms/webhook-form.tsx:394
+#: src/components/notifications/forms/webhook-form.tsx:388
 msgid "secret"
 msgstr "secret"
 
@@ -6331,8 +6335,8 @@ msgstr "选择会话"
 msgid "Select a streamer"
 msgstr "选择主播"
 
-#: src/components/notifications/desktop-channel-dialog.tsx:190
-#: src/components/notifications/subscription-manager.tsx:344
+#: src/components/notifications/desktop-channel-dialog.tsx:181
+#: src/components/notifications/subscription-manager.tsx:345
 msgid "Select All"
 msgstr "全选"
 
@@ -6399,7 +6403,7 @@ msgid "Select the days required for this filter to apply."
 msgstr "选择此过滤器生效的日期。"
 
 #. placeholder {0}: channel.name
-#: src/components/notifications/subscription-manager.tsx:298
+#: src/components/notifications/subscription-manager.tsx:299
 msgid "Select the events that should trigger notifications for <0>{0}</0>."
 msgstr "选择会为 <0>{0}</0> 触发通知的事件。"
 
@@ -6412,7 +6416,7 @@ msgid "Select the steps that must complete successfully before this step runs."
 msgstr "选择必须在此步骤运行前成功完成的步骤。"
 
 #: src/components/config/engines/engine-editor.tsx:240
-#: src/components/notifications/channel-form.tsx:339
+#: src/components/notifications/channel-form.tsx:352
 #: src/components/pipeline/presets/editor/preset-meta-form.tsx:161
 msgid "Select type"
 msgstr "选择类型"
@@ -6421,7 +6425,7 @@ msgstr "选择类型"
 msgid "Select your preferred color scheme."
 msgstr "选择你偏好的配色方案。"
 
-#: src/components/notifications/subscription-manager.tsx:423
+#: src/components/notifications/subscription-manager.tsx:424
 msgid "selected"
 msgstr "已选"
 
@@ -6444,6 +6448,11 @@ msgstr "用英文逗号分隔多个路径。"
 #: src/routes/_authed/_dashboard/notifications/index.lazy.tsx:328
 msgid "Server not configured"
 msgstr "服务器未配置"
+
+#: src/components/notifications/channel-card.tsx:133
+#: src/components/notifications/forms/gotify-form.tsx:36
+msgid "Server URL"
+msgstr "服务器地址"
 
 #: src/components/config/global/pipeline-config-card.tsx:259
 #: src/components/config/shared-config-editor.tsx:484
@@ -6634,11 +6643,11 @@ msgstr "跳过互动玩法"
 msgid "Skipped {skippedCount} duplicate stream(s)"
 msgstr "跳过了 {skippedCount} 个重复的流"
 
-#: src/components/notifications/forms/email-form.tsx:39
+#: src/components/notifications/forms/email-form.tsx:40
 msgid "SMTP Host"
 msgstr "SMTP 主机"
 
-#: src/components/notifications/forms/email-form.tsx:44
+#: src/components/notifications/forms/email-form.tsx:45
 msgid "smtp.gmail.com"
 msgstr "smtp.gmail.com"
 
@@ -6744,7 +6753,7 @@ msgid "Starting tdl process..."
 msgstr "正在启动 tdl 进程..."
 
 #: src/routes/_authed/_dashboard/config/theme.lazy.tsx:481
-#: src/routes/_authed/_dashboard/notifications/index.lazy.tsx:504
+#: src/routes/_authed/_dashboard/notifications/index.lazy.tsx:497
 #: src/routes/_authed/_dashboard/pipeline/executions.$pipelineId.lazy.tsx:437
 #: src/routes/_authed/_dashboard/system/health.lazy.tsx:148
 #: src/routes/_authed/_dashboard/system/health.lazy.tsx:218
@@ -6906,11 +6915,11 @@ msgstr "streamlink"
 msgid "Streams & Metadata"
 msgstr "流与元数据"
 
-#: src/components/notifications/channel-card.tsx:183
+#: src/components/notifications/channel-card.tsx:197
 msgid "Subscriptions"
 msgstr "订阅"
 
-#: src/components/notifications/subscription-manager.tsx:223
+#: src/components/notifications/subscription-manager.tsx:224
 msgid "Subscriptions updated"
 msgstr "订阅已更新"
 
@@ -6965,7 +6974,7 @@ msgstr "同步"
 msgid "System"
 msgstr "系统"
 
-#: src/components/notifications/events/event-card.tsx:161
+#: src/components/notifications/events/event-card.tsx:154
 msgid "SYSTEM"
 msgstr "系统"
 
@@ -7110,11 +7119,11 @@ msgstr "模板"
 msgid "Temporarily Paused"
 msgstr "暂时暂停"
 
-#: src/components/notifications/desktop-channel-dialog.tsx:241
+#: src/components/notifications/desktop-channel-dialog.tsx:232
 msgid "Test"
 msgstr "测试"
 
-#: src/components/notifications/channel-card.tsx:187
+#: src/components/notifications/channel-card.tsx:201
 msgid "Test Notification"
 msgstr "测试通知"
 
@@ -7161,7 +7170,7 @@ msgstr "主题模式"
 msgid "Theme Preset"
 msgstr "主题预设"
 
-#: src/components/notifications/desktop-channel-dialog.tsx:228
+#: src/components/notifications/desktop-channel-dialog.tsx:219
 msgid "These settings only apply to the desktop app. The server will still deliver channel notifications (Discord/Email/Webhook) normally."
 msgstr "这些设置仅适用于桌面应用。服务器仍将正常发送通道通知（Discord/电子邮件/Webhook）。"
 
@@ -7207,7 +7216,7 @@ msgid "This will cancel all pending and processing jobs in this pipeline."
 msgstr "这将取消此处理管道中所有待处理和处理中的任务。"
 
 #. placeholder {0}: channel.name
-#: src/components/notifications/channel-card.tsx:204
+#: src/components/notifications/channel-card.tsx:218
 msgid "This will permanently delete the notification channel \"{0}\"."
 msgstr "这将永久删除通知渠道“{0}”。"
 
@@ -7281,7 +7290,11 @@ msgstr "超时"
 msgid "Timeout (ms)"
 msgstr "超时（毫秒）"
 
-#: src/components/notifications/forms/webhook-form.tsx:182
+#: src/components/notifications/forms/gotify-form.tsx:107
+msgid "Timeout (s)"
+msgstr "超时（秒）"
+
+#: src/components/notifications/forms/webhook-form.tsx:176
 msgid "Timeout (seconds)"
 msgstr "超时（秒）"
 
@@ -7314,11 +7327,11 @@ msgstr "时间与延迟"
 msgid "Title"
 msgstr "标题"
 
-#: src/components/notifications/channel-card.tsx:95
+#: src/components/notifications/channel-card.tsx:98
 msgid "To"
 msgstr "收件人"
 
-#: src/components/notifications/forms/email-form.tsx:149
+#: src/components/notifications/forms/email-form.tsx:150
 msgid "To Addresses"
 msgstr "收件人地址"
 
@@ -7326,7 +7339,7 @@ msgstr "收件人地址"
 msgid "Today"
 msgstr "今天"
 
-#: src/components/notifications/forms/webhook-form.tsx:285
+#: src/components/notifications/forms/webhook-form.tsx:279
 msgid "Token"
 msgstr "令牌"
 
@@ -7401,59 +7414,59 @@ msgstr "每个分段录制后触发"
 msgid "Triggered after the entire session ends"
 msgstr "整个会话结束后触发"
 
-#: src/components/notifications/subscription-manager.tsx:143
+#: src/components/notifications/subscription-manager.tsx:144
 msgid "Triggered when a download fails with an error."
 msgstr "当下载因错误失败时触发。"
 
-#: src/components/notifications/subscription-manager.tsx:149
+#: src/components/notifications/subscription-manager.tsx:150
 msgid "Triggered when a download is manually cancelled."
 msgstr "当下载被手动取消时触发。"
 
-#: src/components/notifications/subscription-manager.tsx:152
+#: src/components/notifications/subscription-manager.tsx:153
 msgid "Triggered when a download is rejected (e.g., circuit breaker)."
 msgstr "当下载被拒绝时触发（例如熔断器）。"
 
-#: src/components/notifications/subscription-manager.tsx:141
+#: src/components/notifications/subscription-manager.tsx:142
 msgid "Triggered when a download successfully completes."
 msgstr "当下载成功完成时触发。"
 
-#: src/components/notifications/subscription-manager.tsx:147
+#: src/components/notifications/subscription-manager.tsx:148
 msgid "Triggered when a file segment is finished."
 msgstr "当文件分段完成时触发。"
 
-#: src/components/notifications/subscription-manager.tsx:139
+#: src/components/notifications/subscription-manager.tsx:140
 msgid "Triggered when a new download recording begins."
 msgstr "当新的下载录制开始时触发。"
 
-#: src/components/notifications/subscription-manager.tsx:145
+#: src/components/notifications/subscription-manager.tsx:146
 msgid "Triggered when a new file segment is created."
 msgstr "当创建新的文件分段时触发。"
 
-#: src/components/notifications/subscription-manager.tsx:163
+#: src/components/notifications/subscription-manager.tsx:164
 msgid "Triggered when a pipeline job fails."
 msgstr "当处理任务失败时触发。"
 
-#: src/components/notifications/subscription-manager.tsx:161
+#: src/components/notifications/subscription-manager.tsx:162
 msgid "Triggered when a pipeline job finishes successfully."
 msgstr "当处理任务成功完成时触发。"
 
-#: src/components/notifications/subscription-manager.tsx:165
+#: src/components/notifications/subscription-manager.tsx:166
 msgid "Triggered when a pipeline job is cancelled."
 msgstr "当处理任务被取消时触发。"
 
-#: src/components/notifications/subscription-manager.tsx:159
+#: src/components/notifications/subscription-manager.tsx:160
 msgid "Triggered when a post-processing pipeline job starts."
 msgstr "当后处理任务开始时触发。"
 
-#: src/components/notifications/subscription-manager.tsx:156
+#: src/components/notifications/subscription-manager.tsx:157
 msgid "Triggered when streamer configuration is dynamically updated."
 msgstr "当主播配置被动态更新时触发。"
 
-#: src/components/notifications/subscription-manager.tsx:177
+#: src/components/notifications/subscription-manager.tsx:178
 msgid "Triggered when the application shuts down."
 msgstr "应用关闭时触发。"
 
-#: src/components/notifications/subscription-manager.tsx:175
+#: src/components/notifications/subscription-manager.tsx:176
 msgid "Triggered when the application starts up."
 msgstr "应用启动时触发。"
 
@@ -7525,7 +7538,7 @@ msgstr "Twitch 代理播放列表"
 msgid "Twitch Proxy Playlist Exclude"
 msgstr "Twitch 代理播放列表排除"
 
-#: src/components/notifications/channel-form.tsx:319
+#: src/components/notifications/channel-form.tsx:332
 msgid "Type"
 msgstr "类型"
 
@@ -7588,7 +7601,7 @@ msgstr "无标题直播"
 msgid "UPDATE"
 msgstr "更新"
 
-#: src/components/notifications/channel-form.tsx:394
+#: src/components/notifications/channel-form.tsx:409
 msgid "Update Channel"
 msgstr "更新渠道"
 
@@ -7639,7 +7652,7 @@ msgstr "使用 rclone 将文件上传到云存储。在 rclone 配置中设置�
 msgid "Uptime"
 msgstr "运行时间"
 
-#: src/components/notifications/channel-card.tsx:130
+#: src/components/notifications/channel-card.tsx:144
 #: src/components/streamers/config/streamer-general-settings.tsx:66
 #: src/components/streamers/edit/streamer-meta-form.tsx:116
 #: src/components/streamers/progress-indicator.tsx:152
@@ -7678,7 +7691,7 @@ msgstr "使用二维码登录"
 msgid "Use System Proxy"
 msgstr "使用系统代理"
 
-#: src/components/notifications/forms/email-form.tsx:207
+#: src/components/notifications/forms/email-form.tsx:204
 msgid "Use TLS"
 msgstr "启用 TLS"
 
@@ -7692,15 +7705,15 @@ msgid "User Agent"
 msgstr "User-Agent"
 
 #: src/components/config/shared/proxy-settings-card.tsx:179
-#: src/components/notifications/forms/email-form.tsx:85
-#: src/components/notifications/forms/email-form.tsx:90
-#: src/components/notifications/forms/webhook-form.tsx:317
-#: src/components/notifications/forms/webhook-form.tsx:322
+#: src/components/notifications/forms/email-form.tsx:86
+#: src/components/notifications/forms/email-form.tsx:91
+#: src/components/notifications/forms/webhook-form.tsx:311
+#: src/components/notifications/forms/webhook-form.tsx:316
 #: src/routes/_public/login.lazy.tsx:168
 msgid "Username"
 msgstr "用户名"
 
-#: src/components/notifications/forms/discord-form.tsx:57
+#: src/components/notifications/forms/discord-form.tsx:58
 msgid "Username (Optional)"
 msgstr "用户名（可选）"
 
@@ -7726,7 +7739,7 @@ msgid "Validation service unavailable"
 msgstr "校验服务不可用"
 
 #: src/components/config/engines/forms/mesio-hls-form.tsx:582
-#: src/components/notifications/forms/webhook-form.tsx:459
+#: src/components/notifications/forms/webhook-form.tsx:453
 #: src/components/pipeline/presets/processors/metadata-config-form.tsx:78
 #: src/components/pipeline/presets/processors/remux-config-form.tsx:1036
 #: src/components/pipeline/presets/processors/tdl-config-form.tsx:99
@@ -7840,7 +7853,7 @@ msgstr "开始前等待时间。"
 msgid "Waiting for connection..."
 msgstr "正在等待连接..."
 
-#: src/components/notifications/subscription-manager.tsx:171
+#: src/components/notifications/subscription-manager.tsx:172
 msgid "Warning when the processing queue gets too long."
 msgstr "处理队列过长时发出警告。"
 
@@ -7857,7 +7870,7 @@ msgid "Web Optimize"
 msgstr "网页优化"
 
 #: src/components/notifications/browser-channel-dialog.tsx:119
-#: src/routes/_authed/_dashboard/notifications/index.lazy.tsx:546
+#: src/routes/_authed/_dashboard/notifications/index.lazy.tsx:539
 msgid "Web Push"
 msgstr "Web 推送"
 
@@ -7885,9 +7898,9 @@ msgstr "此浏览器不支持 Web 推送"
 msgid "Web Push priority updated"
 msgstr "Web 推送优先级已更新"
 
-#: src/components/notifications/channel-card.tsx:83
-#: src/components/notifications/forms/discord-form.tsx:36
-#: src/components/notifications/forms/webhook-form.tsx:70
+#: src/components/notifications/channel-card.tsx:86
+#: src/components/notifications/forms/discord-form.tsx:37
+#: src/components/notifications/forms/webhook-form.tsx:71
 msgid "Webhook URL"
 msgstr "Webhook URL"
 
@@ -7972,7 +7985,7 @@ msgstr "写入超时（毫秒）"
 msgid "WUP"
 msgstr "WUP"
 
-#: src/components/notifications/forms/webhook-form.tsx:374
+#: src/components/notifications/forms/webhook-form.tsx:368
 msgid "X-Auth-Key"
 msgstr "X-Auth-Key"
 

--- a/rust-srec/frontend/src/routes/_authed/_dashboard/notifications/events.lazy.tsx
+++ b/rust-srec/frontend/src/routes/_authed/_dashboard/notifications/events.lazy.tsx
@@ -54,6 +54,7 @@ import {
 } from '@/lib/notification-state';
 import { DashboardHeader } from '@/components/shared/dashboard-header';
 import { SearchInput } from '@/components/sessions/search-input';
+import { priorityLabel } from '@/lib/priority';
 
 export const Route = createLazyFileRoute(
   '/_authed/_dashboard/notifications/events',
@@ -128,12 +129,11 @@ function NotificationEventsPage() {
     if (!rawEvents || typeof window === 'undefined') return;
 
     // Don't auto-dismiss if filters would hide critical events
-    const criticalVisible = priority === 'all' || priority === 'critical';
+    const criticalVisible = priority === 'all' || priority === '10';
     if (!criticalVisible) return;
 
     const maxCritical = rawEvents.reduce((max, e) => {
-      const p = (e.priority ?? '').toString().trim().toLowerCase();
-      if (p !== 'critical') return max;
+      if (e.priority < 10) return max;
       return Math.max(max, e.created_at);
     }, 0);
     if (maxCritical <= 0) return;
@@ -158,19 +158,19 @@ function NotificationEventsPage() {
     () => [
       { value: 'all', label: i18n._(msg`All`), icon: Filter },
       {
-        value: 'critical',
+        value: '10',
         label: i18n._(msg`Critical`),
         icon: Flame,
         color: 'text-red-500',
       },
       {
-        value: 'high',
+        value: '8',
         label: i18n._(msg`High+`),
         icon: Zap,
         color: 'text-orange-500',
       },
       {
-        value: 'normal',
+        value: '5',
         label: i18n._(msg`Normal+`),
         icon: Circle,
         color: 'text-blue-500',
@@ -220,7 +220,7 @@ function NotificationEventsPage() {
 
   const handleViewDetails = useCallback((event: any) => {
     setSelectedPayload({
-      title: `${event.event_type} (${event.priority})`,
+      title: `${event.event_type} (${priorityLabel(event.priority)})`,
       payload: event.payload,
     });
   }, []);

--- a/rust-srec/frontend/src/routes/_authed/_dashboard/notifications/index.lazy.tsx
+++ b/rust-srec/frontend/src/routes/_authed/_dashboard/notifications/index.lazy.tsx
@@ -72,7 +72,7 @@ function NotificationsPage() {
   const [webPushPermission, setWebPushPermission] =
     useState<NotificationPermission>('default');
   const [webPushEnabled, setWebPushEnabled] = useState(false);
-  const [webPushMinPriority, setWebPushMinPriority] = useState('critical');
+  const [webPushMinPriority, setWebPushMinPriority] = useState(10);
 
   const [isBrowserDialogOpen, setIsBrowserDialogOpen] = useState(false);
   const [browserNotificationsEnabled, setBrowserNotificationsEnabledState] =
@@ -82,7 +82,7 @@ function NotificationsPage() {
 
   const defaultDesktopConfig: DesktopNotificationConfig = {
     enabled: true,
-    minPriority: 'normal',
+    minPriority: 5,
     // Empty => no desktop notifications until events are selected.
     eventTypes: [],
   };
@@ -181,7 +181,7 @@ function NotificationsPage() {
     enabled: webPushSupported,
   });
 
-  const handleWebPushPriorityChange = async (priority: string) => {
+  const handleWebPushPriorityChange = async (priority: number) => {
     setWebPushMinPriority(priority);
 
     // If already enabled, update the subscription on the server
@@ -332,18 +332,11 @@ function NotificationsPage() {
   }, [i18n, webPushKeyQuery.isError, webPushPermission, webPushSupported]);
 
   const desktopMinPriorityLabel = useMemo(() => {
-    const p = desktopNotificationsConfig?.minPriority ?? 'normal';
-    switch (p) {
-      case 'critical':
-        return i18n._(msg`Critical Only`);
-      case 'high':
-        return i18n._(msg`High+`);
-      case 'low':
-        return i18n._(msg`All`);
-      case 'normal':
-      default:
-        return i18n._(msg`Normal+`);
-    }
+    const p = desktopNotificationsConfig?.minPriority ?? 5;
+    if (p >= 10) return i18n._(msg`Critical Only`);
+    if (p >= 7) return i18n._(msg`High+`);
+    if (p >= 4) return i18n._(msg`Normal+`);
+    return i18n._(msg`All`);
   }, [desktopNotificationsConfig?.minPriority, i18n]);
 
   const desktopConfiguredEventsText = useMemo(() => {

--- a/rust-srec/frontend/src/server/functions/notifications.ts
+++ b/rust-srec/frontend/src/server/functions/notifications.ts
@@ -150,7 +150,7 @@ export const subscribeWebPush = createServerFn({ method: 'POST' })
   .inputValidator(
     (d: {
       subscription: z.infer<typeof WebPushSubscriptionJsonSchema>;
-      min_priority?: string;
+      min_priority?: number;
     }) => d,
   )
   .handler(async ({ data }) => {

--- a/rust-srec/migrations/20260408120000_priority_to_integer.sql
+++ b/rust-srec/migrations/20260408120000_priority_to_integer.sql
@@ -1,0 +1,84 @@
+-- Migrate notification priority from TEXT to INTEGER.
+--
+-- Priority mapping (Gotify-compatible 0-10 scale):
+--   low      -> 2
+--   normal   -> 5
+--   high     -> 8
+--   critical -> 10
+
+-- ============================================
+-- notification_event_log: priority TEXT -> INTEGER
+-- ============================================
+
+CREATE TABLE notification_event_log_new (
+    id TEXT PRIMARY KEY,
+    event_type TEXT NOT NULL,
+    priority INTEGER NOT NULL DEFAULT 5,
+    payload TEXT NOT NULL,
+    streamer_id TEXT,
+    created_at INTEGER NOT NULL,
+    FOREIGN KEY (streamer_id) REFERENCES streamers(id) ON DELETE SET NULL
+);
+
+INSERT INTO notification_event_log_new (id, event_type, priority, payload, streamer_id, created_at)
+SELECT id, event_type,
+    CASE LOWER(priority)
+        WHEN 'low' THEN 2
+        WHEN 'normal' THEN 5
+        WHEN 'high' THEN 8
+        WHEN 'critical' THEN 10
+        ELSE 5
+    END,
+    payload, streamer_id, created_at
+FROM notification_event_log;
+
+DROP TABLE notification_event_log;
+ALTER TABLE notification_event_log_new RENAME TO notification_event_log;
+
+CREATE INDEX idx_notification_event_log_created_at ON notification_event_log(created_at);
+CREATE INDEX idx_notification_event_log_event_type ON notification_event_log(event_type);
+CREATE INDEX idx_notification_event_log_streamer_id ON notification_event_log(streamer_id);
+
+-- ============================================
+-- web_push_subscription: min_priority TEXT -> INTEGER
+-- ============================================
+
+CREATE TABLE web_push_subscription_new (
+    id TEXT PRIMARY KEY NOT NULL,
+    user_id TEXT NOT NULL,
+    endpoint TEXT NOT NULL UNIQUE,
+    p256dh TEXT NOT NULL,
+    auth TEXT NOT NULL,
+    min_priority INTEGER NOT NULL DEFAULT 10,
+    created_at INTEGER NOT NULL DEFAULT (unixepoch('now') * 1000),
+    updated_at INTEGER NOT NULL DEFAULT (unixepoch('now') * 1000),
+    next_attempt_at INTEGER,
+    last_429_at INTEGER,
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+
+INSERT INTO web_push_subscription_new (id, user_id, endpoint, p256dh, auth, min_priority, created_at, updated_at, next_attempt_at, last_429_at)
+SELECT id, user_id, endpoint, p256dh, auth,
+    CASE LOWER(min_priority)
+        WHEN 'low' THEN 2
+        WHEN 'normal' THEN 5
+        WHEN 'high' THEN 8
+        WHEN 'critical' THEN 10
+        ELSE 10
+    END,
+    created_at, updated_at, next_attempt_at, last_429_at
+FROM web_push_subscription;
+
+DROP TABLE web_push_subscription;
+ALTER TABLE web_push_subscription_new RENAME TO web_push_subscription;
+
+CREATE INDEX idx_web_push_subscription_user_updated_at
+    ON web_push_subscription(user_id, updated_at DESC);
+
+CREATE INDEX idx_web_push_subscription_next_attempt_at
+    ON web_push_subscription(next_attempt_at)
+    WHERE next_attempt_at IS NOT NULL;
+
+CREATE INDEX idx_web_push_subscription_last_429_at
+    ON web_push_subscription(last_429_at)
+    WHERE last_429_at IS NOT NULL;

--- a/rust-srec/src-tauri/src/desktop_notifications.rs
+++ b/rust-srec/src-tauri/src/desktop_notifications.rs
@@ -26,14 +26,88 @@ pub const DEFAULT_DESKTOP_NOTIFICATION_EVENT_TYPES: &[&str] = &[
     "credential_invalid",
 ];
 
-#[derive(Debug, Default, Clone, Copy, Serialize, Deserialize)]
-#[serde(rename_all = "lowercase")]
+/// Desktop notification minimum priority.
+///
+/// Serializes as integer (Gotify-compatible 0-10 scale).
+/// Deserializes from integer or legacy string ("low"/"normal"/"high"/"critical").
+#[derive(Debug, Default, Clone, Copy)]
 pub enum DesktopNotificationMinPriority {
     Low,
     #[default]
     Normal,
     High,
     Critical,
+}
+
+impl DesktopNotificationMinPriority {
+    fn as_int(self) -> u8 {
+        match self {
+            Self::Low => 2,
+            Self::Normal => 5,
+            Self::High => 8,
+            Self::Critical => 10,
+        }
+    }
+
+    fn from_int(value: u8) -> Option<Self> {
+        match value {
+            0..=3 => Some(Self::Low),
+            4..=6 => Some(Self::Normal),
+            7..=9 => Some(Self::High),
+            10..=u8::MAX => Some(Self::Critical),
+        }
+    }
+}
+
+impl Serialize for DesktopNotificationMinPriority {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_u8(self.as_int())
+    }
+}
+
+impl<'de> Deserialize<'de> for DesktopNotificationMinPriority {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        use serde::de;
+
+        struct Visitor;
+
+        impl<'de> de::Visitor<'de> for Visitor {
+            type Value = DesktopNotificationMinPriority;
+
+            fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+                f.write_str("integer (0-10) or string (low/normal/high/critical)")
+            }
+
+            fn visit_u64<E: de::Error>(self, v: u64) -> Result<Self::Value, E> {
+                let val = u8::try_from(v)
+                    .map_err(|_| de::Error::invalid_value(de::Unexpected::Unsigned(v), &self))?;
+                DesktopNotificationMinPriority::from_int(val)
+                    .ok_or_else(|| de::Error::invalid_value(de::Unexpected::Unsigned(v), &self))
+            }
+
+            fn visit_i64<E: de::Error>(self, v: i64) -> Result<Self::Value, E> {
+                let val = u8::try_from(v)
+                    .map_err(|_| de::Error::invalid_value(de::Unexpected::Signed(v), &self))?;
+                DesktopNotificationMinPriority::from_int(val)
+                    .ok_or_else(|| de::Error::invalid_value(de::Unexpected::Signed(v), &self))
+            }
+
+            fn visit_str<E: de::Error>(self, v: &str) -> Result<Self::Value, E> {
+                match v.trim().to_ascii_lowercase().as_str() {
+                    "low" => Ok(DesktopNotificationMinPriority::Low),
+                    "normal" => Ok(DesktopNotificationMinPriority::Normal),
+                    "high" => Ok(DesktopNotificationMinPriority::High),
+                    "critical" => Ok(DesktopNotificationMinPriority::Critical),
+                    _ => Err(de::Error::unknown_variant(
+                        v,
+                        &["low", "normal", "high", "critical"],
+                    )),
+                }
+            }
+        }
+
+        deserializer.deserialize_any(Visitor)
+    }
 }
 
 impl From<DesktopNotificationMinPriority> for rust_srec::notification::NotificationPriority {

--- a/rust-srec/src/api/routes/notifications.rs
+++ b/rust-srec/src/api/routes/notifications.rs
@@ -100,7 +100,7 @@ pub struct WebPushSubscriptionJson {
 pub struct WebPushSubscriptionResponse {
     pub id: String,
     pub endpoint: String,
-    pub min_priority: String,
+    pub min_priority: i32,
     pub created_at: i64,
     pub updated_at: i64,
 }
@@ -108,8 +108,8 @@ pub struct WebPushSubscriptionResponse {
 #[derive(Debug, serde::Deserialize, utoipa::ToSchema)]
 pub struct SubscribeWebPushRequest {
     pub subscription: WebPushSubscriptionJson,
-    /// Minimum priority to send ("low"|"normal"|"high"|"critical"), default: "critical".
-    pub min_priority: Option<String>,
+    /// Minimum priority to send (integer 0-10 scale, or legacy string), default: 10 (critical).
+    pub min_priority: Option<serde_json::Value>,
 }
 
 #[derive(Debug, serde::Deserialize, utoipa::ToSchema)]
@@ -245,14 +245,24 @@ pub async fn subscribe_web_push(
         ));
     }
 
-    let min_priority = match req.min_priority.as_deref() {
+    let min_priority = match &req.min_priority {
         None => NotificationPriority::Critical,
-        Some(value) => parse_priority(value).ok_or_else(|| {
+        Some(serde_json::Value::Number(n)) => {
+            let val = n
+                .as_u64()
+                .and_then(|v| u8::try_from(v).ok())
+                .ok_or_else(|| {
+                    ApiError::bad_request("min_priority must be an integer between 0 and 10")
+                })?;
+            NotificationPriority::from_int(val).unwrap_or(NotificationPriority::Critical)
+        }
+        Some(serde_json::Value::String(s)) => parse_priority(s).ok_or_else(|| {
             ApiError::bad_request(format!(
-                "Invalid min_priority '{}'. Expected one of: low, normal, high, critical",
-                value
+                "Invalid min_priority '{}'. Expected integer (0-10) or one of: low, normal, high, critical",
+                s
             ))
         })?,
+        _ => NotificationPriority::Critical,
     };
 
     let saved = service
@@ -351,6 +361,10 @@ pub async fn list_events(
 }
 
 fn parse_priority(input: &str) -> Option<NotificationPriority> {
+    // Try integer first (new format), then string (legacy).
+    if let Ok(int_val) = input.trim().parse::<u8>() {
+        return NotificationPriority::from_int(int_val);
+    }
     match input.trim().to_ascii_lowercase().as_str() {
         "low" => Some(NotificationPriority::Low),
         "normal" => Some(NotificationPriority::Normal),

--- a/rust-srec/src/database/models/notification.rs
+++ b/rust-srec/src/database/models/notification.rs
@@ -36,6 +36,7 @@ impl NotificationChannelDbModel {
 pub enum ChannelType {
     Discord,
     Email,
+    Gotify,
     Telegram,
     Webhook,
 }
@@ -45,6 +46,7 @@ impl ChannelType {
         match self {
             Self::Discord => "Discord",
             Self::Email => "Email",
+            Self::Gotify => "Gotify",
             Self::Telegram => "Telegram",
             Self::Webhook => "Webhook",
         }
@@ -54,6 +56,7 @@ impl ChannelType {
         match s.trim().to_ascii_lowercase().as_str() {
             "discord" => Some(Self::Discord),
             "email" => Some(Self::Email),
+            "gotify" => Some(Self::Gotify),
             "telegram" => Some(Self::Telegram),
             "webhook" => Some(Self::Webhook),
             _ => None,
@@ -95,6 +98,19 @@ pub struct EmailChannelSettings {
     pub to_addresses: Vec<String>,
     #[serde(default)]
     pub use_tls: bool,
+}
+
+/// Gotify channel settings.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GotifyChannelSettings {
+    pub server_url: String,
+    pub app_token: String,
+    #[serde(default = "default_gotify_timeout")]
+    pub timeout_secs: u64,
+}
+
+fn default_gotify_timeout() -> u64 {
+    30
 }
 
 /// Webhook channel settings.
@@ -177,7 +193,7 @@ impl NotificationDeadLetterDbModel {
 pub struct NotificationEventLogDbModel {
     pub id: String,
     pub event_type: String,
-    pub priority: String,
+    pub priority: i32,
     /// JSON blob of the event payload
     pub payload: String,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -196,8 +212,8 @@ pub struct WebPushSubscriptionDbModel {
     pub endpoint: String,
     pub p256dh: String,
     pub auth: String,
-    /// Minimum priority to send (low|normal|high|critical).
-    pub min_priority: String,
+    /// Minimum priority to send (integer, Gotify-compatible 0-10 scale).
+    pub min_priority: i32,
     pub created_at: i64,
     pub updated_at: i64,
     /// Optional next allowed attempt time. When set and in the future, delivery is skipped.

--- a/rust-srec/src/database/repositories/notification.rs
+++ b/rust-srec/src/database/repositories/notification.rs
@@ -282,7 +282,7 @@ impl NotificationRepository for SqlxNotificationRepository {
         )
         .bind(&entry.id)
         .bind(&entry.event_type)
-        .bind(&entry.priority)
+        .bind(entry.priority)
         .bind(&entry.payload)
         .bind(&entry.streamer_id)
         .bind(entry.created_at)
@@ -320,16 +320,7 @@ impl NotificationRepository for SqlxNotificationRepository {
         }
 
         if priority.is_some() {
-            // Map priority to numeric value for >= comparison
-            // low=0, normal=1, high=2, critical=3
-            conditions.push(
-                "CASE LOWER(nel.priority) \
-                 WHEN 'low' THEN 0 \
-                 WHEN 'normal' THEN 1 \
-                 WHEN 'high' THEN 2 \
-                 WHEN 'critical' THEN 3 \
-                 ELSE 0 END >= ?",
-            );
+            conditions.push("nel.priority >= ?");
         }
 
         if !conditions.is_empty() {
@@ -353,12 +344,17 @@ impl NotificationRepository for SqlxNotificationRepository {
             query = query.bind(sid);
         }
         if let Some(p) = priority {
-            let priority_value = match p.to_ascii_lowercase().as_str() {
-                "low" => 0,
-                "normal" => 1,
-                "high" => 2,
-                "critical" => 3,
-                _ => 0,
+            // Accept both integer (new format) and string (legacy format).
+            let priority_value: i32 = if let Ok(int_val) = p.parse::<i32>() {
+                int_val
+            } else {
+                match p.trim() {
+                    s if s.eq_ignore_ascii_case("low") => 2,
+                    s if s.eq_ignore_ascii_case("normal") => 5,
+                    s if s.eq_ignore_ascii_case("high") => 8,
+                    s if s.eq_ignore_ascii_case("critical") => 10,
+                    _ => 2,
+                }
             };
             query = query.bind(priority_value);
         }

--- a/rust-srec/src/notification/channels/gotify.rs
+++ b/rust-srec/src/notification/channels/gotify.rs
@@ -1,0 +1,217 @@
+//! Gotify notification channel.
+//!
+//! Sends messages via the Gotify REST API (`POST /message?token=<app_token>`).
+
+use async_trait::async_trait;
+use reqwest::Client;
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use tracing::{debug, warn};
+
+use super::NotificationChannel;
+use crate::Result;
+use crate::notification::events::{NotificationEvent, NotificationPriority};
+
+/// Gotify channel configuration.
+#[derive(Clone, Serialize, Deserialize)]
+pub struct GotifyConfig {
+    /// Stable channel instance identifier (recommended).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    /// Optional display name for this channel instance.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    /// Whether the channel is enabled.
+    pub enabled: bool,
+    /// Gotify server base URL (e.g. `https://gotify.example.com`).
+    pub server_url: String,
+    /// Gotify application token.
+    pub app_token: String,
+    /// Minimum priority level to send (default: Normal).
+    #[serde(default)]
+    pub min_priority: NotificationPriority,
+    /// Request timeout in seconds.
+    #[serde(default = "default_timeout")]
+    pub timeout_secs: u64,
+}
+
+impl std::fmt::Debug for GotifyConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("GotifyConfig")
+            .field("id", &self.id)
+            .field("name", &self.name)
+            .field("enabled", &self.enabled)
+            .field("server_url", &self.server_url)
+            .field("app_token", &"[REDACTED]")
+            .field("min_priority", &self.min_priority)
+            .field("timeout_secs", &self.timeout_secs)
+            .finish()
+    }
+}
+
+fn default_timeout() -> u64 {
+    30
+}
+
+impl Default for GotifyConfig {
+    fn default() -> Self {
+        Self {
+            id: None,
+            name: None,
+            enabled: false,
+            server_url: String::new(),
+            app_token: String::new(),
+            min_priority: NotificationPriority::Normal,
+            timeout_secs: default_timeout(),
+        }
+    }
+}
+
+/// Gotify notification channel.
+pub struct GotifyChannel {
+    config: GotifyConfig,
+    client: Client,
+    /// Pre-computed message endpoint (without token query param).
+    message_url: String,
+}
+
+impl GotifyChannel {
+    /// Create a new Gotify channel.
+    pub fn new(config: GotifyConfig) -> Self {
+        crate::utils::http_client::install_rustls_provider();
+        let message_url = format!("{}/message", config.server_url.trim_end_matches('/'));
+        let client = Client::builder()
+            .timeout(std::time::Duration::from_secs(config.timeout_secs))
+            .build()
+            .unwrap_or_default();
+        Self {
+            config,
+            client,
+            message_url,
+        }
+    }
+
+    /// Build the Gotify message payload.
+    fn build_payload(&self, event: &NotificationEvent) -> serde_json::Value {
+        json!({
+            "title": event.title(),
+            "message": event.description(),
+            "priority": event.priority().as_int(),
+        })
+    }
+}
+
+#[async_trait]
+impl NotificationChannel for GotifyChannel {
+    fn channel_type(&self) -> &'static str {
+        "gotify"
+    }
+
+    fn is_enabled(&self) -> bool {
+        self.config.enabled
+            && !self.config.server_url.is_empty()
+            && !self.config.app_token.is_empty()
+    }
+
+    async fn send(&self, event: &NotificationEvent) -> Result<()> {
+        if !self.is_enabled() {
+            return Ok(());
+        }
+
+        // Check priority filter
+        if event.priority() < self.config.min_priority {
+            debug!(
+                "Skipping Gotify notification for {} (priority {} < {})",
+                event.event_type(),
+                event.priority(),
+                self.config.min_priority
+            );
+            return Ok(());
+        }
+
+        let payload = self.build_payload(event);
+
+        let response = self
+            .client
+            .post(&self.message_url)
+            .query(&[("token", &self.config.app_token)])
+            .json(&payload)
+            .send()
+            .await
+            .map_err(|e| crate::Error::Other(format!("Gotify request failed: {}", e)))?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            warn!("Gotify request failed: {} - {}", status, body);
+            return Err(crate::Error::Other(format!(
+                "Gotify request failed: {} - {}",
+                status, body
+            )));
+        }
+
+        debug!("Gotify notification sent: {}", event.event_type());
+        Ok(())
+    }
+
+    async fn test(&self) -> Result<()> {
+        let test_event = NotificationEvent::SystemStartup {
+            version: "test".to_string(),
+            timestamp: chrono::Utc::now(),
+        };
+        self.send(&test_event).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_gotify_config_default() {
+        let config = GotifyConfig::default();
+        assert!(!config.enabled);
+        assert!(config.server_url.is_empty());
+        assert!(config.app_token.is_empty());
+        assert_eq!(config.priority, 5);
+        assert_eq!(config.min_priority, NotificationPriority::Normal);
+    }
+
+    #[test]
+    fn test_gotify_channel_disabled() {
+        let config = GotifyConfig::default();
+        let channel = GotifyChannel::new(config);
+        assert!(!channel.is_enabled());
+    }
+
+    #[test]
+    fn test_gotify_channel_enabled() {
+        let config = GotifyConfig {
+            enabled: true,
+            server_url: "https://gotify.example.com".to_string(),
+            app_token: "test-token".to_string(),
+            ..Default::default()
+        };
+        let channel = GotifyChannel::new(config);
+        assert!(channel.is_enabled());
+    }
+
+    #[test]
+    fn test_build_payload() {
+        let config = GotifyConfig::default();
+        let channel = GotifyChannel::new(config);
+
+        let event = NotificationEvent::StreamOnline {
+            streamer_id: "123".to_string(),
+            streamer_name: "TestStreamer".to_string(),
+            title: "Playing Games".to_string(),
+            category: Some("Gaming".to_string()),
+            timestamp: chrono::Utc::now(),
+        };
+
+        let payload = channel.build_payload(&event);
+        assert!(payload["title"].as_str().is_some());
+        assert!(payload["message"].as_str().is_some());
+        assert_eq!(payload["priority"], 5); // Normal = 5
+    }
+}

--- a/rust-srec/src/notification/channels/gotify.rs
+++ b/rust-srec/src/notification/channels/gotify.rs
@@ -173,8 +173,8 @@ mod tests {
         assert!(!config.enabled);
         assert!(config.server_url.is_empty());
         assert!(config.app_token.is_empty());
-        assert_eq!(config.priority, 5);
         assert_eq!(config.min_priority, NotificationPriority::Normal);
+        assert_eq!(config.timeout_secs, 30);
     }
 
     #[test]

--- a/rust-srec/src/notification/channels/mod.rs
+++ b/rust-srec/src/notification/channels/mod.rs
@@ -8,11 +8,13 @@
 
 mod discord;
 mod email;
+mod gotify;
 mod telegram;
 mod webhook;
 
 pub use discord::{DiscordChannel, DiscordConfig};
 pub use email::{EmailChannel, EmailConfig};
+pub use gotify::{GotifyChannel, GotifyConfig};
 pub use telegram::{TelegramChannel, TelegramConfig};
 pub use webhook::{WebhookAuth, WebhookChannel, WebhookConfig};
 
@@ -46,6 +48,8 @@ pub enum ChannelConfig {
     Discord(DiscordConfig),
     /// Email channel.
     Email(EmailConfig),
+    /// Gotify push notification channel.
+    Gotify(GotifyConfig),
     /// Telegram Bot API channel.
     Telegram(TelegramConfig),
     /// Generic webhook channel.
@@ -58,6 +62,7 @@ impl ChannelConfig {
         match self {
             Self::Discord(_) => "discord",
             Self::Email(_) => "email",
+            Self::Gotify(_) => "gotify",
             Self::Telegram(_) => "telegram",
             Self::Webhook(_) => "webhook",
         }
@@ -68,6 +73,7 @@ impl ChannelConfig {
         match self {
             Self::Discord(c) => c.enabled,
             Self::Email(c) => c.enabled,
+            Self::Gotify(c) => c.enabled,
             Self::Telegram(c) => c.enabled,
             Self::Webhook(c) => c.enabled,
         }
@@ -78,6 +84,7 @@ impl ChannelConfig {
         match self {
             Self::Discord(c) => c.id.as_deref(),
             Self::Email(c) => c.id.as_deref(),
+            Self::Gotify(c) => c.id.as_deref(),
             Self::Telegram(c) => c.id.as_deref(),
             Self::Webhook(c) => c.id.as_deref(),
         }
@@ -88,6 +95,7 @@ impl ChannelConfig {
         match self {
             Self::Discord(c) => c.name.as_deref(),
             Self::Email(c) => c.name.as_deref(),
+            Self::Gotify(c) => c.name.as_deref(),
             Self::Telegram(c) => c.name.as_deref(),
             Self::Webhook(c) => c.name.as_deref(),
         }

--- a/rust-srec/src/notification/channels/webhook.rs
+++ b/rust-srec/src/notification/channels/webhook.rs
@@ -139,7 +139,8 @@ impl WebhookChannel {
     fn build_payload(&self, event: &NotificationEvent) -> serde_json::Value {
         json!({
             "event_type": event.event_type(),
-            "priority": event.priority().to_string(),
+            "priority": event.priority().as_int(),
+            "priority_label": event.priority().to_string(),
             "title": event.title(),
             "description": event.description(),
             "timestamp": event.timestamp().to_rfc3339(),
@@ -255,6 +256,8 @@ mod tests {
         let payload = channel.build_payload(&event);
         assert_eq!(payload["event_type"], "stream_online");
         assert_eq!(payload["streamer_id"], "123");
+        assert_eq!(payload["priority"], 5); // Normal = 5 (integer)
+        assert_eq!(payload["priority_label"], "normal");
     }
 
     #[test]

--- a/rust-srec/src/notification/events.rs
+++ b/rust-srec/src/notification/events.rs
@@ -14,7 +14,7 @@ pub struct NotificationEventTypeInfo {
     pub event_type: &'static str,
     /// Human-friendly label.
     pub label: &'static str,
-    /// Default priority level.
+    /// Default priority level (integer, Gotify-compatible 0-10 scale).
     pub priority: NotificationPriority,
     /// Additional accepted subscription keys (legacy / aliases).
     pub aliases: &'static [&'static str],
@@ -245,20 +245,12 @@ fn normalize_subscription_key(input: &str) -> String {
 }
 
 /// Priority level for notifications.
-#[derive(
-    Debug,
-    Clone,
-    Copy,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Hash,
-    Serialize,
-    Deserialize,
-    Default,
-    utoipa::ToSchema,
-)]
+///
+/// Serializes as an integer (Gotify-compatible 0-10 scale):
+/// Low = 2, Normal = 5, High = 8, Critical = 10.
+///
+/// Deserializes from either an integer or a string label (backward compat).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 pub enum NotificationPriority {
     /// Low priority - informational only.
     Low,
@@ -269,6 +261,99 @@ pub enum NotificationPriority {
     High,
     /// Critical priority - requires immediate attention.
     Critical,
+}
+
+impl utoipa::PartialSchema for NotificationPriority {
+    fn schema() -> utoipa::openapi::RefOr<utoipa::openapi::schema::Schema> {
+        use utoipa::openapi::schema::{Object, SchemaType, Type};
+        Object::builder()
+            .schema_type(SchemaType::Type(Type::Integer))
+            .description(Some(
+                "Priority level (integer, 0-10 scale): 2=Low, 5=Normal, 8=High, 10=Critical",
+            ))
+            .enum_values(Some([2i32, 5, 8, 10]))
+            .build()
+            .into()
+    }
+}
+
+impl utoipa::ToSchema for NotificationPriority {}
+
+impl Serialize for NotificationPriority {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_u8(self.as_int())
+    }
+}
+
+impl<'de> Deserialize<'de> for NotificationPriority {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        use serde::de;
+
+        struct PriorityVisitor;
+
+        impl<'de> de::Visitor<'de> for PriorityVisitor {
+            type Value = NotificationPriority;
+
+            fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+                f.write_str("an integer (0-10) or a string (low/normal/high/critical)")
+            }
+
+            fn visit_u64<E: de::Error>(self, value: u64) -> Result<Self::Value, E> {
+                let val = u8::try_from(value).map_err(|_| {
+                    de::Error::invalid_value(de::Unexpected::Unsigned(value), &self)
+                })?;
+                NotificationPriority::from_int(val)
+                    .ok_or_else(|| de::Error::invalid_value(de::Unexpected::Unsigned(value), &self))
+            }
+
+            fn visit_i64<E: de::Error>(self, value: i64) -> Result<Self::Value, E> {
+                let val = u8::try_from(value)
+                    .map_err(|_| de::Error::invalid_value(de::Unexpected::Signed(value), &self))?;
+                NotificationPriority::from_int(val)
+                    .ok_or_else(|| de::Error::invalid_value(de::Unexpected::Signed(value), &self))
+            }
+
+            fn visit_str<E: de::Error>(self, value: &str) -> Result<Self::Value, E> {
+                match value.trim().to_ascii_lowercase().as_str() {
+                    "low" => Ok(NotificationPriority::Low),
+                    "normal" => Ok(NotificationPriority::Normal),
+                    "high" => Ok(NotificationPriority::High),
+                    "critical" => Ok(NotificationPriority::Critical),
+                    _ => Err(de::Error::unknown_variant(
+                        value,
+                        &["low", "normal", "high", "critical"],
+                    )),
+                }
+            }
+        }
+
+        deserializer.deserialize_any(PriorityVisitor)
+    }
+}
+
+impl NotificationPriority {
+    /// Integer representation aligned with Gotify's 0-10 priority scale.
+    pub fn as_int(&self) -> u8 {
+        match self {
+            Self::Low => 2,
+            Self::Normal => 5,
+            Self::High => 8,
+            Self::Critical => 10,
+        }
+    }
+
+    /// Parse from integer value.
+    ///
+    /// Maps ranges to the closest priority level:
+    /// 0-3 → Low, 4-6 → Normal, 7-9 → High, 10+ → Critical
+    pub fn from_int(value: u8) -> Option<Self> {
+        match value {
+            0..=3 => Some(Self::Low),
+            4..=6 => Some(Self::Normal),
+            7..=9 => Some(Self::High),
+            10..=u8::MAX => Some(Self::Critical),
+        }
+    }
 }
 
 impl std::fmt::Display for NotificationPriority {
@@ -864,6 +949,66 @@ mod tests {
     fn test_notification_priority_display() {
         assert_eq!(NotificationPriority::Low.to_string(), "low");
         assert_eq!(NotificationPriority::Critical.to_string(), "critical");
+    }
+
+    #[test]
+    fn test_notification_priority_as_int() {
+        assert_eq!(NotificationPriority::Low.as_int(), 2);
+        assert_eq!(NotificationPriority::Normal.as_int(), 5);
+        assert_eq!(NotificationPriority::High.as_int(), 8);
+        assert_eq!(NotificationPriority::Critical.as_int(), 10);
+    }
+
+    #[test]
+    fn test_notification_priority_from_int() {
+        assert_eq!(
+            NotificationPriority::from_int(0),
+            Some(NotificationPriority::Low)
+        );
+        assert_eq!(
+            NotificationPriority::from_int(2),
+            Some(NotificationPriority::Low)
+        );
+        assert_eq!(
+            NotificationPriority::from_int(3),
+            Some(NotificationPriority::Low)
+        );
+        assert_eq!(
+            NotificationPriority::from_int(4),
+            Some(NotificationPriority::Normal)
+        );
+        assert_eq!(
+            NotificationPriority::from_int(5),
+            Some(NotificationPriority::Normal)
+        );
+        assert_eq!(
+            NotificationPriority::from_int(7),
+            Some(NotificationPriority::High)
+        );
+        assert_eq!(
+            NotificationPriority::from_int(8),
+            Some(NotificationPriority::High)
+        );
+        assert_eq!(
+            NotificationPriority::from_int(10),
+            Some(NotificationPriority::Critical)
+        );
+        assert_eq!(
+            NotificationPriority::from_int(255),
+            Some(NotificationPriority::Critical)
+        );
+    }
+
+    #[test]
+    fn test_notification_priority_int_roundtrip() {
+        for p in [
+            NotificationPriority::Low,
+            NotificationPriority::Normal,
+            NotificationPriority::High,
+            NotificationPriority::Critical,
+        ] {
+            assert_eq!(NotificationPriority::from_int(p.as_int()), Some(p));
+        }
     }
 
     #[test]

--- a/rust-srec/src/notification/service.rs
+++ b/rust-srec/src/notification/service.rs
@@ -28,17 +28,17 @@ use tracing::{debug, info, warn};
 use uuid::Uuid;
 
 use super::channels::{
-    ChannelConfig, DiscordChannel, EmailChannel, NotificationChannel, TelegramChannel,
-    WebhookChannel,
+    ChannelConfig, DiscordChannel, EmailChannel, GotifyChannel, NotificationChannel,
+    TelegramChannel, WebhookChannel,
 };
 use super::events::canonicalize_subscription_event_name;
 use super::events::{NotificationEvent, NotificationPriority};
 use super::web_push::WebPushService;
 use crate::Result;
 use crate::database::models::{
-    ChannelType, DiscordChannelSettings, EmailChannelSettings, NotificationChannelDbModel,
-    NotificationDeadLetterDbModel, NotificationEventLogDbModel, TelegramChannelSettings,
-    WebhookChannelSettings,
+    ChannelType, DiscordChannelSettings, EmailChannelSettings, GotifyChannelSettings,
+    NotificationChannelDbModel, NotificationDeadLetterDbModel, NotificationEventLogDbModel,
+    TelegramChannelSettings, WebhookChannelSettings,
 };
 use crate::database::repositories::NotificationRepository;
 use crate::downloader::DownloadManagerEvent;
@@ -447,6 +447,7 @@ impl NotificationService {
             let channel: Arc<dyn NotificationChannel> = match channel_config {
                 ChannelConfig::Discord(c) => Arc::new(DiscordChannel::new(c.clone())),
                 ChannelConfig::Email(c) => Arc::new(EmailChannel::new(c.clone())),
+                ChannelConfig::Gotify(c) => Arc::new(GotifyChannel::new(c.clone())),
                 ChannelConfig::Telegram(c) => Arc::new(TelegramChannel::new(c.clone())),
                 ChannelConfig::Webhook(c) => Arc::new(WebhookChannel::new(c.clone())),
             };
@@ -509,6 +510,7 @@ impl NotificationService {
         let channel: Arc<dyn NotificationChannel> = match &config {
             ChannelConfig::Discord(c) => Arc::new(DiscordChannel::new(c.clone())),
             ChannelConfig::Email(c) => Arc::new(EmailChannel::new(c.clone())),
+            ChannelConfig::Gotify(c) => Arc::new(GotifyChannel::new(c.clone())),
             ChannelConfig::Telegram(c) => Arc::new(TelegramChannel::new(c.clone())),
             ChannelConfig::Webhook(c) => Arc::new(WebhookChannel::new(c.clone())),
         };
@@ -666,8 +668,14 @@ impl NotificationService {
 
         let min_priority = settings_json
             .get("min_priority")
-            .and_then(|v| v.as_str())
-            .and_then(parse_notification_priority)
+            .and_then(|v| {
+                // Accept integer (new format) or string (legacy format).
+                if let Some(n) = v.as_u64() {
+                    NotificationPriority::from_int(n as u8)
+                } else {
+                    v.as_str().and_then(parse_notification_priority)
+                }
+            })
             .unwrap_or(NotificationPriority::Normal);
 
         let runtime_channel: Arc<dyn NotificationChannel> = match channel_type {
@@ -766,6 +774,19 @@ impl NotificationService {
                     auth,
                     min_priority,
                     timeout_secs: settings.timeout_secs.unwrap_or(30),
+                }))
+            }
+            ChannelType::Gotify => {
+                let settings: GotifyChannelSettings =
+                    serde_json::from_value(settings_json.clone())?;
+                Arc::new(GotifyChannel::new(super::channels::GotifyConfig {
+                    id: None,
+                    name: None,
+                    enabled: true,
+                    server_url: settings.server_url,
+                    app_token: settings.app_token,
+                    min_priority,
+                    timeout_secs: settings.timeout_secs,
                 }))
             }
         };
@@ -912,7 +933,7 @@ impl NotificationService {
             let entry = NotificationEventLogDbModel {
                 id: event_log_id.clone(),
                 event_type: event.event_type().to_string(),
-                priority: event.priority().to_string(),
+                priority: event.priority().as_int() as i32,
                 payload: serde_json::to_string(&event).unwrap_or_else(|_| "{}".to_string()),
                 streamer_id: event.streamer_id().map(|s| s.to_string()),
                 created_at: event.timestamp().timestamp_millis(),
@@ -1803,6 +1824,11 @@ impl NotificationService {
 }
 
 fn parse_notification_priority(value: &str) -> Option<NotificationPriority> {
+    // Try parsing as integer first (new format).
+    if let Ok(int_val) = value.trim().parse::<u8>() {
+        return NotificationPriority::from_int(int_val);
+    }
+    // Fall back to string labels (legacy format).
     match value.trim().to_ascii_lowercase().as_str() {
         "low" => Some(NotificationPriority::Low),
         "normal" => Some(NotificationPriority::Normal),

--- a/rust-srec/src/notification/web_push.rs
+++ b/rust-srec/src/notification/web_push.rs
@@ -158,7 +158,7 @@ impl WebPushService {
     ) -> Result<WebPushSubscriptionDbModel> {
         let id = uuid::Uuid::new_v4().to_string();
         let now = Utc::now().timestamp_millis();
-        let min_priority = min_priority.to_string();
+        let min_priority = min_priority.as_int() as i32;
 
         sqlx::query(
             r#"
@@ -178,7 +178,7 @@ impl WebPushService {
         .bind(endpoint)
         .bind(p256dh)
         .bind(auth)
-        .bind(&min_priority)
+        .bind(min_priority)
         .bind(now)
         .bind(now)
         .execute(&self.write_pool)
@@ -279,8 +279,10 @@ impl WebPushService {
                         return;
                     }
 
-                    let min_priority =
-                        parse_priority(&sub.min_priority).unwrap_or(NotificationPriority::Critical);
+                    let min_priority = u8::try_from(sub.min_priority)
+                        .ok()
+                        .and_then(NotificationPriority::from_int)
+                        .unwrap_or(NotificationPriority::Critical);
                     if priority < min_priority {
                         return;
                     }
@@ -494,7 +496,7 @@ struct WebPushPayload {
     body: String,
     url: String,
     event_type: String,
-    priority: String,
+    priority: u8,
     created_at: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     event_log_id: Option<String>,
@@ -507,7 +509,7 @@ impl WebPushPayload {
             body: event.description(),
             url: "/notifications/events".to_string(),
             event_type: event.event_type().to_string(),
-            priority: event.priority().to_string(),
+            priority: event.priority().as_int(),
             created_at: event.timestamp().to_rfc3339(),
             event_log_id: event_log_id.map(|s| s.to_string()),
         }
@@ -536,16 +538,6 @@ impl WebPushPayload {
         let bytes = serde_json::to_vec(&minimal)
             .map_err(|e| Error::Other(format!("Failed to serialize web push payload: {}", e)))?;
         Ok(bytes)
-    }
-}
-
-fn parse_priority(input: &str) -> Option<NotificationPriority> {
-    match input.trim().to_ascii_lowercase().as_str() {
-        "low" => Some(NotificationPriority::Low),
-        "normal" => Some(NotificationPriority::Normal),
-        "high" => Some(NotificationPriority::High),
-        "critical" => Some(NotificationPriority::Critical),
-        _ => None,
     }
 }
 


### PR DESCRIPTION
## Summary

- Add dedicated **Gotify notification channel** with proper API format (`POST /message?token=`), configurable timeout, URL-safe token encoding, and redacted Debug impl
- **Migrate entire priority system** from string-based (`"low"`/`"normal"`/`"high"`/`"critical"`) to integer-based (Gotify-compatible 0-10 scale: Low=2, Normal=5, High=8, Critical=10) across backend, DB, API, frontend, and Tauri desktop
- **Refactor webhook payload** to send `"priority"` as integer + `"priority_label"` as string, fixing Gotify 400 Bad Request when using generic webhooks
- All API endpoints accept both integer and legacy string formats for backward compatibility

### Backend
- `NotificationPriority` custom Serialize (u8) / Deserialize (int or string)
- DB migration converting `notification_event_log.priority` and `web_push_subscription.min_priority` from TEXT to INTEGER
- Simplified repository SQL (direct integer comparison replaces CASE statements)
- Safe integer casts with `u8::try_from()` bounds checking
- Correct OpenAPI schema documenting integer priority values

### Frontend
- Shared `priority.ts` utility with constants, labels, and pre-computed options
- Gotify channel form, card display, and type selector
- All `min_priority` selectors migrated from string enums to integers
- Desktop notification schema accepts both int and legacy string configs

### Tauri
- `DesktopNotificationMinPriority` serializes as integer with backward-compatible string deserialization

## Test plan
- [ ] Create a Gotify channel via UI, verify settings are saved and loaded correctly
- [ ] Send a test notification to Gotify, verify it arrives with correct priority
- [ ] Create/edit Webhook, Telegram channels — verify integer min_priority persists
- [ ] Check notification events page — priority badges display correctly
- [ ] Verify existing web push subscriptions still work after migration
- [ ] Desktop app: verify notification config loads (both fresh and existing users with old string config)
- [ ] API: send `min_priority` as both integer and string to web push subscribe endpoint