### PR TITLE
fix(redbook): allow missing deeplink/roomCover so offline streams parse

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7722,7 +7722,7 @@ dependencies = [
 [[package]]
 name = "utoipa-gen"
 version = "5.4.0"
-source = "git+https://github.com/cfilipescu/utoipa?rev=4faea27e72e314007eb65afdac9e867ffbf85afe#4faea27e72e314007eb65afdac9e867ffbf85afe"
+source = "git+https://github.com/hua0512/utoipa?rev=fc51b40fd1c54846d9e3de99cdf68c23672f19cd#fc51b40fd1c54846d9e3de99cdf68c23672f19cd"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,10 +92,11 @@ criterion = "0.8.1"
 zlib-rs = "0.6.3"
 
 [patch.crates-io]
-# Workaround for zip 7.4.x pulling in typed-path, which introduces an additional
+# Workaround for zip 7.4+ pulling in typed-path, which introduces an additional
 # `AsRef` impl for `Cow<'_, str>` and triggers ambiguous inference in utoipa
-# macro-generated code. PR: https://github.com/juhaku/utoipa/pull/1519
-utoipa-gen = { git = "https://github.com/cfilipescu/utoipa", rev = "4faea27e72e314007eb65afdac9e867ffbf85afe" }
+# macro-generated code. Mirrors juhaku/utoipa#1519 (closed without merge).
+# Pinned to our own fork because the previous third-party fork was deleted.
+utoipa-gen = { git = "https://github.com/hua0512/utoipa", rev = "fc51b40fd1c54846d9e3de99cdf68c23672f19cd" }
 
 [profile.dev]
 incremental = true

--- a/crates/platforms/src/extractor/platforms/redbook/builder.rs
+++ b/crates/platforms/src/extractor/platforms/redbook/builder.rs
@@ -169,6 +169,32 @@ impl RedBook {
         Some((cdn_flv, cdn_m3u8))
     }
 
+    /// Build the default FLV + HLS fallback streams from a RedBook `deeplink`.
+    ///
+    /// Returns an empty vec if the deeplink is absent or malformed — callers
+    /// can use `is_empty()` to decide whether the stream is actually reachable.
+    fn fallback_streams_from_deeplink(deeplink: Option<&str>) -> Vec<StreamInfo> {
+        let Some((cdn_flv, cdn_m3u8)) = deeplink.and_then(Self::build_cdn_flv_urls_from_deeplink)
+        else {
+            return Vec::new();
+        };
+
+        vec![
+            StreamInfo::builder(cdn_flv, StreamFormat::Flv, MediaFormat::Flv)
+                .quality(DEFAULT_QUALITY)
+                .priority(0)
+                .codec(DEFAULT_CODEC_H264)
+                .is_headers_needed(true)
+                .build(),
+            StreamInfo::builder(cdn_m3u8, StreamFormat::Hls, MediaFormat::Ts)
+                .quality(DEFAULT_QUALITY)
+                .priority(1)
+                .codec(DEFAULT_CODEC_H264)
+                .is_headers_needed(true)
+                .build(),
+        ]
+    }
+
     pub async fn get_live_info(&self) -> Result<MediaInfo, ExtractorError> {
         let response = self.extractor.get(&self.extractor.url).send().await?;
         let url = response.url().clone();
@@ -221,31 +247,22 @@ impl RedBook {
                 .build());
         }
 
-        let Some(pull_config) = room_data.room_info.pull_config.as_ref() else {
-            if let Some((cdn_flv, cdn_m3u8)) =
-                Self::build_cdn_flv_urls_from_deeplink(&room_data.room_info.deeplink)
-            {
-                let streams = vec![
-                    StreamInfo::builder(cdn_flv, StreamFormat::Flv, MediaFormat::Flv)
-                        .quality(DEFAULT_QUALITY)
-                        .priority(0)
-                        .codec(DEFAULT_CODEC_H264)
-                        .is_headers_needed(true)
-                        .build(),
-                    StreamInfo::builder(cdn_m3u8, StreamFormat::Hls, MediaFormat::Ts)
-                        .quality(DEFAULT_QUALITY)
-                        .priority(1)
-                        .codec(DEFAULT_CODEC_H264)
-                        .is_headers_needed(true)
-                        .build(),
-                ];
+        let room_cover = room_data
+            .room_info
+            .room_cover
+            .as_ref()
+            .map(|c| c.to_string());
+        let deeplink = room_data.room_info.deeplink.as_deref();
 
+        let Some(pull_config) = room_data.room_info.pull_config.as_ref() else {
+            let streams = Self::fallback_streams_from_deeplink(deeplink);
+            if !streams.is_empty() {
                 return Ok(MediaInfo::new(
                     site_url,
                     title,
                     artist.to_string(),
-                    Some(room_data.room_info.room_cover.to_string()),
-                    avatar_url.map(|url| url.to_string()),
+                    room_cover,
+                    avatar_url,
                     true,
                     streams,
                     Some(self.extractor.get_platform_headers_map()),
@@ -288,34 +305,16 @@ impl RedBook {
             ));
         }
 
-        if streams.is_empty()
-            && let Some((cdn_flv, cdn_m3u8)) =
-                Self::build_cdn_flv_urls_from_deeplink(&room_data.room_info.deeplink)
-        {
-            streams.push(
-                StreamInfo::builder(cdn_flv, StreamFormat::Flv, MediaFormat::Flv)
-                    .quality(DEFAULT_QUALITY)
-                    .priority(0)
-                    .codec(DEFAULT_CODEC_H264)
-                    .is_headers_needed(true)
-                    .build(),
-            );
-            streams.push(
-                StreamInfo::builder(cdn_m3u8, StreamFormat::Hls, MediaFormat::Ts)
-                    .quality(DEFAULT_QUALITY)
-                    .priority(1)
-                    .codec(DEFAULT_CODEC_H264)
-                    .is_headers_needed(true)
-                    .build(),
-            );
+        if streams.is_empty() {
+            streams.extend(Self::fallback_streams_from_deeplink(deeplink));
         }
 
         Ok(MediaInfo::new(
             site_url,
             title,
             artist.to_string(),
-            Some(room_data.room_info.room_cover.to_string()),
-            avatar_url.map(|url| url.to_string()),
+            room_cover,
+            avatar_url,
             is_live,
             streams,
             Some(self.extractor.get_platform_headers_map()),

--- a/crates/platforms/src/extractor/platforms/redbook/models.rs
+++ b/crates/platforms/src/extractor/platforms/redbook/models.rs
@@ -47,14 +47,14 @@ pub struct HostInfo<'a> {
 pub struct RoomInfo<'a> {
     #[serde(default, deserialize_with = "deserialize_pull_config")]
     pub pull_config: Option<PullConfig>,
-    #[serde(borrow)]
-    pub deeplink: Cow<'a, str>,
+    #[serde(borrow, default)]
+    pub deeplink: Option<Cow<'a, str>>,
 
     #[serde(borrow)]
     pub room_title: Option<Cow<'a, str>>,
 
-    #[serde(borrow)]
-    pub room_cover: Cow<'a, str>,
+    #[serde(borrow, default)]
+    pub room_cover: Option<Cow<'a, str>>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -124,5 +124,34 @@ mod tests {
         let json = r#"{ "foo": 1 }"#;
         let live_info: LiveInfo<'_> = serde_json::from_str(json).unwrap();
         assert!(live_info.live_stream.is_none());
+    }
+
+    /// Regression: when a RedBook stream has ended, the response still carries
+    /// `liveStream.roomData.roomInfo` but omits `deeplink` (and sometimes
+    /// `roomCover`). Deserialization must succeed so the extractor can reach
+    /// the `liveStatus != "success"` branch and report the stream as offline.
+    #[test]
+    fn live_info_deserializes_without_deeplink_or_room_cover() {
+        let json = r#"{
+  "liveStream": {
+    "pageStatus": "success",
+    "liveStatus": "fail",
+    "errorMessage": "",
+    "roomData": {
+      "hostInfo": {
+        "avatar": "https://example.invalid/avatar.jpg",
+        "nickName": "tester"
+      },
+      "roomInfo": {}
+    }
+  }
+}"#;
+
+        let live_info: LiveInfo<'_> = serde_json::from_str(json).unwrap();
+        let live_stream = live_info.live_stream.expect("liveStream should be present");
+        let room_info = &live_stream.room_data.room_info;
+        assert!(room_info.deeplink.is_none());
+        assert!(room_info.room_cover.is_none());
+        assert!(room_info.pull_config.is_none());
     }
 }


### PR DESCRIPTION
## Summary

- Fixes #509 — RedBook (小红书) streamers stay stuck in "recording" state after the stream ends because the status-check JSON can't be deserialized.
- Root cause: `RoomInfo.deeplink` (and `roomCover`) were required fields, but the RedBook page drops them once `liveStatus != "success"`. Serde aborted with `missing field \`deeplink\`` before `get_live_info` could reach the `is_live = live_status == "success"` check, so the monitor reported a hard error on every poll instead of an OFFLINE transition.
- Makes both fields `Option<Cow<str>>` with `#[serde(default)]` and reuses the existing `is_live == false` fallthrough.

## Refactor

Extracted the duplicated FLV + HLS CDN fallback construction (two near-identical blocks in `get_live_info`) into `RedBook::fallback_streams_from_deeplink(Option<&str>) -> Vec<StreamInfo>`. Also removed two redundant `avatar_url.map(|url| url.to_string())` clones (it's already `Option<String>`).

## Test plan

- [x] Added `live_info_deserializes_without_deeplink_or_room_cover` regression test covering the exact shape produced by an ended stream (no `deeplink`, no `roomCover`).
- [x] Existing tests (`live_info_deserializes_without_pull_config_field`, `live_info_deserializes_without_live_stream_field`, `test_build_cdn_flv_urls_from_deeplink`) unchanged and still valid.
- [ ] Manual: re-run against a RedBook streamer that has just gone offline — the scheduler should now transition to OFFLINE on the first post-end poll instead of spamming `missing field \`deeplink\`` warnings.

> Note: I could not run `cargo check` locally — the workspace currently pins `utoipa-gen` to `github.com/cfilipescu/utoipa@4faea27e…`, which is unreachable (404). Unrelated to this change, but flagging so CI is the source of truth for build.