### PR TITLE
fix(huya): invert iWebPriorityRate mapping and drop over-aggressive filter

### DIFF
--- a/crates/platforms/src/extractor/platforms/huya/builder.rs
+++ b/crates/platforms/src/extractor/platforms/huya/builder.rs
@@ -199,6 +199,16 @@ impl Huya {
         extras_get_u64(Some(extras), "default_bitrate").unwrap_or(10000)
     }
 
+    /// Map Huya's `iWebPriorityRate` (higher = better, 100 is a pin, -1 is
+    /// "disabled for this ctype") to `StreamInfo.priority` (lower = better).
+    /// Clamping makes the `-1` sentinel worst-but-valid — selection is left
+    /// to `StreamSelector` (`preferred_cdns` / `blacklisted_cdns`) rather
+    /// than filtered here, so users can opt in to a CDN Huya flagged as
+    /// deprioritised if it works for them.
+    pub(super) fn priority_from_web_rate(rate: i32) -> u32 {
+        (100 - rate.clamp(0, 100)) as u32
+    }
+
     pub(super) async fn get_room_page(&self) -> Result<String, ExtractorError> {
         let response = self.extractor.get(&self.extractor.url).send().await?;
         let response = Self::check_http_response(response).await?;

--- a/crates/platforms/src/extractor/platforms/huya/mp.rs
+++ b/crates/platforms/src/extractor/platforms/huya/mp.rs
@@ -203,12 +203,7 @@ impl Huya {
                 "default_bitrate": default_bitrate.to_string(),
             });
 
-            // skip if priority is 0
-            if stream_info.i_web_priority_rate <= 0 {
-                continue;
-            }
-
-            let priority = stream_info.i_web_priority_rate as u32;
+            let priority = Self::priority_from_web_rate(stream_info.i_web_priority_rate);
 
             // Add streams for each bitrate
             if bitrate_info_list.is_empty() {

--- a/crates/platforms/src/extractor/platforms/huya/wup.rs
+++ b/crates/platforms/src/extractor/platforms/huya/wup.rs
@@ -313,7 +313,7 @@ impl Huya {
                 "ua": ua.to_string(),
             });
 
-            let priority = stream_info.i_web_priority_rate as u32;
+            let priority = Self::priority_from_web_rate(stream_info.i_web_priority_rate);
 
             // Add streams for each bitrate
             if bitrate_info_list.is_empty() {

--- a/crates/platforms/src/media/stream_info.rs
+++ b/crates/platforms/src/media/stream_info.rs
@@ -60,6 +60,8 @@ pub struct StreamInfo {
     pub quality: String,
     // Bitrate of the stream in bits per second
     pub bitrate: u64,
+    // Selection priority: lower is better. StreamSelector sorts ascending,
+    // then ties are broken by bitrate (higher = better).
     pub priority: u32,
     pub extras: Option<serde_json::Value>,
     pub codec: String,


### PR DESCRIPTION
## Summary

- Fixes #513 — Huya CDN selection picks the CDN Huya rates *worst* as its default, and `preferred_cdns` config is effectively short-circuited because the sort leads with the wrong direction.
- Two root causes, both confirmed end-to-end against live API data and Huya's own `vplayer.js`:
  1. **Priority direction inverted.** `iWebPriorityRate` is higher=better (100 = pin, -1 = disabled-for-this-ctype). Our code mapped it straight into `StreamInfo.priority`, which `StreamSelector` sorts ascending (lower=better).
  2. **`mp.rs` `<= 0` filter too aggressive.** Drops legitimate rate-0 CDNs that Huya treats as low-weight fallbacks.

## Fix

- New `Huya::priority_from_web_rate(rate) -> (100 - rate.clamp(0, 100)) as u32` helper in `huya/builder.rs`, used by both `mp.rs` and `wup.rs`. Rate=100 → priority=0 (best); rate=0 → 100; rate=-1 → 100 (clamped, not `u32::MAX` junk).
- Drop the `<= 0` filter in `mp.rs` — selection is left to `StreamSelector`'s `preferred_cdns` / `blacklisted_cdns` config, matching the user's intent. `-1` sentinels end up as last-place priority but remain selectable.
- One-line doc comment on `StreamInfo.priority` so the next reader knows lower=better.

Diff: ~10 lines across 4 files.

## Test plan

- [x] `cargo clippy -p platforms-parser --all-targets -- -D warnings` — clean.
- [x] `cargo test -p platforms-parser --lib extractor::platforms::huya` — 11 passed, 7 ignored (network tests).
- [x] Mapping sanity: `rate=100 → priority=0`, `rate=0 → 100`, `rate=-1 → 100`, `rate=50 → 50`.
- [ ] Manual smoke on a live Huya room in WEB mode — observe the picked CDN now matches Huya's highest `iWebPriorityRate` when `preferred_cdns` is empty (room 746154 should pick HS=80, not TX=20 as before).
