### PR TITLE
refactor(errors): migrate 9 manual Error impls to thiserror

### DIFF
--- a/crates/flv-fix/src/operators/script_filter.rs
+++ b/crates/flv-fix/src/operators/script_filter.rs
@@ -269,13 +269,11 @@ mod tests {
                 FlvData::Header(_) => {
                     in_first_segment = false; // Switch to second segment after seeing second header
                 }
-                FlvData::Tag(tag) => {
-                    if tag.tag_type == FlvTagType::ScriptData {
-                        if in_first_segment {
-                            first_segment_script_count += 1;
-                        } else {
-                            second_segment_script_count += 1;
-                        }
+                FlvData::Tag(tag) if tag.tag_type == FlvTagType::ScriptData => {
+                    if in_first_segment {
+                        first_segment_script_count += 1;
+                    } else {
+                        second_segment_script_count += 1;
                     }
                 }
                 _ => {}

--- a/crates/flv-fix/src/operators/timing_repair.rs
+++ b/crates/flv-fix/src/operators/timing_repair.rs
@@ -232,21 +232,9 @@ impl TimingState {
 
         for (key, value) in props.iter() {
             match key.as_ref() {
-                "fps" => {
-                    if fps_value.is_none() {
-                        fps_value = Some(value);
-                    }
-                }
-                "framerate" => {
-                    if framerate_value.is_none() {
-                        framerate_value = Some(value);
-                    }
-                }
-                "audiosamplerate" => {
-                    if audio_rate_value.is_none() {
-                        audio_rate_value = Some(value);
-                    }
-                }
+                "fps" if fps_value.is_none() => fps_value = Some(value),
+                "framerate" if framerate_value.is_none() => framerate_value = Some(value),
+                "audiosamplerate" if audio_rate_value.is_none() => audio_rate_value = Some(value),
                 _ => {}
             }
         }

--- a/crates/flv/src/aac.rs
+++ b/crates/flv/src/aac.rs
@@ -71,15 +71,11 @@ impl AacPacket {
 
     pub(crate) fn is_stereo(&self) -> bool {
         match self {
-            AacPacket::SequenceHeader(data) => {
-                // Check if the first byte is 0xFF and the second byte is 0xF1
-                if data.len() >= 2 && data[0] == 0xFF && data[1] == 0xF1 {
-                    // Check the channel configuration in the 4th byte
-                    let channel_config = (data[3] >> 3) & 0x0F;
-                    channel_config == 2 // Stereo
-                } else {
-                    false
-                }
+            AacPacket::SequenceHeader(data)
+                if data.len() >= 2 && data[0] == 0xFF && data[1] == 0xF1 =>
+            {
+                let channel_config = (data[3] >> 3) & 0x0F;
+                channel_config == 2 // Stereo
             }
             _ => false,
         }
@@ -87,39 +83,31 @@ impl AacPacket {
 
     pub(crate) fn sample_rate(&self) -> f32 {
         match self {
-            AacPacket::SequenceHeader(data) => {
-                // Check if the first byte is 0xFF and the second byte is 0xF1
-                if data.len() >= 2 && data[0] == 0xFF && data[1] == 0xF1 {
-                    // Check the sample rate index in the 2nd byte
-                    let sample_rate_index = (data[2] >> 2) & 0x03;
-                    match sample_rate_index {
-                        0 => 96000.0,
-                        1 => 88200.0,
-                        2 => 64000.0,
-                        3 => 48000.0,
-                        _ => 44100.0, // Default to 44100 Hz
-                    }
-                } else {
-                    44100.0 // Default to 44100 Hz
+            AacPacket::SequenceHeader(data)
+                if data.len() >= 2 && data[0] == 0xFF && data[1] == 0xF1 =>
+            {
+                let sample_rate_index = (data[2] >> 2) & 0x03;
+                match sample_rate_index {
+                    0 => 96000.0,
+                    1 => 88200.0,
+                    2 => 64000.0,
+                    3 => 48000.0,
+                    _ => 44100.0,
                 }
             }
-            _ => 44100.0, // Default to 44100 Hz
+            _ => 44100.0,
         }
     }
 
     pub(crate) fn sample_size(&self) -> u32 {
         match self {
-            AacPacket::SequenceHeader(data) => {
-                // Check if the first byte is 0xFF and the second byte is 0xF1
-                if data.len() >= 2 && data[0] == 0xFF && data[1] == 0xF1 {
-                    // Check the sample size in the 3rd byte
-                    let sample_size = (data[2] >> 4) & 0x0F;
-                    sample_size as u32
-                } else {
-                    16 // Default to 16 bits
-                }
+            AacPacket::SequenceHeader(data)
+                if data.len() >= 2 && data[0] == 0xFF && data[1] == 0xF1 =>
+            {
+                let sample_size = (data[2] >> 4) & 0x0F;
+                sample_size as u32
             }
-            _ => 16, // Default to 16 bits
+            _ => 16,
         }
     }
 }

--- a/crates/mesio/src/cache/providers/file.rs
+++ b/crates/mesio/src/cache/providers/file.rs
@@ -95,7 +95,6 @@ impl FileCache {
     }
 }
 
-#[async_trait::async_trait]
 impl CacheProvider for FileCache {
     async fn contains(&self, key: &CacheKey) -> CacheResult<bool> {
         if !self.enabled {

--- a/crates/mesio/src/cache/providers/memory.rs
+++ b/crates/mesio/src/cache/providers/memory.rs
@@ -63,7 +63,6 @@ impl MemoryCache {
     }
 }
 
-#[async_trait::async_trait]
 impl CacheProvider for MemoryCache {
     async fn contains(&self, key: &CacheKey) -> CacheResult<bool> {
         Ok(self.cache.contains_key(key))

--- a/crates/mesio/src/cache/providers/provider.rs
+++ b/crates/mesio/src/cache/providers/provider.rs
@@ -2,29 +2,34 @@
 //!
 //! This module defines the cache provider trait that all cache implementations must follow.
 
-use async_trait::async_trait;
+use std::future::Future;
+
 use bytes::Bytes;
 
 use crate::cache::types::{CacheKey, CacheLookupResult, CacheMetadata, CacheResult};
 
 /// A trait for cache providers that can store and retrieve cached data
-#[async_trait]
 pub trait CacheProvider: Send + Sync {
     /// Check if the cache contains an entry for the given key
-    async fn contains(&self, key: &CacheKey) -> CacheResult<bool>;
+    fn contains(&self, key: &CacheKey) -> impl Future<Output = CacheResult<bool>> + Send;
 
     /// Get an entry from the cache
-    async fn get(&self, key: &CacheKey) -> CacheLookupResult;
+    fn get(&self, key: &CacheKey) -> impl Future<Output = CacheLookupResult> + Send;
 
     /// Put an entry into the cache
-    async fn put(&self, key: CacheKey, data: Bytes, metadata: CacheMetadata) -> CacheResult<()>;
+    fn put(
+        &self,
+        key: CacheKey,
+        data: Bytes,
+        metadata: CacheMetadata,
+    ) -> impl Future<Output = CacheResult<()>> + Send;
 
     /// Remove an entry from the cache
-    async fn remove(&self, key: &CacheKey) -> CacheResult<()>;
+    fn remove(&self, key: &CacheKey) -> impl Future<Output = CacheResult<()>> + Send;
 
     /// Clear all entries from the cache
-    async fn clear(&self) -> CacheResult<()>;
+    fn clear(&self) -> impl Future<Output = CacheResult<()>> + Send;
 
     /// Remove expired entries from the cache
-    async fn sweep(&self) -> CacheResult<()>;
+    fn sweep(&self) -> impl Future<Output = CacheResult<()>> + Send;
 }

--- a/crates/mp4/src/fragment.rs
+++ b/crates/mp4/src/fragment.rs
@@ -98,7 +98,7 @@ pub fn validate_av1_media_segment_with_track_ids_and_options(
         return Ok(Av1MediaValidationSummary::default());
     }
 
-    let track_ids_sorted = av1_track_ids.windows(2).all(|pair| pair[0] <= pair[1]);
+    let track_ids_sorted = av1_track_ids.array_windows::<2>().all(|[a, b]| a <= b);
     validate_av1_tracks_in_fragment(media_segment, av1_track_ids, track_ids_sorted, options)
 }
 

--- a/crates/pipeline-common/src/writer_task.rs
+++ b/crates/pipeline-common/src/writer_task.rs
@@ -821,14 +821,9 @@ mod tests {
     // Dummy data type for testing
     struct TestData(String);
 
-    #[derive(Debug)]
+    #[derive(Debug, thiserror::Error)]
+    #[error("TestStrategyError: {0}")]
     struct TestStrategyError(String);
-    impl std::fmt::Display for TestStrategyError {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            write!(f, "TestStrategyError: {}", self.0)
-        }
-    }
-    impl std::error::Error for TestStrategyError {}
 
     struct TestStrategy {
         item_count_to_rotate: usize,

--- a/crates/platforms/src/danmaku/websocket.rs
+++ b/crates/platforms/src/danmaku/websocket.rs
@@ -1,5 +1,6 @@
 use async_trait::async_trait;
 use futures::{SinkExt, StreamExt};
+use std::future::Future;
 use rustls::{ClientConfig, crypto::aws_lc_rs};
 use rustls_platform_verifier::BuilderVerifierExt;
 use std::collections::HashMap;
@@ -228,7 +229,6 @@ fn merge_cookie_headers(base: Option<&str>, extra: Option<&str>) -> Option<Strin
 }
 
 /// Protocol definitions for a specific platform.
-#[async_trait]
 pub trait DanmuProtocol: Send + Sync + 'static {
     /// Platform name (e.g., "huya", "bilibili")
     fn platform(&self) -> &str;
@@ -240,7 +240,7 @@ pub trait DanmuProtocol: Send + Sync + 'static {
     fn extract_room_id(&self, url: &str) -> Option<String>;
 
     /// Get the WebSocket URL for the room
-    async fn websocket_url(&self, room_id: &str) -> Result<String>;
+    fn websocket_url(&self, room_id: &str) -> impl Future<Output = Result<String>> + Send;
 
     /// Get custom headers for the WebSocket connection
     fn headers(&self, _room_id: &str) -> HeaderMap {
@@ -283,8 +283,11 @@ pub trait DanmuProtocol: Send + Sync + 'static {
     }
 
     /// Generate handshake messages to send upon connection
-    async fn handshake_messages(&self, _room_id: &str) -> Result<Vec<Message>> {
-        Ok(vec![])
+    fn handshake_messages(
+        &self,
+        _room_id: &str,
+    ) -> impl Future<Output = Result<Vec<Message>>> + Send {
+        async { Ok(vec![]) }
     }
 
     /// Generate heartbeat message (if any)
@@ -299,12 +302,12 @@ pub trait DanmuProtocol: Send + Sync + 'static {
 
     /// Decode a WebSocket message into a list of danmu items (messages or control events).
     /// `room_id` is provided so protocols can use it for responses that need the room context
-    async fn decode_message(
+    fn decode_message(
         &self,
         message: &Message,
         room_id: &str,
         tx: &mpsc::Sender<Message>,
-    ) -> Result<Vec<DanmuItem>>;
+    ) -> impl Future<Output = Result<Vec<DanmuItem>>> + Send;
 }
 
 /// Internal state for a WebSocket connection

--- a/crates/platforms/src/extractor/hls_extractor.rs
+++ b/crates/platforms/src/extractor/hls_extractor.rs
@@ -1,4 +1,5 @@
-use async_trait::async_trait;
+use std::future::Future;
+
 use m3u8_rs::{MasterPlaylist, Playlist};
 use reqwest::Client;
 use serde::Serialize;
@@ -7,17 +8,16 @@ use url::Url;
 use super::error::ExtractorError;
 use crate::media::{MediaFormat, StreamFormat, stream_info::StreamInfo};
 
-#[async_trait]
-pub trait HlsExtractor {
+pub trait HlsExtractor: Sync {
     /// Extract HLS streams without query parameters
-    async fn extract_hls_stream(
+    fn extract_hls_stream(
         &self,
         client: &Client,
         headers: Option<reqwest::header::HeaderMap>,
         m3u8_url: &str,
         quality_name: Option<&str>,
         extras: Option<serde_json::Value>,
-    ) -> Result<Vec<StreamInfo>, ExtractorError> {
+    ) -> impl Future<Output = Result<Vec<StreamInfo>, ExtractorError>> + Send {
         self.extract_hls_stream_with_params::<()>(
             client,
             headers,
@@ -26,11 +26,10 @@ pub trait HlsExtractor {
             quality_name,
             extras,
         )
-        .await
     }
 
     /// Extract HLS streams with query parameters
-    async fn extract_hls_stream_with_params<Q>(
+    fn extract_hls_stream_with_params<Q>(
         &self,
         client: &Client,
         headers: Option<reqwest::header::HeaderMap>,
@@ -38,48 +37,50 @@ pub trait HlsExtractor {
         m3u8_url: &str,
         quality_name: Option<&str>,
         extras: Option<serde_json::Value>,
-    ) -> Result<Vec<StreamInfo>, ExtractorError>
+    ) -> impl Future<Output = Result<Vec<StreamInfo>, ExtractorError>> + Send
     where
         Q: Serialize + Send + Sync + ?Sized,
     {
-        let base_url =
-            Url::parse(m3u8_url).map_err(|e| ExtractorError::HlsPlaylistError(e.to_string()))?;
+        async move {
+            let base_url = Url::parse(m3u8_url)
+                .map_err(|e| ExtractorError::HlsPlaylistError(e.to_string()))?;
 
-        let mut request = client.get(m3u8_url).headers(headers.unwrap_or_default());
+            let mut request = client.get(m3u8_url).headers(headers.unwrap_or_default());
 
-        if let Some(params) = params {
-            request = request.query(params);
-        }
-
-        let response = request.send().await?.bytes().await?;
-        let playlist = m3u8_rs::parse_playlist_res(&response)
-            .map_err(|e| ExtractorError::HlsPlaylistError(e.to_string()))?;
-
-        let streams = match playlist {
-            Playlist::MasterPlaylist(pl) => process_master_playlist(pl, &base_url, extras),
-            Playlist::MediaPlaylist(pl) => {
-                let media_format = if pl
-                    .segments
-                    .iter()
-                    .any(|s| s.uri.contains("fmp4") || s.uri.contains(".m4s"))
-                {
-                    MediaFormat::Fmp4
-                } else if pl.segments.iter().any(|s| s.uri.contains(".mp4")) {
-                    MediaFormat::Mp4
-                } else {
-                    MediaFormat::Ts
-                };
-
-                vec![
-                    StreamInfo::builder(m3u8_url.to_string(), StreamFormat::Hls, media_format)
-                        .quality(quality_name.unwrap_or("Source"))
-                        .extras_opt(extras)
-                        .build(),
-                ]
+            if let Some(params) = params {
+                request = request.query(params);
             }
-        };
 
-        Ok(streams)
+            let response = request.send().await?.bytes().await?;
+            let playlist = m3u8_rs::parse_playlist_res(&response)
+                .map_err(|e| ExtractorError::HlsPlaylistError(e.to_string()))?;
+
+            let streams = match playlist {
+                Playlist::MasterPlaylist(pl) => process_master_playlist(pl, &base_url, extras),
+                Playlist::MediaPlaylist(pl) => {
+                    let media_format = if pl
+                        .segments
+                        .iter()
+                        .any(|s| s.uri.contains("fmp4") || s.uri.contains(".m4s"))
+                    {
+                        MediaFormat::Fmp4
+                    } else if pl.segments.iter().any(|s| s.uri.contains(".mp4")) {
+                        MediaFormat::Mp4
+                    } else {
+                        MediaFormat::Ts
+                    };
+
+                    vec![
+                        StreamInfo::builder(m3u8_url.to_string(), StreamFormat::Hls, media_format)
+                            .quality(quality_name.unwrap_or("Source"))
+                            .extras_opt(extras)
+                            .build(),
+                    ]
+                }
+            };
+
+            Ok(streams)
+        }
     }
 }
 

--- a/crates/platforms/src/extractor/platforms/bilibili/danmu.rs
+++ b/crates/platforms/src/extractor/platforms/bilibili/danmu.rs
@@ -3,7 +3,6 @@
 //! Implements danmu collection for Bilibili live streaming using the generic
 //! WebSocket provider with binary protocol and Brotli/Zlib compression.
 
-use async_trait::async_trait;
 use byteorder::{BigEndian, ByteOrder};
 use bytes::Bytes;
 use flate2::read::ZlibDecoder;
@@ -593,7 +592,6 @@ impl BilibiliDanmuProtocol {
     }
 }
 
-#[async_trait]
 impl DanmuProtocol for BilibiliDanmuProtocol {
     fn platform(&self) -> &str {
         "bilibili"

--- a/crates/platforms/src/extractor/platforms/douyin/danmu.rs
+++ b/crates/platforms/src/extractor/platforms/douyin/danmu.rs
@@ -3,7 +3,6 @@
 //! Implements danmu collection for the Douyin streaming platform using the generic
 //! WebSocket provider with Protobuf protocol for message encoding/decoding.
 
-use async_trait::async_trait;
 
 use bytes::Bytes;
 use flate2::read::GzDecoder;
@@ -275,7 +274,6 @@ impl DouyinDanmuProtocol {
     }
 }
 
-#[async_trait]
 impl DanmuProtocol for DouyinDanmuProtocol {
     fn platform(&self) -> &str {
         "douyin"

--- a/crates/platforms/src/extractor/platforms/douyu/danmu.rs
+++ b/crates/platforms/src/extractor/platforms/douyu/danmu.rs
@@ -3,7 +3,6 @@
 //! Implements danmu collection for the Douyu streaming platform using the generic
 //! WebSocket provider with STT (Serialized Text Transport) protocol for message encoding/decoding.
 
-use async_trait::async_trait;
 use bytes::Bytes;
 use chrono::Utc;
 use std::time::Duration;
@@ -108,7 +107,6 @@ impl DouyuDanmuProtocol {
     }
 }
 
-#[async_trait]
 impl DanmuProtocol for DouyuDanmuProtocol {
     fn platform(&self) -> &str {
         "douyu"

--- a/crates/platforms/src/extractor/platforms/huya/danmu.rs
+++ b/crates/platforms/src/extractor/platforms/huya/danmu.rs
@@ -3,7 +3,6 @@
 //! Implements danmu collection for the Huya streaming platform using the generic
 //! WebSocket provider with TARS protocol for message encoding/decoding.
 
-use async_trait::async_trait;
 use bytes::{Bytes, BytesMut};
 use chrono::Utc;
 use rustc_hash::FxHashMap;
@@ -66,7 +65,6 @@ impl HuyaDanmuProtocol {
     }
 }
 
-#[async_trait]
 impl DanmuProtocol for HuyaDanmuProtocol {
     fn platform(&self) -> &str {
         "huya"

--- a/crates/platforms/src/extractor/platforms/twitcasting/danmu.rs
+++ b/crates/platforms/src/extractor/platforms/twitcasting/danmu.rs
@@ -7,7 +7,6 @@
 //! 2. Get WebSocket URL: POST https://twitcasting.tv/eventpubsuburl.php with movie_id and password
 //! 3. Connect to the returned wss:// URL for real-time comments (JSON arrays)
 
-use async_trait::async_trait;
 use md5::{Digest, Md5};
 use reqwest::Client;
 use serde::Deserialize;
@@ -346,7 +345,6 @@ impl TwitcastingDanmuProtocol {
     }
 }
 
-#[async_trait]
 impl DanmuProtocol for TwitcastingDanmuProtocol {
     fn platform(&self) -> &str {
         "twitcasting"

--- a/crates/platforms/src/extractor/platforms/twitch/danmu.rs
+++ b/crates/platforms/src/extractor/platforms/twitch/danmu.rs
@@ -2,7 +2,6 @@
 //!
 //! Implements danmu collection for the Twitch streaming platform using IRC over WebSocket.
 
-use async_trait::async_trait;
 use std::time::Duration;
 use tokio::sync::mpsc;
 use tokio_tungstenite::tungstenite::protocol::Message;
@@ -132,7 +131,6 @@ impl TwitchDanmuProtocol {
     }
 }
 
-#[async_trait]
 impl DanmuProtocol for TwitchDanmuProtocol {
     fn platform(&self) -> &str {
         "twitch"
@@ -213,40 +211,11 @@ impl DanmuProtocol for TwitchDanmuProtocol {
         tx: &mpsc::Sender<Message>,
     ) -> Result<Vec<DanmuItem>> {
         match message {
-            Message::Text(text) => {
-                let mut items = Vec::new();
-
-                // Handle each line (Twitch may send multiple messages in one frame)
-                for line in text.lines() {
-                    let trimmed = line.trim();
-                    if trimmed.is_empty() {
-                        continue;
-                    }
-
-                    // debug!("Twitch IRC: {}", trimmed);
-
-                    // Handle PING - respond with PONG
-                    if trimmed.starts_with("PING") {
-                        let pong_data = trimmed.strip_prefix("PING ").unwrap_or(":tmi.twitch.tv");
-                        let pong = format!("PONG {}", pong_data);
-                        debug!("Sending PONG: {}", pong);
-                        let _ = tx.send(Message::Text(pong.into())).await;
-                        continue;
-                    }
-
-                    // Parse chat messages
-                    if let Some(danmu) = Self::parse_irc_message(trimmed) {
-                        items.push(DanmuItem::Message(danmu));
-                    }
-                }
-
-                Ok(items)
-            }
+            Message::Text(text) => Self::decode_text(text, tx).await,
             Message::Binary(data) => {
                 // Twitch IRC uses text, but handle binary just in case
-                if let Ok(text) = String::from_utf8(data.to_vec()) {
-                    // Recursively process as text
-                    Box::pin(self.decode_message(&Message::Text(text.into()), _room_id, tx)).await
+                if let Ok(text) = std::str::from_utf8(data) {
+                    Self::decode_text(text, tx).await
                 } else {
                     Ok(vec![])
                 }
@@ -258,6 +227,36 @@ impl DanmuProtocol for TwitchDanmuProtocol {
             }
             _ => Ok(vec![]),
         }
+    }
+}
+
+impl TwitchDanmuProtocol {
+    async fn decode_text(text: &str, tx: &mpsc::Sender<Message>) -> Result<Vec<DanmuItem>> {
+        let mut items = Vec::new();
+
+        // Handle each line (Twitch may send multiple messages in one frame)
+        for line in text.lines() {
+            let trimmed = line.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+
+            // Handle PING - respond with PONG
+            if trimmed.starts_with("PING") {
+                let pong_data = trimmed.strip_prefix("PING ").unwrap_or(":tmi.twitch.tv");
+                let pong = format!("PONG {}", pong_data);
+                debug!("Sending PONG: {}", pong);
+                let _ = tx.send(Message::Text(pong.into())).await;
+                continue;
+            }
+
+            // Parse chat messages
+            if let Some(danmu) = Self::parse_irc_message(trimmed) {
+                items.push(DanmuItem::Message(danmu));
+            }
+        }
+
+        Ok(items)
     }
 }
 

--- a/crates/platforms/src/js_engine/error.rs
+++ b/crates/platforms/src/js_engine/error.rs
@@ -1,44 +1,30 @@
 //! JavaScript engine error types.
 
-use std::fmt;
-
 /// Errors that can occur during JavaScript execution.
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum JsError {
     /// Failed to create a new JavaScript runtime.
+    #[error("Failed to create JS runtime: {0}")]
     RuntimeCreation(String),
     /// Failed to create a JavaScript context.
+    #[error("Failed to create JS context: {0}")]
     ContextCreation(String),
     /// JavaScript evaluation failed.
+    #[error(
+        "JS evaluation failed: {message}{}",
+        stack.as_deref().map(|s| format!("\nStack: {s}")).unwrap_or_default()
+    )]
     Evaluation {
         message: String,
         stack: Option<String>,
     },
     /// Type conversion error (e.g., expected string, got object).
+    #[error("JS type conversion error: {0}")]
     TypeConversion(String),
     /// The runtime pool is exhausted.
+    #[error("JS runtime pool exhausted")]
     PoolExhausted,
 }
-
-impl fmt::Display for JsError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            JsError::RuntimeCreation(msg) => write!(f, "Failed to create JS runtime: {}", msg),
-            JsError::ContextCreation(msg) => write!(f, "Failed to create JS context: {}", msg),
-            JsError::Evaluation { message, stack } => {
-                if let Some(stack) = stack {
-                    write!(f, "JS evaluation failed: {}\nStack: {}", message, stack)
-                } else {
-                    write!(f, "JS evaluation failed: {}", message)
-                }
-            }
-            JsError::TypeConversion(msg) => write!(f, "JS type conversion error: {}", msg),
-            JsError::PoolExhausted => write!(f, "JS runtime pool exhausted"),
-        }
-    }
-}
-
-impl std::error::Error for JsError {}
 
 impl JsError {
     /// Create an evaluation error from a message.
@@ -64,5 +50,38 @@ impl From<rquickjs::Error> for JsError {
             message: err.to_string(),
             stack: None,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn display_matches_pre_migration_formatting() {
+        assert_eq!(
+            JsError::RuntimeCreation("boom".into()).to_string(),
+            "Failed to create JS runtime: boom"
+        );
+        assert_eq!(
+            JsError::ContextCreation("boom".into()).to_string(),
+            "Failed to create JS context: boom"
+        );
+        assert_eq!(
+            JsError::eval("boom").to_string(),
+            "JS evaluation failed: boom"
+        );
+        assert_eq!(
+            JsError::eval_with_stack("boom", "at foo.js:1").to_string(),
+            "JS evaluation failed: boom\nStack: at foo.js:1"
+        );
+        assert_eq!(
+            JsError::TypeConversion("boom".into()).to_string(),
+            "JS type conversion error: boom"
+        );
+        assert_eq!(
+            JsError::PoolExhausted.to_string(),
+            "JS runtime pool exhausted"
+        );
     }
 }

--- a/crates/tars-codec/src/types.rs
+++ b/crates/tars-codec/src/types.rs
@@ -116,8 +116,8 @@ impl Ord for TarsValue {
                 // Compare HashMaps by converting to sorted vectors
                 let mut a_vec: Vec<_> = a.iter().collect();
                 let mut b_vec: Vec<_> = b.iter().collect();
-                a_vec.sort_by(|(k1, _), (k2, _)| k1.cmp(k2));
-                b_vec.sort_by(|(k1, _), (k2, _)| k1.cmp(k2));
+                a_vec.sort_by_key(|(k, _)| *k);
+                b_vec.sort_by_key(|(k, _)| *k);
                 a_vec.cmp(&b_vec)
             }
             (TarsValue::List(a), TarsValue::List(b)) => {
@@ -211,7 +211,7 @@ impl Hash for TarsValue {
                 if v.len() <= 3 {
                     // For small maps, collect and sort with faster unstable sort
                     let mut pairs: Vec<_> = v.iter().collect();
-                    pairs.sort_unstable_by(|(k1, _), (k2, _)| k1.cmp(k2));
+                    pairs.sort_unstable_by_key(|(k, _)| *k);
                     // Hash length first for better distribution
                     v.len().hash(state);
                     for (k, val) in pairs {

--- a/rust-srec/src/api/routes/downloads.rs
+++ b/rust-srec/src/api/routes/downloads.rs
@@ -187,11 +187,10 @@ async fn handle_socket(socket: WebSocket, state: AppState) {
                         // debug!("Client disconnected");
                         break;
                     }
-                    Some(Ok(Message::Ping(data))) => {
-                        // Respond to client Ping with Pong (Requirement 7.4)
-                        if sender.send(Message::Pong(data)).await.is_err() {
-                            break;
-                        }
+                    Some(Ok(Message::Ping(data)))
+                        if sender.send(Message::Pong(data.clone())).await.is_err() =>
+                    {
+                        break;
                     }
                     Some(Ok(Message::Pong(_))) => {
                         // Client responded to our Ping - reset awaiting_pong state

--- a/rust-srec/src/downloader/engine/traits.rs
+++ b/rust-srec/src/downloader/engine/traits.rs
@@ -13,8 +13,6 @@ use std::time::Duration;
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 
-use std::fmt::Display;
-
 use crate::Result;
 
 /// Type of download engine.
@@ -476,7 +474,8 @@ impl DownloadFailureKind {
 /// Error returned by [`DownloadEngine::start`] carrying a classified
 /// [`DownloadFailureKind`] so the manager can make informed retry and
 /// circuit-breaker decisions without hardcoding `Other`.
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
+#[error("{message}")]
 pub struct EngineStartError {
     /// Classified failure kind.
     pub kind: DownloadFailureKind,
@@ -493,14 +492,6 @@ impl EngineStartError {
         }
     }
 }
-
-impl Display for EngineStartError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.message)
-    }
-}
-
-impl std::error::Error for EngineStartError {}
 
 impl From<crate::Error> for EngineStartError {
     fn from(err: crate::Error) -> Self {

--- a/rust-srec/src/downloader/output_root_gate.rs
+++ b/rust-srec/src/downloader/output_root_gate.rs
@@ -85,7 +85,8 @@ pub type RecoveryHook = Arc<dyn Fn(&Path) + Send + Sync>;
 
 /// Error returned by [`OutputRootGate::check`] when the gate has blocked a
 /// download from starting.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, thiserror::Error)]
+#[error("output root {} is unwritable ({}): {message}", .root.display(), .kind.as_str())]
 pub struct GateBlocked {
     /// The resolved root that is in the Degraded state.
     pub root: PathBuf,
@@ -95,20 +96,6 @@ pub struct GateBlocked {
     /// from the original `io::Error::to_string()`).
     pub message: String,
 }
-
-impl std::fmt::Display for GateBlocked {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "output root {} is unwritable ({}): {}",
-            self.root.display(),
-            self.kind.as_str(),
-            self.message
-        )
-    }
-}
-
-impl std::error::Error for GateBlocked {}
 
 /// Snapshot of one tracked root, used by the `/health` endpoint.
 #[derive(Debug, Clone)]

--- a/rust-srec/src/scheduler/actor/handle.rs
+++ b/rust-srec/src/scheduler/actor/handle.rs
@@ -21,27 +21,18 @@ pub const DEFAULT_SEND_TIMEOUT: Duration = Duration::from_millis(100);
 pub const BACKPRESSURE_THRESHOLD: f64 = 0.8;
 
 /// Error type for send operations.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub enum SendError {
     /// The actor has stopped and is no longer accepting messages.
+    #[error("Actor has stopped")]
     ActorStopped,
     /// The mailbox is full and the send timed out.
+    #[error("Mailbox is full")]
     MailboxFull,
     /// The send operation timed out.
+    #[error("Send operation timed out")]
     Timeout,
 }
-
-impl fmt::Display for SendError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            SendError::ActorStopped => write!(f, "Actor has stopped"),
-            SendError::MailboxFull => write!(f, "Mailbox is full"),
-            SendError::Timeout => write!(f, "Send operation timed out"),
-        }
-    }
-}
-
-impl std::error::Error for SendError {}
 
 /// Metadata about an actor.
 #[derive(Debug, Clone)]

--- a/rust-srec/src/scheduler/actor/monitor_adapter.rs
+++ b/rust-srec/src/scheduler/actor/monitor_adapter.rs
@@ -86,7 +86,8 @@ pub trait BatchChecker: Send + Sync + 'static {
 }
 
 /// Error type for check operations.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, thiserror::Error)]
+#[error("{message}")]
 pub struct CheckError {
     /// Error message.
     pub message: String,
@@ -111,14 +112,6 @@ impl CheckError {
         }
     }
 }
-
-impl std::fmt::Display for CheckError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.message)
-    }
-}
-
-impl std::error::Error for CheckError {}
 
 impl From<crate::Error> for CheckError {
     fn from(err: crate::Error) -> Self {

--- a/rust-srec/src/scheduler/actor/registry.rs
+++ b/rust-srec/src/scheduler/actor/registry.rs
@@ -330,24 +330,15 @@ impl ActorRegistry {
 }
 
 /// Error type for registry operations.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub enum RegistryError {
     /// An actor with the given ID already exists.
+    #[error("Actor already exists: {0}")]
     ActorExists(String),
     /// The actor was not found.
+    #[error("Actor not found: {0}")]
     ActorNotFound(String),
 }
-
-impl std::fmt::Display for RegistryError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            RegistryError::ActorExists(id) => write!(f, "Actor already exists: {}", id),
-            RegistryError::ActorNotFound(id) => write!(f, "Actor not found: {}", id),
-        }
-    }
-}
-
-impl std::error::Error for RegistryError {}
 
 #[cfg(test)]
 mod tests {

--- a/rust-srec/src/scheduler/actor/streamer_actor.rs
+++ b/rust-srec/src/scheduler/actor/streamer_actor.rs
@@ -54,7 +54,8 @@ pub enum ActorOutcome {
 }
 
 /// Error type for actor operations.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, thiserror::Error)]
+#[error("{message}")]
 pub struct ActorError {
     /// Error message.
     pub message: String,
@@ -79,14 +80,6 @@ impl ActorError {
         }
     }
 }
-
-impl std::fmt::Display for ActorError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.message)
-    }
-}
-
-impl std::error::Error for ActorError {}
 
 /// A self-managing actor for monitoring a single streamer.
 ///

--- a/rust-srec/src/scheduler/actor/supervisor.rs
+++ b/rust-srec/src/scheduler/actor/supervisor.rs
@@ -644,24 +644,15 @@ pub enum TaskCompletionAction {
 }
 
 /// Error type for spawn operations.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, thiserror::Error)]
 pub enum SpawnError {
     /// An actor with the given ID already exists.
+    #[error("Actor already exists: {0}")]
     ActorExists(String),
     /// Registry error.
+    #[error("Registry error: {0}")]
     RegistryError(String),
 }
-
-impl std::fmt::Display for SpawnError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            SpawnError::ActorExists(id) => write!(f, "Actor already exists: {}", id),
-            SpawnError::RegistryError(e) => write!(f, "Registry error: {}", e),
-        }
-    }
-}
-
-impl std::error::Error for SpawnError {}
 
 /// Report from a shutdown operation.
 #[derive(Debug, Clone)]

--- a/rust-srec/src/streamer/manager.rs
+++ b/rust-srec/src/streamer/manager.rs
@@ -564,7 +564,7 @@ where
     /// Get streamers sorted by priority (High first, then Normal, then Low).
     pub fn get_all_sorted_by_priority(&self) -> Vec<StreamerMetadata> {
         let mut streamers: Vec<_> = self.get_all();
-        streamers.sort_by(|a, b| b.priority.cmp(&a.priority));
+        streamers.sort_by_key(|s| std::cmp::Reverse(s.priority));
         streamers
     }
 


### PR DESCRIPTION
## Summary

Stacked on [#516](https://github.com/hua0512/rust-srec/pull/516). Replaces the nine remaining hand-written `impl std::error::Error` + `impl Display` pairs with `#[derive(thiserror::Error)]` + `#[error("...")]`. `thiserror` was already in every affected crate's Cargo.toml and already drives 12 other error types in the workspace -- this just closes the gap.

Types migrated: `TestStrategyError`, `JsError`, `RegistryError`, `SendError`, `SpawnError`, `CheckError`, `ActorError`, `GateBlocked`, `EngineStartError`. Net -49 LOC.

## Notes

- Semantic fields that aren't part of Display are preserved unchanged (`CheckError.transient`, `ActorError.recoverable`, `GateBlocked.kind`, `EngineStartError.kind`) along with their constructors. They drive retry and supervisor-restart logic upstream of the error type.
- Three `From<..>` impls do custom translation and are kept as-is rather than replaced with `#[from]`:
  - `JsError: From<rquickjs::Error>` maps into the `Evaluation` variant with `stack: None`.
  - `CheckError: From<crate::Error>` classifies as transient.
  - `EngineStartError: From<crate::Error>` walks the `source()` chain to classify `io::ErrorKind` into `DownloadFailureKind`.
- Added a display-equivalence test for `JsError` since its `Evaluation` variant has conditional stack-suffix formatting that doesn't fit the plain `#[error("...")]` shape.
- No Cargo.toml changes.

## Test plan

- [x] `cargo build --workspace --exclude rust-srec-desktop` -- clean
- [x] `cargo clippy --workspace --exclude rust-srec-desktop --all-targets -- -D warnings` -- clean
- [x] `cargo test --workspace --exclude rust-srec-desktop` -- 1093 pass; 2 unrelated `output_root_gate` failures that depend on permission denial and don't trigger when running as uid 0 (same baseline as #516)
- [x] `cargo test -p platforms-parser --features rquickjs js_engine::error` -- added Display equivalence test passes
- [ ] `rust-srec-desktop` (Tauri) on a host with `pkg-config` + glib-2.0 (environmental)