### PR TITLE
refactor(async): replace async-trait with dynosaur workspace-wide

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3670,7 +3670,6 @@ name = "mesio-engine"
 version = "0.4.0"
 dependencies = [
  "aes 0.9.0-rc.4",
- "async-trait",
  "bytes",
  "cbc",
  "cipher 0.5.1",
@@ -4654,7 +4653,6 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 name = "platforms-parser"
 version = "0.2.0"
 dependencies = [
- "async-trait",
  "base64 0.22.1",
  "brotli",
  "byteorder",
@@ -5528,7 +5526,6 @@ dependencies = [
  "aes-gcm",
  "anyhow",
  "argon2",
- "async-trait",
  "axum",
  "base64 0.22.1",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1655,6 +1655,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "dynosaur"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a12303417f378f29ba12cb12fc78a9df0d8e16ccb1ad94abf04d48d96bdda532"
+dependencies = [
+ "dynosaur_derive",
+]
+
+[[package]]
+name = "dynosaur_derive"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b0713d5c1d52e774c5cd7bb8b043d7c0fc4f921abfb678556140bfbe6ab2364"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "ecdsa"
 version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3655,6 +3675,7 @@ dependencies = [
  "cbc",
  "cipher 0.5.1",
  "clap",
+ "dynosaur",
  "flv",
  "futures",
  "hex",
@@ -4639,6 +4660,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "chrono",
+ "dynosaur",
  "flate2",
  "futures",
  "libsm",
@@ -5515,6 +5537,7 @@ dependencies = [
  "cron",
  "dashmap",
  "dotenvy",
+ "dynosaur",
  "flate2",
  "flv",
  "flv-fix",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,6 @@ serde_json = "1.0.149"
 thiserror = "2.0.18"
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.23", features = ["env-filter", "json", "fmt"] }
-async-trait = "0.1.89"
 dynosaur = "0.3"
 rand = "0.10.0"
 regex = { version = "1.12.3", default-features = false, features = ["std", "unicode-perl", "unicode-case"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ thiserror = "2.0.18"
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.23", features = ["env-filter", "json", "fmt"] }
 async-trait = "0.1.89"
+dynosaur = "0.3"
 rand = "0.10.0"
 regex = { version = "1.12.3", default-features = false, features = ["std", "unicode-perl", "unicode-case"] }
 futures = "0.3.32"

--- a/crates/mesio/Cargo.toml
+++ b/crates/mesio/Cargo.toml
@@ -22,7 +22,6 @@ reqwest = { workspace = true, features = [
   "deflate",
 ] }
 url = { workspace = true }
-async-trait = { workspace = true }
 dynosaur = { workspace = true }
 thiserror = { workspace = true }
 m3u8-rs = { workspace = true }

--- a/crates/mesio/Cargo.toml
+++ b/crates/mesio/Cargo.toml
@@ -23,6 +23,7 @@ reqwest = { workspace = true, features = [
 ] }
 url = { workspace = true }
 async-trait = { workspace = true }
+dynosaur = { workspace = true }
 thiserror = { workspace = true }
 m3u8-rs = { workspace = true }
 serde = { workspace = true, features = ["derive"] }

--- a/crates/mesio/src/hls/coordinator.rs
+++ b/crates/mesio/src/hls/coordinator.rs
@@ -5,11 +5,11 @@ use crate::downloader::ClientPool;
 use crate::hls::config::HlsConfig;
 use crate::hls::decryption::{DecryptionService, KeyFetcher};
 use crate::hls::events::HlsStreamEvent;
-use crate::hls::fetcher::{SegmentDownloader, SegmentFetcher};
+use crate::hls::fetcher::{DynSegmentDownloader, SegmentFetcher};
 use crate::hls::metrics::PerformanceMetrics;
 use crate::hls::output::OutputManager;
 use crate::hls::playlist::{DynPlaylistProvider, InitialPlaylist, PlaylistEngine, PlaylistProvider};
-use crate::hls::processor::{SegmentProcessor, SegmentTransformer};
+use crate::hls::processor::{DynSegmentTransformer, SegmentProcessor};
 use crate::hls::scheduler::{ScheduledSegmentJob, SegmentScheduler};
 use std::sync::Arc;
 use tokio::sync::mpsc;
@@ -65,20 +65,19 @@ impl HlsStreamCoordinator {
             Arc::clone(&key_fetcher),
             cache_manager.clone(),
         ));
-        let segment_fetcher: Arc<dyn SegmentDownloader> = Arc::new(SegmentFetcher::with_metrics(
+        let segment_fetcher = DynSegmentDownloader::new_arc(SegmentFetcher::with_metrics(
             Arc::clone(&clients),
             Arc::clone(&config),
             cache_manager.clone(),
             Arc::clone(&performance_metrics),
             token.clone(),
         ));
-        let segment_processor: Arc<dyn SegmentTransformer> =
-            Arc::new(SegmentProcessor::with_metrics(
-                Arc::clone(&config),
-                Arc::clone(&decryption_service),
-                cache_manager.clone(),
-                Arc::clone(&performance_metrics),
-            ));
+        let segment_processor = DynSegmentTransformer::new_arc(SegmentProcessor::with_metrics(
+            Arc::clone(&config),
+            Arc::clone(&decryption_service),
+            cache_manager.clone(),
+            Arc::clone(&performance_metrics),
+        ));
         let playlist_engine: Arc<DynPlaylistProvider<'static>> =
             DynPlaylistProvider::new_arc(PlaylistEngine::new(
                 Arc::clone(&clients),

--- a/crates/mesio/src/hls/coordinator.rs
+++ b/crates/mesio/src/hls/coordinator.rs
@@ -8,7 +8,7 @@ use crate::hls::events::HlsStreamEvent;
 use crate::hls::fetcher::{SegmentDownloader, SegmentFetcher};
 use crate::hls::metrics::PerformanceMetrics;
 use crate::hls::output::OutputManager;
-use crate::hls::playlist::{InitialPlaylist, PlaylistEngine, PlaylistProvider};
+use crate::hls::playlist::{DynPlaylistProvider, InitialPlaylist, PlaylistEngine, PlaylistProvider};
 use crate::hls::processor::{SegmentProcessor, SegmentTransformer};
 use crate::hls::scheduler::{ScheduledSegmentJob, SegmentScheduler};
 use std::sync::Arc;
@@ -79,11 +79,12 @@ impl HlsStreamCoordinator {
                 cache_manager.clone(),
                 Arc::clone(&performance_metrics),
             ));
-        let playlist_engine: Arc<dyn PlaylistProvider> = Arc::new(PlaylistEngine::new(
-            Arc::clone(&clients),
-            cache_manager,
-            Arc::clone(&config),
-        ));
+        let playlist_engine: Arc<DynPlaylistProvider<'static>> =
+            DynPlaylistProvider::new_arc(PlaylistEngine::new(
+                Arc::clone(&clients),
+                cache_manager,
+                Arc::clone(&config),
+            ));
 
         // Channels - sized for optimal throughput
         let (client_event_tx, client_event_rx) = mpsc::channel(32);

--- a/crates/mesio/src/hls/fetcher.rs
+++ b/crates/mesio/src/hls/fetcher.rs
@@ -6,7 +6,6 @@ use crate::hls::HlsDownloaderError;
 use crate::hls::config::HlsConfig;
 use crate::hls::retry::{RetryAction, RetryPolicy, is_retryable_reqwest_error, retry_with_backoff};
 use crate::{CacheManager, cache::CacheKey};
-use async_trait::async_trait;
 use bytes::Bytes;
 use indicatif::ProgressStyle;
 use std::sync::Arc;
@@ -18,12 +17,12 @@ use tokio_util::sync::CancellationToken;
 
 use crate::hls::scheduler::ScheduledSegmentJob;
 
-#[async_trait]
+#[dynosaur::dynosaur(pub DynSegmentDownloader = dyn(box) SegmentDownloader)]
 pub trait SegmentDownloader: Send + Sync {
-    async fn download_segment_from_job(
+    fn download_segment_from_job(
         &self,
         job: &ScheduledSegmentJob,
-    ) -> Result<Bytes, HlsDownloaderError>;
+    ) -> impl std::future::Future<Output = Result<Bytes, HlsDownloaderError>> + Send;
 }
 
 pub struct SegmentFetcher {
@@ -257,7 +256,6 @@ impl SegmentFetcher {
     }
 }
 
-#[async_trait]
 impl SegmentDownloader for SegmentFetcher {
     /// Downloads a segment from the given job.
     /// If the segment is already cached, it retrieves it from the cache.

--- a/crates/mesio/src/hls/playlist.rs
+++ b/crates/mesio/src/hls/playlist.rs
@@ -6,7 +6,6 @@ use crate::hls::HlsDownloaderError;
 use crate::hls::config::{HlsConfig, HlsVariantSelectionPolicy};
 use crate::hls::scheduler::ScheduledSegmentJob;
 use crate::hls::twitch_processor::TwitchPlaylistProcessor;
-use async_trait::async_trait;
 use m3u8_rs::{MasterPlaylist, MediaPlaylist, MediaSegment, parse_playlist_res};
 use moka::future::Cache;
 use moka::policy::EvictionPolicy;
@@ -19,23 +18,25 @@ use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, trace, warn};
 use url::Url;
 
-#[async_trait]
+#[dynosaur::dynosaur(pub DynPlaylistProvider = dyn(box) PlaylistProvider)]
 pub trait PlaylistProvider: Send + Sync {
-    async fn load_initial_playlist(&self, url: &str)
-    -> Result<InitialPlaylist, HlsDownloaderError>;
-    async fn select_media_playlist(
+    fn load_initial_playlist(
+        &self,
+        url: &str,
+    ) -> impl std::future::Future<Output = Result<InitialPlaylist, HlsDownloaderError>> + Send;
+    fn select_media_playlist(
         &self,
         initial_playlist_with_base_url: &InitialPlaylist,
         policy: &HlsVariantSelectionPolicy,
-    ) -> Result<MediaPlaylistDetails, HlsDownloaderError>;
-    async fn monitor_media_playlist(
+    ) -> impl std::future::Future<Output = Result<MediaPlaylistDetails, HlsDownloaderError>> + Send;
+    fn monitor_media_playlist(
         &self,
         playlist_url: &str,
         initial_playlist: MediaPlaylist,
         base_url: String,
         segment_request_tx: mpsc::Sender<ScheduledSegmentJob>,
         token: CancellationToken,
-    ) -> Result<(), HlsDownloaderError>;
+    ) -> impl std::future::Future<Output = Result<(), HlsDownloaderError>> + Send;
 }
 
 #[derive(Debug, Clone)]
@@ -147,7 +148,6 @@ impl AdaptiveRefreshTracker {
     }
 }
 
-#[async_trait]
 impl PlaylistProvider for PlaylistEngine {
     async fn load_initial_playlist(
         &self,

--- a/crates/mesio/src/hls/processor.rs
+++ b/crates/mesio/src/hls/processor.rs
@@ -9,20 +9,19 @@ use crate::hls::decryption::DecryptionService;
 use crate::hls::metrics::PerformanceMetrics;
 use crate::hls::scheduler::ScheduledSegmentJob;
 use crate::hls::segment_utils::create_hls_data;
-use async_trait::async_trait;
 use bytes::Bytes;
 use hls::HlsData;
 use std::sync::Arc;
 use std::time::Instant;
 use tracing::{trace, warn};
 
-#[async_trait]
+#[dynosaur::dynosaur(pub DynSegmentTransformer = dyn(box) SegmentTransformer)]
 pub trait SegmentTransformer: Send + Sync {
-    async fn process_segment_from_job(
+    fn process_segment_from_job(
         &self,
         raw_data: Bytes,
         job: &ScheduledSegmentJob,
-    ) -> Result<HlsData, HlsDownloaderError>;
+    ) -> impl std::future::Future<Output = Result<HlsData, HlsDownloaderError>> + Send;
 }
 
 pub struct SegmentProcessor {
@@ -65,7 +64,6 @@ impl SegmentProcessor {
     }
 }
 
-#[async_trait]
 impl SegmentTransformer for SegmentProcessor {
     async fn process_segment_from_job(
         &self,

--- a/crates/mesio/src/hls/scheduler.rs
+++ b/crates/mesio/src/hls/scheduler.rs
@@ -2,10 +2,10 @@
 
 use crate::hls::HlsDownloaderError;
 use crate::hls::config::{BatchSchedulerConfig, HlsConfig};
-use crate::hls::fetcher::SegmentDownloader;
+use crate::hls::fetcher::{DynSegmentDownloader, SegmentDownloader};
 use crate::hls::metrics::PerformanceMetrics;
 use crate::hls::prefetch::PrefetchManager;
-use crate::hls::processor::SegmentTransformer;
+use crate::hls::processor::{DynSegmentTransformer, SegmentTransformer};
 use futures::StreamExt;
 use futures::stream::FuturesUnordered;
 use hls::HlsData;
@@ -170,8 +170,8 @@ pub struct ProcessedSegmentOutput {
 
 pub struct SegmentScheduler {
     config: Arc<HlsConfig>,
-    segment_fetcher: Arc<dyn SegmentDownloader>,
-    segment_processor: Arc<dyn SegmentTransformer>,
+    segment_fetcher: Arc<DynSegmentDownloader<'static>>,
+    segment_processor: Arc<DynSegmentTransformer<'static>>,
     segment_request_rx: mpsc::Receiver<ScheduledSegmentJob>,
     output_tx: mpsc::Sender<Result<ProcessedSegmentOutput, HlsDownloaderError>>,
     token: CancellationToken,
@@ -198,8 +198,8 @@ pub struct SegmentScheduler {
 impl SegmentScheduler {
     pub fn new(
         config: Arc<HlsConfig>,
-        segment_fetcher: Arc<dyn SegmentDownloader>,
-        segment_processor: Arc<dyn SegmentTransformer>,
+        segment_fetcher: Arc<DynSegmentDownloader<'static>>,
+        segment_processor: Arc<DynSegmentTransformer<'static>>,
         segment_request_rx: mpsc::Receiver<ScheduledSegmentJob>,
         output_tx: mpsc::Sender<Result<ProcessedSegmentOutput, HlsDownloaderError>>,
         token: CancellationToken,
@@ -228,8 +228,8 @@ impl SegmentScheduler {
     /// Create a new SegmentScheduler with performance metrics
     pub fn with_metrics(
         config: Arc<HlsConfig>,
-        segment_fetcher: Arc<dyn SegmentDownloader>,
-        segment_processor: Arc<dyn SegmentTransformer>,
+        segment_fetcher: Arc<DynSegmentDownloader<'static>>,
+        segment_processor: Arc<DynSegmentTransformer<'static>>,
         segment_request_rx: mpsc::Receiver<ScheduledSegmentJob>,
         output_tx: mpsc::Sender<Result<ProcessedSegmentOutput, HlsDownloaderError>>,
         token: CancellationToken,
@@ -249,8 +249,8 @@ impl SegmentScheduler {
 
     /// Result of segment processing, including metadata for prefetch tracking
     async fn perform_segment_processing(
-        segment_fetcher: Arc<dyn SegmentDownloader>,
-        segment_processor: Arc<dyn SegmentTransformer>,
+        segment_fetcher: Arc<DynSegmentDownloader<'static>>,
+        segment_processor: Arc<DynSegmentTransformer<'static>>,
         job: ScheduledSegmentJob,
     ) -> (
         u64,
@@ -372,8 +372,8 @@ impl SegmentScheduler {
         futures: &mut FuturesUnordered<F>,
         buffer_size: &mut usize,
         in_flight_segments: &mut HashSet<u64>,
-        segment_fetcher: &Arc<dyn SegmentDownloader>,
-        segment_processor: &Arc<dyn SegmentTransformer>,
+        segment_fetcher: &Arc<DynSegmentDownloader<'static>>,
+        segment_processor: &Arc<DynSegmentTransformer<'static>>,
         max_concurrency: usize,
     ) where
         F: From<
@@ -415,8 +415,8 @@ impl SegmentScheduler {
         futures: &mut FuturesUnordered<F>,
         buffer_size: &mut usize,
         in_flight_segments: &mut HashSet<u64>,
-        segment_fetcher: &Arc<dyn SegmentDownloader>,
-        segment_processor: &Arc<dyn SegmentTransformer>,
+        segment_fetcher: &Arc<DynSegmentDownloader<'static>>,
+        segment_processor: &Arc<DynSegmentTransformer<'static>>,
     ) where
         F: From<
             std::pin::Pin<

--- a/crates/platforms/Cargo.toml
+++ b/crates/platforms/Cargo.toml
@@ -40,7 +40,6 @@ regex = { workspace = true, default-features = false, features = [
  # Logging
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
-async-trait = { workspace = true }
 dynosaur = { workspace = true }
 tars-codec = { path = "../tars-codec"}
 rustc-hash = { workspace = true }

--- a/crates/platforms/Cargo.toml
+++ b/crates/platforms/Cargo.toml
@@ -41,6 +41,7 @@ regex = { workspace = true, default-features = false, features = [
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 async-trait = { workspace = true }
+dynosaur = { workspace = true }
 tars-codec = { path = "../tars-codec"}
 rustc-hash = { workspace = true }
 rand = { workspace = true }

--- a/crates/platforms/src/danmaku/mod.rs
+++ b/crates/platforms/src/danmaku/mod.rs
@@ -11,7 +11,7 @@ pub mod writer;
 pub use error::{DanmakuError, Result};
 pub use event::{DanmuControlEvent, DanmuItem};
 pub use message::{DanmuMessage, DanmuType};
-pub use provider::{ConnectionConfig, DanmuConnection, DanmuProvider};
+pub use provider::{ConnectionConfig, DanmuConnection, DanmuProvider, DynDanmuProvider};
 pub use registry::ProviderRegistry;
 pub use sampler::{
     DanmuSampler, DanmuSamplingConfig, FixedIntervalSampler, VelocitySampler, create_sampler,

--- a/crates/platforms/src/danmaku/provider.rs
+++ b/crates/platforms/src/danmaku/provider.rs
@@ -2,7 +2,6 @@
 //!
 //! Defines the interface for platform-specific danmu providers.
 
-use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use std::collections::HashMap;
 
@@ -96,20 +95,30 @@ impl ConnectionConfig {
 }
 
 /// Trait for platform-specific danmu providers.
-#[async_trait]
+#[dynosaur::dynosaur(pub DynDanmuProvider = dyn(box) DanmuProvider)]
 pub trait DanmuProvider: Send + Sync {
     /// Get the platform name this provider handles.
     fn platform(&self) -> &str;
 
     /// Connect to the danmu stream for a room.
-    async fn connect(&self, room_id: &str, config: ConnectionConfig) -> Result<DanmuConnection>;
+    fn connect(
+        &self,
+        room_id: &str,
+        config: ConnectionConfig,
+    ) -> impl std::future::Future<Output = Result<DanmuConnection>> + Send;
 
     /// Disconnect from the danmu stream.
-    async fn disconnect(&self, connection: &mut DanmuConnection) -> Result<()>;
+    fn disconnect(
+        &self,
+        connection: &mut DanmuConnection,
+    ) -> impl std::future::Future<Output = Result<()>> + Send;
 
     /// Receive the next danmu item (message or control event).
     /// Returns None if the connection is closed.
-    async fn receive(&self, connection: &DanmuConnection) -> Result<Option<DanmuItem>>;
+    fn receive(
+        &self,
+        connection: &DanmuConnection,
+    ) -> impl std::future::Future<Output = Result<Option<DanmuItem>>> + Send;
 
     /// Check if the provider supports the given URL.
     fn supports_url(&self, url: &str) -> bool;

--- a/crates/platforms/src/danmaku/registry.rs
+++ b/crates/platforms/src/danmaku/registry.rs
@@ -1,6 +1,6 @@
 //! Registry of available danmu providers.
 
-use crate::danmaku::provider::DanmuProvider;
+use crate::danmaku::provider::{DanmuProvider, DynDanmuProvider};
 use crate::extractor::platforms::bilibili::danmu::create_bilibili_danmu_provider;
 use crate::extractor::platforms::douyin::create_douyin_danmu_provider;
 use crate::extractor::platforms::douyu::create_douyu_danmu_provider;
@@ -12,7 +12,7 @@ use std::sync::Arc;
 /// Registry of available danmu providers.
 #[derive(Default)]
 pub struct ProviderRegistry {
-    providers: Vec<Arc<dyn DanmuProvider>>,
+    providers: Vec<Arc<DynDanmuProvider<'static>>>,
 }
 
 impl ProviderRegistry {
@@ -26,22 +26,22 @@ impl ProviderRegistry {
     /// Create a registry with default providers.
     pub fn with_defaults() -> Self {
         let mut registry = Self::new();
-        registry.register(Arc::new(create_huya_danmu_provider()));
-        registry.register(Arc::new(create_bilibili_danmu_provider()));
-        registry.register(Arc::new(create_douyu_danmu_provider()));
-        registry.register(Arc::new(create_douyin_danmu_provider()));
-        registry.register(Arc::new(create_twitch_danmu_provider()));
-        registry.register(Arc::new(create_twitcasting_danmu_provider()));
+        registry.register(DynDanmuProvider::new_arc(create_huya_danmu_provider()));
+        registry.register(DynDanmuProvider::new_arc(create_bilibili_danmu_provider()));
+        registry.register(DynDanmuProvider::new_arc(create_douyu_danmu_provider()));
+        registry.register(DynDanmuProvider::new_arc(create_douyin_danmu_provider()));
+        registry.register(DynDanmuProvider::new_arc(create_twitch_danmu_provider()));
+        registry.register(DynDanmuProvider::new_arc(create_twitcasting_danmu_provider()));
         registry
     }
 
     /// Register a provider.
-    pub fn register(&mut self, provider: Arc<dyn DanmuProvider>) {
+    pub fn register(&mut self, provider: Arc<DynDanmuProvider<'static>>) {
         self.providers.push(provider);
     }
 
     /// Get a provider for the given platform.
-    pub fn get_by_platform(&self, platform: &str) -> Option<Arc<dyn DanmuProvider>> {
+    pub fn get_by_platform(&self, platform: &str) -> Option<Arc<DynDanmuProvider<'static>>> {
         self.providers
             .iter()
             .find(|p| p.platform().eq_ignore_ascii_case(platform))
@@ -49,7 +49,7 @@ impl ProviderRegistry {
     }
 
     /// Get a provider that supports the given URL.
-    pub fn get_by_url(&self, url: &str) -> Option<Arc<dyn DanmuProvider>> {
+    pub fn get_by_url(&self, url: &str) -> Option<Arc<DynDanmuProvider<'static>>> {
         self.providers.iter().find(|p| p.supports_url(url)).cloned()
     }
 

--- a/crates/platforms/src/danmaku/websocket.rs
+++ b/crates/platforms/src/danmaku/websocket.rs
@@ -1,4 +1,3 @@
-use async_trait::async_trait;
 use futures::{SinkExt, StreamExt};
 use std::future::Future;
 use rustls::{ClientConfig, crypto::aws_lc_rs};
@@ -670,7 +669,6 @@ impl<P: DanmuProtocol + Clone> WebSocketDanmuProvider<P> {
     }
 }
 
-#[async_trait]
 impl<P: DanmuProtocol + Clone> DanmuProvider for WebSocketDanmuProvider<P> {
     fn platform(&self) -> &str {
         self.protocol.platform()

--- a/crates/platforms/src/extractor/factory.rs
+++ b/crates/platforms/src/extractor/factory.rs
@@ -1,7 +1,7 @@
 use std::sync::LazyLock;
 
 use super::error::ExtractorError;
-use super::platform_extractor::PlatformExtractor;
+use super::platform_extractor::DynPlatformExtractor;
 use super::streamlink_extractor::StreamlinkExtractor;
 use crate::extractor::platforms::{
     self, acfun::Acfun, bilibili::Bilibili, douyin::Douyin, douyu::Douyu, huya::Huya,
@@ -16,8 +16,12 @@ static REDBOOK_PROFILE_URL_REGEX: LazyLock<Regex> = LazyLock::new(|| {
 });
 
 // A type alias for a thread-safe constructor function.
-type ExtractorConstructor =
-    fn(String, Client, Option<String>, Option<serde_json::Value>) -> Box<dyn PlatformExtractor>;
+type ExtractorConstructor = fn(
+    String,
+    Client,
+    Option<String>,
+    Option<serde_json::Value>,
+) -> Box<DynPlatformExtractor<'static>>;
 
 struct PlatformEntry {
     regex: &'static LazyLock<Regex>,
@@ -31,8 +35,7 @@ macro_rules! platform_registry {
                 PlatformEntry {
                     regex: &$regex,
                     constructor: |url, client, cookies, extras| {
-                        Box::new($builder(url, client, cookies, extras))
-                            as Box<dyn PlatformExtractor>
+                        DynPlatformExtractor::new_box($builder(url, client, cookies, extras))
                     },
                 },
             )+
@@ -71,7 +74,7 @@ impl ExtractorFactory {
         url: &str,
         cookies: Option<String>,
         extras: Option<serde_json::Value>,
-    ) -> Result<Box<dyn PlatformExtractor>, ExtractorError> {
+    ) -> Result<Box<DynPlatformExtractor<'static>>, ExtractorError> {
         if REDBOOK_PROFILE_URL_REGEX.is_match(url) {
             return Err(ExtractorError::ValidationError(
                 "RedBook profile URLs are not supported; use xhslink.com/m share links".to_string(),
@@ -92,7 +95,7 @@ impl ExtractorFactory {
         // Automatic fallback: try Streamlink for anything not covered by built-in extractors.
         // If Streamlink isn't available or can't handle the URL, preserve the legacy behavior.
         StreamlinkExtractor::new(url.to_string(), self.client.clone(), cookies, extras)
-            .map(|e| Box::new(e) as Box<dyn PlatformExtractor>)
+            .map(DynPlatformExtractor::new_box)
             .or(Err(ExtractorError::UnsupportedExtractor))
     }
 }

--- a/crates/platforms/src/extractor/platform_extractor.rs
+++ b/crates/platforms/src/extractor/platform_extractor.rs
@@ -2,7 +2,6 @@ use crate::extractor::default::DEFAULT_UA;
 use crate::media::StreamInfo;
 
 use super::{super::media::media_info::MediaInfo, error::ExtractorError};
-use async_trait::async_trait;
 use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
 use reqwest::{Client, Method, RequestBuilder};
 use rustc_hash::FxHashMap;
@@ -442,7 +441,7 @@ impl Extractor {
     }
 }
 
-#[async_trait]
+#[dynosaur::dynosaur(pub DynPlatformExtractor = dyn(box) PlatformExtractor)]
 pub trait PlatformExtractor: Send + Sync {
     fn get_extractor(&self) -> &Extractor;
 
@@ -454,11 +453,13 @@ pub trait PlatformExtractor: Send + Sync {
         &self.get_extractor().platform_params
     }
 
-    async fn extract(&self) -> Result<MediaInfo, ExtractorError>;
+    fn extract(&self) -> impl std::future::Future<Output = Result<MediaInfo, ExtractorError>> + Send;
 
     #[allow(unused_variables)]
-    async fn get_url(&self, stream_info: &mut StreamInfo) -> Result<(), ExtractorError> {
-        // Default implementation, can be overridden by specific extractors
-        Ok(())
+    fn get_url(
+        &self,
+        stream_info: &mut StreamInfo,
+    ) -> impl std::future::Future<Output = Result<(), ExtractorError>> + Send {
+        async { Ok(()) }
     }
 }

--- a/crates/platforms/src/extractor/platforms/acfun/builder.rs
+++ b/crates/platforms/src/extractor/platforms/acfun/builder.rs
@@ -1,6 +1,5 @@
 use std::sync::LazyLock;
 
-use async_trait::async_trait;
 use regex::Regex;
 use reqwest::{Client, header};
 
@@ -47,7 +46,6 @@ impl Acfun {
     }
 }
 
-#[async_trait]
 impl PlatformExtractor for Acfun {
     fn get_extractor(&self) -> &Extractor {
         &self.extractor

--- a/crates/platforms/src/extractor/platforms/bilibili/builder.rs
+++ b/crates/platforms/src/extractor/platforms/bilibili/builder.rs
@@ -1,6 +1,5 @@
 use std::{fmt::Display, sync::LazyLock};
 
-use async_trait::async_trait;
 use regex::Regex;
 use reqwest::Client;
 use tracing::debug;
@@ -323,7 +322,6 @@ impl Bilibili {
     }
 }
 
-#[async_trait]
 impl PlatformExtractor for Bilibili {
     fn get_extractor(&self) -> &Extractor {
         &self.extractor

--- a/crates/platforms/src/extractor/platforms/douyin/builder.rs
+++ b/crates/platforms/src/extractor/platforms/douyin/builder.rs
@@ -18,7 +18,6 @@ use crate::extractor::utils::{extras_get_bool, extras_get_str};
 use crate::media::formats::{MediaFormat, StreamFormat};
 use crate::media::media_info::MediaInfo;
 use crate::media::stream_info::StreamInfo;
-use async_trait::async_trait;
 use regex::Regex;
 use reqwest::{Client, RequestBuilder};
 use rustc_hash::FxHashMap;
@@ -1125,7 +1124,6 @@ impl<'a> DouyinRequest<'a> {
     }
 }
 
-#[async_trait]
 impl PlatformExtractor for Douyin {
     fn get_extractor(&self) -> &Extractor {
         &self.extractor

--- a/crates/platforms/src/extractor/platforms/douyu/builder.rs
+++ b/crates/platforms/src/extractor/platforms/douyu/builder.rs
@@ -1,6 +1,5 @@
 use std::sync::{Arc, LazyLock};
 
-use async_trait::async_trait;
 
 use parking_lot::RwLock;
 use regex::Regex;
@@ -1033,7 +1032,6 @@ impl Douyu {
     }
 }
 
-#[async_trait]
 impl PlatformExtractor for Douyu {
     fn get_extractor(&self) -> &Extractor {
         &self.extractor

--- a/crates/platforms/src/extractor/platforms/huya/builder.rs
+++ b/crates/platforms/src/extractor/platforms/huya/builder.rs
@@ -10,7 +10,6 @@ use crate::media::MediaFormat;
 use crate::media::formats::StreamFormat;
 use crate::media::media_info::MediaInfo;
 use crate::media::stream_info::StreamInfo;
-use async_trait::async_trait;
 
 use regex::Regex;
 use reqwest::Client;
@@ -217,7 +216,6 @@ impl Huya {
     }
 }
 
-#[async_trait]
 impl PlatformExtractor for Huya {
     fn get_extractor(&self) -> &Extractor {
         &self.extractor

--- a/crates/platforms/src/extractor/platforms/pandatv/builder.rs
+++ b/crates/platforms/src/extractor/platforms/pandatv/builder.rs
@@ -1,6 +1,5 @@
 use std::sync::LazyLock;
 
-use async_trait::async_trait;
 use regex::Regex;
 use reqwest::Client;
 use rustc_hash::FxHashMap;
@@ -205,7 +204,6 @@ impl PandaTV {
 
 impl HlsExtractor for PandaTV {}
 
-#[async_trait]
 impl PlatformExtractor for PandaTV {
     fn get_extractor(&self) -> &Extractor {
         &self.extractor

--- a/crates/platforms/src/extractor/platforms/picarto/builder.rs
+++ b/crates/platforms/src/extractor/platforms/picarto/builder.rs
@@ -131,7 +131,6 @@ impl Picarto {
 
 impl HlsExtractor for Picarto {}
 
-#[async_trait::async_trait]
 impl PlatformExtractor for Picarto {
     fn get_extractor(&self) -> &Extractor {
         &self.extractor

--- a/crates/platforms/src/extractor/platforms/redbook/builder.rs
+++ b/crates/platforms/src/extractor/platforms/redbook/builder.rs
@@ -1,4 +1,3 @@
-use async_trait::async_trait;
 use regex::Regex;
 use reqwest::Client;
 use std::sync::LazyLock;
@@ -323,7 +322,6 @@ impl RedBook {
     }
 }
 
-#[async_trait]
 impl PlatformExtractor for RedBook {
     fn get_extractor(&self) -> &Extractor {
         &self.extractor

--- a/crates/platforms/src/extractor/platforms/tiktok/builder.rs
+++ b/crates/platforms/src/extractor/platforms/tiktok/builder.rs
@@ -1,6 +1,5 @@
 use std::{collections::HashMap, sync::LazyLock};
 
-use async_trait::async_trait;
 use regex::Regex;
 use reqwest::Client;
 use serde_json::json;
@@ -222,7 +221,6 @@ impl TikTok {
     }
 }
 
-#[async_trait]
 impl PlatformExtractor for TikTok {
     fn get_extractor(&self) -> &Extractor {
         &self.extractor

--- a/crates/platforms/src/extractor/platforms/twitcasting/builder.rs
+++ b/crates/platforms/src/extractor/platforms/twitcasting/builder.rs
@@ -8,7 +8,6 @@ use crate::{
     },
     media::{MediaInfo, stream_info::StreamInfo},
 };
-use async_trait::async_trait;
 use md5::{Digest, Md5};
 use regex::Regex;
 use reqwest::Client;
@@ -173,7 +172,6 @@ impl Twitcasting {
 
 impl HlsExtractor for Twitcasting {}
 
-#[async_trait]
 impl PlatformExtractor for Twitcasting {
     fn get_extractor(&self) -> &Extractor {
         &self.extractor

--- a/crates/platforms/src/extractor/platforms/twitch/builder.rs
+++ b/crates/platforms/src/extractor/platforms/twitch/builder.rs
@@ -8,7 +8,6 @@ use crate::extractor::platforms::twitch::models::TwitchResponse;
 use crate::extractor::utils::{capture_group_1_or_invalid_url, extras_get_str};
 use crate::media::StreamInfo;
 use crate::media::media_info::MediaInfo;
-use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use rand::RngExt;
 use regex::Regex;
@@ -295,7 +294,6 @@ impl Twitch {
 
 impl HlsExtractor for Twitch {}
 
-#[async_trait]
 impl PlatformExtractor for Twitch {
     fn get_extractor(&self) -> &Extractor {
         &self.extractor

--- a/crates/platforms/src/extractor/platforms/weibo/builder.rs
+++ b/crates/platforms/src/extractor/platforms/weibo/builder.rs
@@ -1,4 +1,3 @@
-use async_trait::async_trait;
 use regex::Regex;
 use reqwest::Client;
 use std::sync::LazyLock;
@@ -231,7 +230,6 @@ impl Weibo {
     }
 }
 
-#[async_trait]
 impl PlatformExtractor for Weibo {
     fn get_extractor(&self) -> &Extractor {
         &self.extractor

--- a/crates/platforms/src/extractor/streamlink_extractor.rs
+++ b/crates/platforms/src/extractor/streamlink_extractor.rs
@@ -1,7 +1,6 @@
 use crate::extractor::error::ExtractorError;
 use crate::extractor::platform_extractor::{Extractor, PlatformExtractor};
 use crate::media::{MediaFormat, MediaInfo, StreamFormat, StreamInfo};
-use async_trait::async_trait;
 use reqwest::Client;
 use rustc_hash::FxHashMap;
 use serde::Deserialize;
@@ -204,7 +203,6 @@ impl StreamlinkExtractor {
     }
 }
 
-#[async_trait]
 impl PlatformExtractor for StreamlinkExtractor {
     fn get_extractor(&self) -> &Extractor {
         &self.extractor

--- a/rust-srec/Cargo.toml
+++ b/rust-srec/Cargo.toml
@@ -20,6 +20,7 @@ futures = { workspace = true }
 anyhow = { workspace = true }
 serde_json = { workspace = true }
 async-trait = { workspace = true }
+dynosaur = { workspace = true }
 reqwest = { workspace = true }
 sqlx = { workspace = true }
 url = { workspace = true }

--- a/rust-srec/Cargo.toml
+++ b/rust-srec/Cargo.toml
@@ -19,7 +19,6 @@ tokio-util = { workspace = true }
 futures = { workspace = true }
 anyhow = { workspace = true }
 serde_json = { workspace = true }
-async-trait = { workspace = true }
 dynosaur = { workspace = true }
 reqwest = { workspace = true }
 sqlx = { workspace = true }

--- a/rust-srec/src/api/auth_service.rs
+++ b/rust-srec/src/api/auth_service.rs
@@ -17,7 +17,10 @@ use sha2::{Digest, Sha256};
 use tracing::{debug, info, warn};
 
 use crate::database::models::RefreshTokenDbModel;
-use crate::database::repositories::{RefreshTokenRepository, UserRepository};
+use crate::database::repositories::{
+    DynUserRepository, RefreshTokenRepository, UserRepository,
+    refresh_token::DynRefreshTokenRepository,
+};
 
 use super::jwt::JwtService;
 
@@ -173,8 +176,8 @@ pub struct SessionInfo {
 
 /// Authentication service for managing user authentication and tokens.
 pub struct AuthService {
-    user_repo: Arc<dyn UserRepository>,
-    token_repo: Arc<dyn RefreshTokenRepository>,
+    user_repo: Arc<DynUserRepository<'static>>,
+    token_repo: Arc<DynRefreshTokenRepository<'static>>,
     jwt_service: Arc<JwtService>,
     config: AuthConfig,
 }
@@ -182,8 +185,8 @@ pub struct AuthService {
 impl AuthService {
     /// Create a new AuthService.
     pub fn new(
-        user_repo: Arc<dyn UserRepository>,
-        token_repo: Arc<dyn RefreshTokenRepository>,
+        user_repo: Arc<DynUserRepository<'static>>,
+        token_repo: Arc<DynRefreshTokenRepository<'static>>,
         jwt_service: Arc<JwtService>,
         config: AuthConfig,
     ) -> Self {
@@ -195,7 +198,7 @@ impl AuthService {
         }
     }
 
-    pub fn user_repository(&self) -> Arc<dyn UserRepository> {
+    pub fn user_repository(&self) -> Arc<DynUserRepository<'static>> {
         self.user_repo.clone()
     }
 
@@ -772,8 +775,8 @@ mod tests {
         use std::sync::Arc;
 
         // Create mock repositories using a simple in-memory implementation
-        let user_repo = Arc::new(MockUserRepository);
-        let token_repo = Arc::new(MockRefreshTokenRepository);
+        let user_repo = DynUserRepository::new_arc(MockUserRepository);
+        let token_repo = DynRefreshTokenRepository::new_arc(MockRefreshTokenRepository);
         let jwt_service = Arc::new(JwtService::new(
             "test-secret-key-32-chars-long!!",
             "test-issuer",
@@ -787,7 +790,6 @@ mod tests {
     // Mock implementations for testing
     struct MockUserRepository;
 
-    #[async_trait::async_trait]
     impl UserRepository for MockUserRepository {
         async fn create(&self, _user: &UserDbModel) -> crate::Result<()> {
             Ok(())
@@ -823,7 +825,6 @@ mod tests {
 
     struct MockRefreshTokenRepository;
 
-    #[async_trait::async_trait]
     impl RefreshTokenRepository for MockRefreshTokenRepository {
         async fn create(&self, _token: &RefreshTokenDbModel) -> crate::Result<()> {
             Ok(())
@@ -854,25 +855,25 @@ mod tests {
         }
     }
 
+    #[derive(Clone)]
     struct SpyRefreshTokenRepository {
-        token: Mutex<RefreshTokenDbModel>,
-        revoke_all_called: AtomicBool,
-        revoke_called: AtomicBool,
-        create_called: AtomicBool,
+        token: Arc<Mutex<RefreshTokenDbModel>>,
+        revoke_all_called: Arc<AtomicBool>,
+        revoke_called: Arc<AtomicBool>,
+        create_called: Arc<AtomicBool>,
     }
 
     impl SpyRefreshTokenRepository {
         fn new(token: RefreshTokenDbModel) -> Self {
             Self {
-                token: Mutex::new(token),
-                revoke_all_called: AtomicBool::new(false),
-                revoke_called: AtomicBool::new(false),
-                create_called: AtomicBool::new(false),
+                token: Arc::new(Mutex::new(token)),
+                revoke_all_called: Arc::new(AtomicBool::new(false)),
+                revoke_called: Arc::new(AtomicBool::new(false)),
+                create_called: Arc::new(AtomicBool::new(false)),
             }
         }
     }
 
-    #[async_trait::async_trait]
     impl RefreshTokenRepository for SpyRefreshTokenRepository {
         async fn create(&self, _token: &RefreshTokenDbModel) -> crate::Result<()> {
             self.create_called.store(true, Ordering::SeqCst);
@@ -920,7 +921,6 @@ mod tests {
         user: UserDbModel,
     }
 
-    #[async_trait::async_trait]
     impl UserRepository for SpyUserRepository {
         async fn create(&self, _user: &UserDbModel) -> crate::Result<()> {
             Ok(())
@@ -967,8 +967,9 @@ mod tests {
             RefreshTokenDbModel::new("user-1", token_hash, Utc::now() + Duration::days(7), None);
         stored.revoked_at = Some((Utc::now() - Duration::hours(2)).timestamp_millis());
 
-        let token_repo = Arc::new(SpyRefreshTokenRepository::new(stored));
-        let user_repo = Arc::new(MockUserRepository);
+        let token_repo = SpyRefreshTokenRepository::new(stored);
+        let token_repo_dyn = DynRefreshTokenRepository::new_arc(token_repo.clone());
+        let user_repo = DynUserRepository::new_arc(MockUserRepository);
         let jwt_service = Arc::new(JwtService::new(
             "test-secret-key-32-chars-long!!",
             "test-issuer",
@@ -978,7 +979,7 @@ mod tests {
 
         let service = AuthService::new(
             user_repo,
-            token_repo.clone(),
+            token_repo_dyn,
             jwt_service,
             AuthConfig::default(),
         );
@@ -997,8 +998,9 @@ mod tests {
             RefreshTokenDbModel::new("user-1", token_hash, Utc::now() + Duration::days(7), None);
         stored.revoked_at = Some((Utc::now() - Duration::hours(2)).timestamp_millis());
 
-        let token_repo = Arc::new(SpyRefreshTokenRepository::new(stored));
-        let user_repo = Arc::new(MockUserRepository);
+        let token_repo = SpyRefreshTokenRepository::new(stored);
+        let token_repo_dyn = DynRefreshTokenRepository::new_arc(token_repo.clone());
+        let user_repo = DynUserRepository::new_arc(MockUserRepository);
         let jwt_service = Arc::new(JwtService::new(
             "test-secret-key-32-chars-long!!",
             "test-issuer",
@@ -1011,7 +1013,7 @@ mod tests {
             ..Default::default()
         };
 
-        let service = AuthService::new(user_repo, token_repo.clone(), jwt_service, config);
+        let service = AuthService::new(user_repo, token_repo_dyn, jwt_service, config);
 
         let result = service.refresh_tokens(refresh_token).await;
         assert!(matches!(result, Err(AuthError::TokenRevoked)));
@@ -1031,12 +1033,13 @@ mod tests {
         );
         stored.revoked_at = Some((Utc::now() - Duration::seconds(1)).timestamp_millis());
 
-        let token_repo = Arc::new(SpyRefreshTokenRepository::new(stored));
+        let token_repo = SpyRefreshTokenRepository::new(stored);
+        let token_repo_dyn = DynRefreshTokenRepository::new_arc(token_repo.clone());
 
         let mut user = UserDbModel::new("u", "hash", vec!["admin".to_string()]);
         user.id = "user-1".to_string();
         user.must_change_password = false;
-        let user_repo = Arc::new(SpyUserRepository { user });
+        let user_repo = DynUserRepository::new_arc(SpyUserRepository { user });
 
         let jwt_service = Arc::new(JwtService::new(
             "test-secret-key-32-chars-long!!",
@@ -1050,7 +1053,7 @@ mod tests {
             ..Default::default()
         };
 
-        let service = AuthService::new(user_repo, token_repo.clone(), jwt_service, config);
+        let service = AuthService::new(user_repo, token_repo_dyn, jwt_service, config);
 
         let result = service.refresh_tokens(refresh_token).await;
         assert!(result.is_ok());
@@ -1281,7 +1284,6 @@ mod property_tests {
 
         struct MockUserRepo;
 
-        #[async_trait::async_trait]
         impl UserRepository for MockUserRepo {
             async fn create(&self, _user: &UserDbModel) -> crate::Result<()> {
                 Ok(())
@@ -1325,7 +1327,6 @@ mod property_tests {
 
         struct MockTokenRepo;
 
-        #[async_trait::async_trait]
         impl RefreshTokenRepository for MockTokenRepo {
             async fn create(&self, _token: &RefreshTokenDbModel) -> crate::Result<()> {
                 Ok(())
@@ -1356,8 +1357,8 @@ mod property_tests {
             }
         }
 
-        let user_repo = Arc::new(MockUserRepo);
-        let token_repo = Arc::new(MockTokenRepo);
+        let user_repo = DynUserRepository::new_arc(MockUserRepo);
+        let token_repo = DynRefreshTokenRepository::new_arc(MockTokenRepo);
         let jwt_service = Arc::new(JwtService::new(
             "test-secret-key-32-chars-long!!",
             "test-issuer",

--- a/rust-srec/src/api/routes/credentials.rs
+++ b/rust-srec/src/api/routes/credentials.rs
@@ -12,6 +12,7 @@ use crate::api::error::{ApiError, ApiResult};
 use crate::api::server::AppState;
 use crate::credentials::platforms::bilibili::{BilibiliCredentialManager, QrPollStatus};
 use crate::credentials::{CredentialScope, CredentialSource};
+use crate::database::repositories::streamer::StreamerRepository;
 
 #[derive(Debug, Clone, Serialize, ToSchema)]
 pub struct CredentialSourceResponse {

--- a/rust-srec/src/api/routes/engines.rs
+++ b/rust-srec/src/api/routes/engines.rs
@@ -14,7 +14,9 @@ use crate::database::models::{
     EngineConfigurationDbModel, EngineType, FfmpegEngineConfig, MesioEngineConfig,
     StreamlinkEngineConfig,
 };
-use crate::downloader::engine::{DownloadEngine, FfmpegEngine, MesioEngine, StreamlinkEngine};
+use crate::downloader::engine::{
+    DownloadEngine, DynDownloadEngine, FfmpegEngine, MesioEngine, StreamlinkEngine,
+};
 
 /// Create the engines router.
 pub fn router() -> Router<AppState> {
@@ -256,21 +258,21 @@ pub async fn test_engine(
         ApiError::internal(format!("Invalid engine type: {}", config.engine_type))
     })?;
 
-    let engine: Box<dyn DownloadEngine> = match engine_type {
+    let engine: Box<DynDownloadEngine<'static>> = match engine_type {
         EngineType::Ffmpeg => {
             let engine_config: FfmpegEngineConfig = serde_json::from_str(&config.config)
                 .map_err(|e| ApiError::internal(format!("Invalid ffmpeg config: {}", e)))?;
-            Box::new(FfmpegEngine::with_config(engine_config))
+            DynDownloadEngine::new_box(FfmpegEngine::with_config(engine_config))
         }
         EngineType::Streamlink => {
             let engine_config: StreamlinkEngineConfig = serde_json::from_str(&config.config)
                 .map_err(|e| ApiError::internal(format!("Invalid streamlink config: {}", e)))?;
-            Box::new(StreamlinkEngine::with_config(engine_config))
+            DynDownloadEngine::new_box(StreamlinkEngine::with_config(engine_config))
         }
         EngineType::Mesio => {
             let engine_config: MesioEngineConfig = serde_json::from_str(&config.config)
                 .map_err(|e| ApiError::internal(format!("Invalid mesio config: {}", e)))?;
-            Box::new(MesioEngine::with_config(engine_config))
+            DynDownloadEngine::new_box(MesioEngine::with_config(engine_config))
         }
     };
 

--- a/rust-srec/src/api/routes/export_import.rs
+++ b/rust-srec/src/api/routes/export_import.rs
@@ -22,8 +22,11 @@ use crate::database::models::{
     StreamerDbModel, TemplateConfigDbModel, UserDbModel,
 };
 use crate::database::models::{JobPreset, PipelinePreset};
+use crate::database::repositories::NotificationRepository;
 use crate::database::repositories::filter::FilterRepository;
 use crate::database::repositories::preset::{JobPresetRepository, PipelinePresetRepository};
+use crate::database::repositories::streamer::StreamerRepository;
+use crate::database::repositories::user::UserRepository;
 
 /// Current schema version for exports.
 const EXPORT_SCHEMA_VERSION: &str = "0.1.5";
@@ -1752,7 +1755,10 @@ mod tests {
     use crate::api::auth_service::{AuthConfig, AuthService};
     use crate::api::jwt::JwtService;
     use crate::database::models::RefreshTokenDbModel;
-    use crate::database::repositories::{RefreshTokenRepository, UserRepository};
+    use crate::database::repositories::{
+        DynUserRepository, RefreshTokenRepository, UserRepository,
+        refresh_token::DynRefreshTokenRepository,
+    };
     use std::sync::Arc;
     use tokio::sync::Mutex;
 
@@ -1870,7 +1876,6 @@ mod tests {
             users: Vec<UserDbModel>,
         }
 
-        #[async_trait::async_trait]
         impl UserRepository for TestUserRepo {
             async fn create(&self, _user: &UserDbModel) -> crate::Result<()> {
                 Ok(())
@@ -1921,11 +1926,11 @@ mod tests {
             }
         }
 
+        #[derive(Clone)]
         struct TestTokenRepo {
-            revoked_for_users: Mutex<Vec<String>>,
+            revoked_for_users: Arc<Mutex<Vec<String>>>,
         }
 
-        #[async_trait::async_trait]
         impl RefreshTokenRepository for TestTokenRepo {
             async fn create(&self, _token: &RefreshTokenDbModel) -> crate::Result<()> {
                 Ok(())
@@ -1969,13 +1974,13 @@ mod tests {
         let user1 = UserDbModel::new("user1", "hash1", vec!["user".to_string()]);
         let user2 = UserDbModel::new("user2", "hash2", vec!["user".to_string()]);
 
-        let user_repo: Arc<dyn UserRepository> = Arc::new(TestUserRepo {
+        let user_repo = DynUserRepository::new_arc(TestUserRepo {
             users: vec![user1.clone(), user2.clone()],
         });
-        let token_repo = Arc::new(TestTokenRepo {
-            revoked_for_users: Mutex::new(vec![]),
-        });
-        let token_repo_dyn: Arc<dyn RefreshTokenRepository> = token_repo.clone();
+        let token_repo = TestTokenRepo {
+            revoked_for_users: Arc::new(Mutex::new(vec![])),
+        };
+        let token_repo_dyn = DynRefreshTokenRepository::new_arc(token_repo.clone());
 
         let jwt = Arc::new(JwtService::new("secret", "issuer", "aud", Some(3600)));
         let auth = AuthService::new(user_repo, token_repo_dyn, jwt, AuthConfig::default());

--- a/rust-srec/src/api/routes/export_import.rs
+++ b/rust-srec/src/api/routes/export_import.rs
@@ -22,6 +22,8 @@ use crate::database::models::{
     StreamerDbModel, TemplateConfigDbModel, UserDbModel,
 };
 use crate::database::models::{JobPreset, PipelinePreset};
+use crate::database::repositories::filter::FilterRepository;
+use crate::database::repositories::preset::{JobPresetRepository, PipelinePresetRepository};
 
 /// Current schema version for exports.
 const EXPORT_SCHEMA_VERSION: &str = "0.1.5";

--- a/rust-srec/src/api/routes/filters.rs
+++ b/rust-srec/src/api/routes/filters.rs
@@ -10,6 +10,7 @@ use serde_json::Value;
 use crate::api::error::{ApiError, ApiResult};
 use crate::api::models::{CreateFilterRequest, FilterResponse, UpdateFilterRequest};
 use crate::api::server::AppState;
+use crate::database::repositories::filter::FilterRepository;
 use crate::database::models::{
     CategoryFilterConfig, CronFilterConfig, FilterConfigValidator, FilterDbModel, FilterType,
     KeywordFilterConfig, RegexFilterConfig, TimeBasedFilterConfig,

--- a/rust-srec/src/api/routes/media.rs
+++ b/rust-srec/src/api/routes/media.rs
@@ -11,6 +11,7 @@ use tower_http::services::ServeFile;
 
 use crate::api::error::{ApiError, ApiResult};
 use crate::api::server::AppState;
+use crate::database::repositories::SessionRepository;
 
 /// Create the media router.
 pub fn router() -> Router<AppState> {

--- a/rust-srec/src/api/routes/notifications.rs
+++ b/rust-srec/src/api/routes/notifications.rs
@@ -10,6 +10,7 @@ use url::Url;
 use crate::api::error::ApiError;
 use crate::api::jwt::Claims;
 use crate::api::server::AppState;
+use crate::database::repositories::NotificationRepository;
 use crate::database::models::notification::{
     ChannelType, NotificationChannelDbModel, NotificationEventLogDbModel,
 };

--- a/rust-srec/src/api/routes/parse.rs
+++ b/rust-srec/src/api/routes/parse.rs
@@ -2,6 +2,7 @@
 
 use axum::{Json, Router, extract::State, routing::post};
 use platforms_parser::extractor::factory::ExtractorFactory;
+use platforms_parser::extractor::platform_extractor::PlatformExtractor;
 use std::time::Duration;
 use tracing::{debug, warn};
 

--- a/rust-srec/src/api/routes/pipeline.rs
+++ b/rust-srec/src/api/routes/pipeline.rs
@@ -78,6 +78,7 @@ use crate::api::models::{
 use crate::api::server::AppState;
 use crate::database::models::job::{DagPipelineDefinition, PipelineStep};
 use crate::database::models::{JobFilters, JobStatus as DbJobStatus, OutputFilters, Pagination};
+use crate::database::repositories::preset::PipelinePresetRepository;
 use crate::pipeline::JobProgressSnapshot;
 use crate::pipeline::{Job, JobStatus as QueueJobStatus};
 

--- a/rust-srec/src/api/routes/pipeline.rs
+++ b/rust-srec/src/api/routes/pipeline.rs
@@ -79,6 +79,8 @@ use crate::api::server::AppState;
 use crate::database::models::job::{DagPipelineDefinition, PipelineStep};
 use crate::database::models::{JobFilters, JobStatus as DbJobStatus, OutputFilters, Pagination};
 use crate::database::repositories::preset::PipelinePresetRepository;
+use crate::database::repositories::session::SessionRepository;
+use crate::database::repositories::streamer::StreamerRepository;
 use crate::pipeline::JobProgressSnapshot;
 use crate::pipeline::{Job, JobStatus as QueueJobStatus};
 

--- a/rust-srec/src/api/routes/sessions.rs
+++ b/rust-srec/src/api/routes/sessions.rs
@@ -23,6 +23,8 @@ use crate::api::models::{
     SessionSegmentResponse, TitleChange,
 };
 use crate::api::server::AppState;
+use crate::database::repositories::session::SessionRepository;
+use crate::database::repositories::streamer::StreamerRepository;
 use crate::database::models::{
     DanmuRateEntry, Pagination, SessionFilters, TitleEntry, TopTalkerEntry,
 };
@@ -481,7 +483,7 @@ pub async fn get_session_danmu_statistics(
 /// Helper to get the thumbnail URL for a session
 async fn get_thumbnail_url(
     session_id: &str,
-    repo: &dyn crate::database::repositories::session::SessionRepository,
+    repo: &crate::database::repositories::session::DynSessionRepository<'_>,
 ) -> Option<String> {
     use crate::database::models::MediaFileType;
     // We assume the repository method returns outputs ordered by creation, taking the first thumbnail found

--- a/rust-srec/src/api/server.rs
+++ b/rust-srec/src/api/server.rs
@@ -76,8 +76,8 @@ use crate::credentials::CredentialRefreshService;
 use crate::danmu::DanmuService;
 use crate::database::repositories::{
     config::SqlxConfigRepository,
-    filter::FilterRepository,
-    preset::PipelinePresetRepository,
+    filter::DynFilterRepository,
+    preset::{DynJobPresetRepository, DynPipelinePresetRepository},
     session::SessionRepository,
     streamer::{SqlxStreamerRepository, StreamerRepository},
 };
@@ -111,15 +111,15 @@ pub struct AppState {
     /// Session repository for session and output queries
     pub session_repository: Option<Arc<dyn SessionRepository>>,
     /// Filter repository for streamer filters
-    pub filter_repository: Option<Arc<dyn FilterRepository>>,
+    pub filter_repository: Option<Arc<DynFilterRepository<'static>>>,
     /// Health checker for real health status
     pub health_checker: Option<Arc<HealthChecker>>,
     /// Streamer repository for querying streamer details
     pub streamer_repository: Option<Arc<dyn StreamerRepository>>,
     /// Pipeline preset repository for pipeline presets (workflow sequences)
-    pub pipeline_preset_repository: Option<Arc<dyn PipelinePresetRepository>>,
+    pub pipeline_preset_repository: Option<Arc<DynPipelinePresetRepository<'static>>>,
     /// Job preset repository for job presets (reusable processor configs)
-    pub job_preset_repository: Option<Arc<dyn crate::database::repositories::JobPresetRepository>>,
+    pub job_preset_repository: Option<Arc<DynJobPresetRepository<'static>>>,
     /// Notification repository for channel/subscription management
     pub notification_repository: Option<Arc<dyn NotificationRepository>>,
     /// Notification service for testing and reloading
@@ -251,7 +251,10 @@ impl AppState {
     }
 
     /// Set the filter repository.
-    pub fn with_filter_repository(mut self, filter_repository: Arc<dyn FilterRepository>) -> Self {
+    pub fn with_filter_repository(
+        mut self,
+        filter_repository: Arc<DynFilterRepository<'static>>,
+    ) -> Self {
         self.filter_repository = Some(filter_repository);
         self
     }
@@ -295,7 +298,7 @@ impl AppState {
     /// Set the pipeline preset repository.
     pub fn with_pipeline_preset_repository(
         mut self,
-        repo: Arc<dyn PipelinePresetRepository>,
+        repo: Arc<DynPipelinePresetRepository<'static>>,
     ) -> Self {
         self.pipeline_preset_repository = Some(repo);
         self
@@ -304,7 +307,7 @@ impl AppState {
     /// Set the job preset repository.
     pub fn with_job_preset_repository(
         mut self,
-        repo: Arc<dyn crate::database::repositories::JobPresetRepository>,
+        repo: Arc<DynJobPresetRepository<'static>>,
     ) -> Self {
         self.job_preset_repository = Some(repo);
         self

--- a/rust-srec/src/api/server.rs
+++ b/rust-srec/src/api/server.rs
@@ -14,7 +14,7 @@ use tower_http::trace::TraceLayer;
 use tracing::Span;
 
 use crate::api::routes;
-use crate::database::repositories::NotificationRepository;
+use crate::database::repositories::DynNotificationRepository;
 use crate::error::Result;
 use crate::notification::NotificationService;
 
@@ -78,8 +78,8 @@ use crate::database::repositories::{
     config::SqlxConfigRepository,
     filter::DynFilterRepository,
     preset::{DynJobPresetRepository, DynPipelinePresetRepository},
-    session::SessionRepository,
-    streamer::{SqlxStreamerRepository, StreamerRepository},
+    session::DynSessionRepository,
+    streamer::{DynStreamerRepository, SqlxStreamerRepository},
 };
 use crate::downloader::DownloadManager;
 use crate::metrics::HealthChecker;
@@ -109,19 +109,19 @@ pub struct AppState {
     /// Download manager
     pub download_manager: Option<Arc<DownloadManager>>,
     /// Session repository for session and output queries
-    pub session_repository: Option<Arc<dyn SessionRepository>>,
+    pub session_repository: Option<Arc<DynSessionRepository<'static>>>,
     /// Filter repository for streamer filters
     pub filter_repository: Option<Arc<DynFilterRepository<'static>>>,
     /// Health checker for real health status
     pub health_checker: Option<Arc<HealthChecker>>,
     /// Streamer repository for querying streamer details
-    pub streamer_repository: Option<Arc<dyn StreamerRepository>>,
+    pub streamer_repository: Option<Arc<DynStreamerRepository<'static>>>,
     /// Pipeline preset repository for pipeline presets (workflow sequences)
     pub pipeline_preset_repository: Option<Arc<DynPipelinePresetRepository<'static>>>,
     /// Job preset repository for job presets (reusable processor configs)
     pub job_preset_repository: Option<Arc<DynJobPresetRepository<'static>>>,
     /// Notification repository for channel/subscription management
-    pub notification_repository: Option<Arc<dyn NotificationRepository>>,
+    pub notification_repository: Option<Arc<DynNotificationRepository<'static>>>,
     /// Notification service for testing and reloading
     pub notification_service: Option<Arc<NotificationService>>,
     /// Web push service for browser notifications (VAPID)
@@ -244,7 +244,7 @@ impl AppState {
     /// Set the session repository.
     pub fn with_session_repository(
         mut self,
-        session_repository: Arc<dyn SessionRepository>,
+        session_repository: Arc<DynSessionRepository<'static>>,
     ) -> Self {
         self.session_repository = Some(session_repository);
         self
@@ -262,7 +262,7 @@ impl AppState {
     /// Set the streamer repository.
     pub fn with_streamer_repository(
         mut self,
-        streamer_repository: Arc<dyn StreamerRepository>,
+        streamer_repository: Arc<DynStreamerRepository<'static>>,
     ) -> Self {
         self.streamer_repository = Some(streamer_repository);
         self
@@ -314,7 +314,7 @@ impl AppState {
     }
 
     /// Set the notification repository.
-    pub fn with_notification_repository(mut self, repo: Arc<dyn NotificationRepository>) -> Self {
+    pub fn with_notification_repository(mut self, repo: Arc<DynNotificationRepository<'static>>) -> Self {
         self.notification_repository = Some(repo);
         self
     }

--- a/rust-srec/src/credentials/manager.rs
+++ b/rust-srec/src/credentials/manager.rs
@@ -1,6 +1,5 @@
 //! Platform-specific credential manager trait.
 
-use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 
 use super::CredentialError;
@@ -87,7 +86,7 @@ impl RefreshState {
 /// Platform-specific credential management trait.
 ///
 /// Implementations handle the specific refresh protocols for each platform.
-#[async_trait]
+#[dynosaur::dynosaur(pub DynCredentialManager = dyn(box) CredentialManager)]
 pub trait CredentialManager: Send + Sync {
     /// Platform identifier (e.g., "bilibili", "douyin").
     fn platform_id(&self) -> &'static str;
@@ -100,7 +99,10 @@ pub trait CredentialManager: Send + Sync {
     /// # Returns
     /// * `Ok(CredentialStatus)` - Check completed successfully
     /// * `Err(...)` - Network or parsing error during check
-    async fn check_status(&self, cookies: &str) -> Result<CredentialStatus, CredentialError>;
+    fn check_status(
+        &self,
+        cookies: &str,
+    ) -> impl std::future::Future<Output = Result<CredentialStatus, CredentialError>> + Send;
 
     /// Perform credential refresh.
     ///
@@ -110,7 +112,10 @@ pub trait CredentialManager: Send + Sync {
     /// # Returns
     /// * `Ok(RefreshedCredentials)` - Refresh successful
     /// * `Err(...)` - Refresh failed (may need re-login)
-    async fn refresh(&self, state: &RefreshState) -> Result<RefreshedCredentials, CredentialError>;
+    fn refresh(
+        &self,
+        state: &RefreshState,
+    ) -> impl std::future::Future<Output = Result<RefreshedCredentials, CredentialError>> + Send;
 
     /// Validate credentials are working (e.g., make authenticated API call).
     ///
@@ -121,7 +126,10 @@ pub trait CredentialManager: Send + Sync {
     /// * `Ok(true)` - Credentials are working
     /// * `Ok(false)` - Credentials are invalid
     /// * `Err(...)` - Validation check failed
-    async fn validate(&self, cookies: &str) -> Result<bool, CredentialError>;
+    fn validate(
+        &self,
+        cookies: &str,
+    ) -> impl std::future::Future<Output = Result<bool, CredentialError>> + Send;
 
     /// Whether this manager supports automatic refresh.
     fn supports_auto_refresh(&self) -> bool {

--- a/rust-srec/src/credentials/mod.rs
+++ b/rust-srec/src/credentials/mod.rs
@@ -23,9 +23,11 @@ mod types;
 pub mod platforms;
 
 pub use error::CredentialError;
-pub use manager::{CredentialManager, CredentialStatus, RefreshState, RefreshedCredentials};
+pub use manager::{
+    CredentialManager, CredentialStatus, DynCredentialManager, RefreshState, RefreshedCredentials,
+};
 pub use resolver::CredentialResolver;
 pub use service::CredentialRefreshService;
-pub use store::CredentialStore;
+pub use store::{CredentialStore, DynCredentialStore};
 pub use tracker::{DailyCheckTracker, RefreshFailureTracker};
 pub use types::{CredentialEvent, CredentialScope, CredentialSource};

--- a/rust-srec/src/credentials/platforms/bilibili.rs
+++ b/rust-srec/src/credentials/platforms/bilibili.rs
@@ -5,7 +5,6 @@
 //! - Token refresh: via token_refresh utilities (OAuth2/APP flow)
 //! - Fallback validation: via NAV API for cookie-only users
 
-use async_trait::async_trait;
 use chrono::{Duration, Utc};
 use reqwest::Client;
 use std::sync::OnceLock;
@@ -122,7 +121,6 @@ impl BilibiliCredentialManager {
     }
 }
 
-#[async_trait]
 impl CredentialManager for BilibiliCredentialManager {
     fn platform_id(&self) -> &'static str {
         "bilibili"

--- a/rust-srec/src/credentials/service.rs
+++ b/rust-srec/src/credentials/service.rs
@@ -15,9 +15,11 @@ use crate::notification::{NotificationEvent, NotificationService};
 use crate::streamer::StreamerMetadata;
 
 use super::error::CredentialError;
-use super::manager::{CredentialManager, CredentialStatus, RefreshState, RefreshedCredentials};
+use super::manager::{
+    CredentialManager, CredentialStatus, DynCredentialManager, RefreshState, RefreshedCredentials,
+};
 use super::resolver::CredentialResolver;
-use super::store::CredentialStore;
+use super::store::{CredentialStore, DynCredentialStore};
 use super::tracker::{DailyCheckTracker, RefreshFailureTracker};
 use super::types::{CredentialEvent, CredentialScope, CredentialSource};
 
@@ -26,8 +28,8 @@ use super::types::{CredentialEvent, CredentialScope, CredentialSource};
 /// Orchestrates detection, refresh, and persistence of platform credentials.
 pub struct CredentialRefreshService<R: ConfigRepository> {
     resolver: Arc<CredentialResolver<R>>,
-    store: Arc<dyn CredentialStore>,
-    managers: HashMap<String, Arc<dyn CredentialManager>>,
+    store: Arc<DynCredentialStore<'static>>,
+    managers: HashMap<String, Arc<DynCredentialManager<'static>>>,
     daily_tracker: Arc<DailyCheckTracker>,
     failure_tracker: Arc<RefreshFailureTracker>,
     /// Per-scope locks to prevent concurrent refreshes
@@ -38,7 +40,10 @@ pub struct CredentialRefreshService<R: ConfigRepository> {
 
 impl<R: ConfigRepository + 'static> CredentialRefreshService<R> {
     /// Create a new credential refresh service.
-    pub fn new(resolver: Arc<CredentialResolver<R>>, store: Arc<dyn CredentialStore>) -> Self {
+    pub fn new(
+        resolver: Arc<CredentialResolver<R>>,
+        store: Arc<DynCredentialStore<'static>>,
+    ) -> Self {
         Self {
             resolver,
             store,
@@ -56,7 +61,7 @@ impl<R: ConfigRepository + 'static> CredentialRefreshService<R> {
     }
 
     /// Register a credential manager for a platform.
-    pub fn register_manager(&mut self, manager: Arc<dyn CredentialManager>) {
+    pub fn register_manager(&mut self, manager: Arc<DynCredentialManager<'static>>) {
         let platform_id = manager.platform_id().to_string();
         self.managers.insert(platform_id, manager);
     }
@@ -380,7 +385,7 @@ impl<R: ConfigRepository + 'static> CredentialRefreshService<R> {
     fn get_manager(
         &self,
         platform_name: &str,
-    ) -> Result<&Arc<dyn CredentialManager>, CredentialError> {
+    ) -> Result<&Arc<DynCredentialManager<'static>>, CredentialError> {
         self.managers
             .get(platform_name)
             .ok_or_else(|| CredentialError::UnsupportedPlatform(platform_name.to_string()))

--- a/rust-srec/src/credentials/store.rs
+++ b/rust-srec/src/credentials/store.rs
@@ -3,25 +3,23 @@
 //! The credentials feature needs to persist refreshed cookies / tokens back to the DB.
 //! The concrete SQL implementation lives in the database repository layer.
 
-use async_trait::async_trait;
-
 use super::error::CredentialError;
 use super::manager::RefreshedCredentials;
 use super::types::{CredentialScope, CredentialSource};
 
-#[async_trait]
+#[dynosaur::dynosaur(pub DynCredentialStore = dyn(box) CredentialStore)]
 pub trait CredentialStore: Send + Sync {
     /// Persist refreshed credentials to the correct configuration layer.
-    async fn update_credentials(
+    fn update_credentials(
         &self,
         source: &CredentialSource,
         credentials: &RefreshedCredentials,
-    ) -> Result<(), CredentialError>;
+    ) -> impl std::future::Future<Output = Result<(), CredentialError>> + Send;
 
     /// Persist a "checked today" result for hydration on restart.
-    async fn update_check_result(
+    fn update_check_result(
         &self,
         scope: &CredentialScope,
         result: &str,
-    ) -> Result<(), CredentialError>;
+    ) -> impl std::future::Future<Output = Result<(), CredentialError>> + Send;
 }

--- a/rust-srec/src/danmu/runner.rs
+++ b/rust-srec/src/danmu/runner.rs
@@ -13,7 +13,7 @@ use tokio::sync::{broadcast, mpsc};
 use tokio_util::sync::CancellationToken;
 
 use platforms_parser::danmaku::{
-    ConnectionConfig, DanmuConnection, DanmuControlEvent, DanmuItem, DanmuProvider,
+    ConnectionConfig, DanmuConnection, DanmuControlEvent, DanmuItem, DanmuProvider, DynDanmuProvider,
     message::{DanmuMessage, DanmuType},
 };
 
@@ -50,7 +50,7 @@ pub(crate) struct CollectionRunner {
     room_id: String,
 
     // Provider and connection
-    provider: Arc<dyn DanmuProvider>,
+    provider: Arc<DynDanmuProvider<'static>>,
     connection: DanmuConnection,
 
     // Current segment writer
@@ -72,7 +72,7 @@ pub(crate) struct RunnerParams {
     pub session_id: String,
     pub streamer_id: String,
     pub room_id: String,
-    pub provider: Arc<dyn DanmuProvider>,
+    pub provider: Arc<DynDanmuProvider<'static>>,
     pub conn_config: ConnectionConfig,
     pub stats: StatisticsAggregator,
     pub sampler: Box<dyn DanmuSampler>,

--- a/rust-srec/src/danmu/service.rs
+++ b/rust-srec/src/danmu/service.rs
@@ -23,10 +23,10 @@ use crate::danmu::{
     create_sampler,
 };
 use crate::database::models::DanmuRateEntry;
-use crate::database::repositories::SessionRepository;
+use crate::database::repositories::{DynSessionRepository, SessionRepository};
 use crate::domain::DanmuSamplingConfig;
 use crate::error::{Error, Result};
-use platforms_parser::danmaku::ConnectionConfig;
+use platforms_parser::danmaku::{ConnectionConfig, DanmuProvider};
 
 use super::events::{CollectionCommand, DanmuEvent};
 use super::runner::{CollectionRunner, RunnerParams};
@@ -174,7 +174,7 @@ pub struct DanmuService {
     /// Global cancellation token
     cancel_token: CancellationToken,
     /// Session repository for persistence
-    session_repo: Option<Arc<dyn crate::database::repositories::SessionRepository>>,
+    session_repo: Option<Arc<crate::database::repositories::DynSessionRepository<'static>>>,
 }
 
 impl DanmuService {
@@ -215,7 +215,7 @@ impl DanmuService {
     /// Set the session repository for persistence.
     pub fn with_session_repository(
         mut self,
-        repo: Arc<dyn crate::database::repositories::SessionRepository>,
+        repo: Arc<crate::database::repositories::DynSessionRepository<'static>>,
     ) -> Self {
         self.session_repo = Some(repo);
         self
@@ -224,7 +224,7 @@ impl DanmuService {
     /// Get the session repository (if set).
     pub fn session_repo(
         &self,
-    ) -> Option<&Arc<dyn crate::database::repositories::SessionRepository>> {
+    ) -> Option<&Arc<crate::database::repositories::DynSessionRepository<'static>>> {
         self.session_repo.as_ref()
     }
 
@@ -620,7 +620,7 @@ fn saturating_u64_to_i64(value: u64) -> i64 {
 }
 
 async fn persist_statistics(
-    session_repo: Option<&dyn SessionRepository>,
+    session_repo: Option<&DynSessionRepository<'_>>,
     session_id: &str,
     statistics: &DanmuStatistics,
 ) {

--- a/rust-srec/src/database/repositories/config.rs
+++ b/rust-srec/src/database/repositories/config.rs
@@ -1,6 +1,5 @@
 //! Configuration repository.
 
-use async_trait::async_trait;
 use chrono::Utc;
 use sqlx::SqlitePool;
 
@@ -10,35 +9,91 @@ use crate::database::models::{
 use crate::{Error, Result};
 
 /// Configuration repository trait.
-#[async_trait]
+#[dynosaur::dynosaur(pub DynConfigRepository = dyn(box) ConfigRepository)]
 pub trait ConfigRepository: Send + Sync {
     // Global Config
-    async fn get_global_config(&self) -> Result<GlobalConfigDbModel>;
-    async fn update_global_config(&self, config: &GlobalConfigDbModel) -> Result<()>;
-    async fn create_global_config(&self, config: &GlobalConfigDbModel) -> Result<()>;
+    fn get_global_config(
+        &self,
+    ) -> impl std::future::Future<Output = Result<GlobalConfigDbModel>> + Send;
+    fn update_global_config(
+        &self,
+        config: &GlobalConfigDbModel,
+    ) -> impl std::future::Future<Output = Result<()>> + Send;
+    fn create_global_config(
+        &self,
+        config: &GlobalConfigDbModel,
+    ) -> impl std::future::Future<Output = Result<()>> + Send;
 
     // Platform Config
-    async fn get_platform_config(&self, id: &str) -> Result<PlatformConfigDbModel>;
-    async fn get_platform_config_by_name(&self, name: &str) -> Result<PlatformConfigDbModel>;
-    async fn list_platform_configs(&self) -> Result<Vec<PlatformConfigDbModel>>;
-    async fn create_platform_config(&self, config: &PlatformConfigDbModel) -> Result<()>;
-    async fn update_platform_config(&self, config: &PlatformConfigDbModel) -> Result<()>;
-    async fn delete_platform_config(&self, id: &str) -> Result<()>;
+    fn get_platform_config(
+        &self,
+        id: &str,
+    ) -> impl std::future::Future<Output = Result<PlatformConfigDbModel>> + Send;
+    fn get_platform_config_by_name(
+        &self,
+        name: &str,
+    ) -> impl std::future::Future<Output = Result<PlatformConfigDbModel>> + Send;
+    fn list_platform_configs(
+        &self,
+    ) -> impl std::future::Future<Output = Result<Vec<PlatformConfigDbModel>>> + Send;
+    fn create_platform_config(
+        &self,
+        config: &PlatformConfigDbModel,
+    ) -> impl std::future::Future<Output = Result<()>> + Send;
+    fn update_platform_config(
+        &self,
+        config: &PlatformConfigDbModel,
+    ) -> impl std::future::Future<Output = Result<()>> + Send;
+    fn delete_platform_config(
+        &self,
+        id: &str,
+    ) -> impl std::future::Future<Output = Result<()>> + Send;
 
     // Template Config
-    async fn get_template_config(&self, id: &str) -> Result<TemplateConfigDbModel>;
-    async fn get_template_config_by_name(&self, name: &str) -> Result<TemplateConfigDbModel>;
-    async fn list_template_configs(&self) -> Result<Vec<TemplateConfigDbModel>>;
-    async fn create_template_config(&self, config: &TemplateConfigDbModel) -> Result<()>;
-    async fn update_template_config(&self, config: &TemplateConfigDbModel) -> Result<()>;
-    async fn delete_template_config(&self, id: &str) -> Result<()>;
+    fn get_template_config(
+        &self,
+        id: &str,
+    ) -> impl std::future::Future<Output = Result<TemplateConfigDbModel>> + Send;
+    fn get_template_config_by_name(
+        &self,
+        name: &str,
+    ) -> impl std::future::Future<Output = Result<TemplateConfigDbModel>> + Send;
+    fn list_template_configs(
+        &self,
+    ) -> impl std::future::Future<Output = Result<Vec<TemplateConfigDbModel>>> + Send;
+    fn create_template_config(
+        &self,
+        config: &TemplateConfigDbModel,
+    ) -> impl std::future::Future<Output = Result<()>> + Send;
+    fn update_template_config(
+        &self,
+        config: &TemplateConfigDbModel,
+    ) -> impl std::future::Future<Output = Result<()>> + Send;
+    fn delete_template_config(
+        &self,
+        id: &str,
+    ) -> impl std::future::Future<Output = Result<()>> + Send;
 
     // Engine Config
-    async fn get_engine_config(&self, id: &str) -> Result<EngineConfigurationDbModel>;
-    async fn list_engine_configs(&self) -> Result<Vec<EngineConfigurationDbModel>>;
-    async fn create_engine_config(&self, config: &EngineConfigurationDbModel) -> Result<()>;
-    async fn update_engine_config(&self, config: &EngineConfigurationDbModel) -> Result<()>;
-    async fn delete_engine_config(&self, id: &str) -> Result<()>;
+    fn get_engine_config(
+        &self,
+        id: &str,
+    ) -> impl std::future::Future<Output = Result<EngineConfigurationDbModel>> + Send;
+    fn list_engine_configs(
+        &self,
+    ) -> impl std::future::Future<Output = Result<Vec<EngineConfigurationDbModel>>> + Send;
+    fn create_engine_config(
+        &self,
+        config: &EngineConfigurationDbModel,
+    ) -> impl std::future::Future<Output = Result<()>> + Send;
+    fn update_engine_config(
+        &self,
+        config: &EngineConfigurationDbModel,
+    ) -> impl std::future::Future<Output = Result<()>> + Send;
+    fn delete_engine_config(
+        &self,
+        id: &str,
+    ) -> impl std::future::Future<Output = Result<()>> + Send;
 }
 
 /// SQLx implementation of ConfigRepository.
@@ -53,7 +108,6 @@ impl SqlxConfigRepository {
     }
 }
 
-#[async_trait]
 impl ConfigRepository for SqlxConfigRepository {
     async fn get_global_config(&self) -> Result<GlobalConfigDbModel> {
         let config =

--- a/rust-srec/src/database/repositories/credential_store.rs
+++ b/rust-srec/src/database/repositories/credential_store.rs
@@ -2,7 +2,6 @@
 //!
 //! This is the database-backed persistence implementation for the credentials subsystem.
 
-use async_trait::async_trait;
 use sqlx::SqlitePool;
 use tracing::{debug, instrument};
 
@@ -250,7 +249,6 @@ impl SqlxCredentialStore {
     }
 }
 
-#[async_trait]
 impl CredentialStore for SqlxCredentialStore {
     #[instrument(
         skip(self, credentials),

--- a/rust-srec/src/database/repositories/dag.rs
+++ b/rust-srec/src/database/repositories/dag.rs
@@ -1,6 +1,5 @@
 //! DAG (Directed Acyclic Graph) repository for pipeline execution.
 
-use async_trait::async_trait;
 use sqlx::SqlitePool;
 use std::collections::{HashMap, HashSet};
 
@@ -12,74 +11,118 @@ use crate::database::retry::retry_on_sqlite_busy;
 use crate::{Error, Result};
 
 /// DAG repository trait for pipeline execution management.
-#[async_trait]
+#[dynosaur::dynosaur(pub DynDagRepository = dyn(box) DagRepository)]
 pub trait DagRepository: Send + Sync {
     // ========================================================================
     // DAG Execution CRUD
     // ========================================================================
 
     /// Create a new DAG execution record.
-    async fn create_dag(&self, dag: &DagExecutionDbModel) -> Result<()>;
+    fn create_dag(
+        &self,
+        dag: &DagExecutionDbModel,
+    ) -> impl std::future::Future<Output = Result<()>> + Send;
 
     /// Get a DAG execution by ID.
-    async fn get_dag(&self, id: &str) -> Result<DagExecutionDbModel>;
+    fn get_dag(
+        &self,
+        id: &str,
+    ) -> impl std::future::Future<Output = Result<DagExecutionDbModel>> + Send;
 
     /// Update DAG execution status.
-    async fn update_dag_status(&self, id: &str, status: &str, error: Option<&str>) -> Result<()>;
+    fn update_dag_status(
+        &self,
+        id: &str,
+        status: &str,
+        error: Option<&str>,
+    ) -> impl std::future::Future<Output = Result<()>> + Send;
 
     /// Increment completed steps counter for a DAG.
-    async fn increment_dag_completed(&self, dag_id: &str) -> Result<()>;
+    fn increment_dag_completed(
+        &self,
+        dag_id: &str,
+    ) -> impl std::future::Future<Output = Result<()>> + Send;
 
     /// Increment failed steps counter for a DAG.
-    async fn increment_dag_failed(&self, dag_id: &str) -> Result<()>;
+    fn increment_dag_failed(
+        &self,
+        dag_id: &str,
+    ) -> impl std::future::Future<Output = Result<()>> + Send;
 
     /// List DAG executions with optional status and session_id filters.
-    async fn list_dags(
+    fn list_dags(
         &self,
         status: Option<&str>,
         session_id: Option<&str>,
         limit: u32,
         offset: u32,
-    ) -> Result<Vec<DagExecutionDbModel>>;
+    ) -> impl std::future::Future<Output = Result<Vec<DagExecutionDbModel>>> + Send;
 
     /// Count DAG executions with optional status and session_id filters.
-    async fn count_dags(&self, status: Option<&str>, session_id: Option<&str>) -> Result<u64>;
+    fn count_dags(
+        &self,
+        status: Option<&str>,
+        session_id: Option<&str>,
+    ) -> impl std::future::Future<Output = Result<u64>> + Send;
 
     /// Delete a DAG execution and all its steps.
-    async fn delete_dag(&self, id: &str) -> Result<()>;
+    fn delete_dag(&self, id: &str) -> impl std::future::Future<Output = Result<()>> + Send;
 
     // ========================================================================
     // DAG Step Execution CRUD
     // ========================================================================
 
     /// Create a new step execution record.
-    async fn create_step(&self, step: &DagStepExecutionDbModel) -> Result<()>;
+    fn create_step(
+        &self,
+        step: &DagStepExecutionDbModel,
+    ) -> impl std::future::Future<Output = Result<()>> + Send;
 
     /// Create multiple step execution records in a transaction.
-    async fn create_steps(&self, steps: &[DagStepExecutionDbModel]) -> Result<()>;
+    fn create_steps(
+        &self,
+        steps: &[DagStepExecutionDbModel],
+    ) -> impl std::future::Future<Output = Result<()>> + Send;
 
     /// Get a step execution by ID.
-    async fn get_step(&self, id: &str) -> Result<DagStepExecutionDbModel>;
+    fn get_step(
+        &self,
+        id: &str,
+    ) -> impl std::future::Future<Output = Result<DagStepExecutionDbModel>> + Send;
 
     /// Get a step execution by DAG ID and step ID.
-    async fn get_step_by_dag_and_step_id(
+    fn get_step_by_dag_and_step_id(
         &self,
         dag_id: &str,
         step_id: &str,
-    ) -> Result<DagStepExecutionDbModel>;
+    ) -> impl std::future::Future<Output = Result<DagStepExecutionDbModel>> + Send;
 
     /// Get all step executions for a DAG.
-    async fn get_steps_by_dag(&self, dag_id: &str) -> Result<Vec<DagStepExecutionDbModel>>;
+    fn get_steps_by_dag(
+        &self,
+        dag_id: &str,
+    ) -> impl std::future::Future<Output = Result<Vec<DagStepExecutionDbModel>>> + Send;
 
     /// Update a step execution.
-    async fn update_step(&self, step: &DagStepExecutionDbModel) -> Result<()>;
+    fn update_step(
+        &self,
+        step: &DagStepExecutionDbModel,
+    ) -> impl std::future::Future<Output = Result<()>> + Send;
 
     /// Update step status.
-    async fn update_step_status(&self, id: &str, status: &str) -> Result<()>;
+    fn update_step_status(
+        &self,
+        id: &str,
+        status: &str,
+    ) -> impl std::future::Future<Output = Result<()>> + Send;
 
     /// Update step status and job ID.
-    async fn update_step_status_with_job(&self, id: &str, status: &str, job_id: &str)
-    -> Result<()>;
+    fn update_step_status_with_job(
+        &self,
+        id: &str,
+        status: &str,
+        job_id: &str,
+    ) -> impl std::future::Future<Output = Result<()>> + Send;
 
     // ========================================================================
     // Core DAG Operations (Atomic)
@@ -87,19 +130,27 @@ pub trait DagRepository: Send + Sync {
 
     /// Atomically complete a step and check for ready dependents.
     /// Returns steps that are now ready to run (all dependencies complete).
-    async fn complete_step_and_check_dependents(
+    fn complete_step_and_check_dependents(
         &self,
         step_id: &str,
         outputs: &[String],
-    ) -> Result<Vec<ReadyStep>>;
+    ) -> impl std::future::Future<Output = Result<Vec<ReadyStep>>> + Send;
 
     /// Atomically fail a DAG and cancel all pending/blocked steps.
     /// Returns job IDs of steps that had jobs created (for cancellation).
-    async fn fail_dag_and_cancel_steps(&self, dag_id: &str, error: &str) -> Result<Vec<String>>;
+    fn fail_dag_and_cancel_steps(
+        &self,
+        dag_id: &str,
+        error: &str,
+    ) -> impl std::future::Future<Output = Result<Vec<String>>> + Send;
 
     /// Atomically cancel a DAG and cancel all pending/blocked steps.
     /// Returns job IDs of steps that had jobs created (for cancellation).
-    async fn cancel_dag_and_cancel_steps(&self, dag_id: &str, error: &str) -> Result<Vec<String>>;
+    fn cancel_dag_and_cancel_steps(
+        &self,
+        dag_id: &str,
+        error: &str,
+    ) -> impl std::future::Future<Output = Result<Vec<String>>> + Send;
 
     /// Reset a previously-failed DAG execution for retry.
     ///
@@ -107,30 +158,46 @@ pub trait DagRepository: Send + Sync {
     /// can be scheduled again:
     /// - DAG: status -> PROCESSING, clear error/completed_at, recompute failed_steps
     /// - Steps: CANCELLED -> BLOCKED, FAILED -> PROCESSING (preserves job_id)
-    async fn reset_dag_for_retry(&self, dag_id: &str) -> Result<()>;
+    fn reset_dag_for_retry(
+        &self,
+        dag_id: &str,
+    ) -> impl std::future::Future<Output = Result<()>> + Send;
 
     // ========================================================================
     // Query Operations
     // ========================================================================
 
     /// Get concatenated outputs from all specified dependency steps.
-    async fn get_dependency_outputs(
+    fn get_dependency_outputs(
         &self,
         dag_id: &str,
         step_ids: &[String],
-    ) -> Result<Vec<String>>;
+    ) -> impl std::future::Future<Output = Result<Vec<String>>> + Send;
 
     /// Check if all dependencies for a step are complete.
-    async fn check_all_dependencies_complete(&self, dag_id: &str, step_id: &str) -> Result<bool>;
+    fn check_all_dependencies_complete(
+        &self,
+        dag_id: &str,
+        step_id: &str,
+    ) -> impl std::future::Future<Output = Result<bool>> + Send;
 
     /// Get statistics for a DAG execution.
-    async fn get_dag_stats(&self, dag_id: &str) -> Result<DagExecutionStats>;
+    fn get_dag_stats(
+        &self,
+        dag_id: &str,
+    ) -> impl std::future::Future<Output = Result<DagExecutionStats>> + Send;
 
     /// Get job IDs for all processing steps in a DAG.
-    async fn get_processing_job_ids(&self, dag_id: &str) -> Result<Vec<String>>;
+    fn get_processing_job_ids(
+        &self,
+        dag_id: &str,
+    ) -> impl std::future::Future<Output = Result<Vec<String>>> + Send;
 
     /// Get pending root steps for a DAG (for initial job creation).
-    async fn get_pending_root_steps(&self, dag_id: &str) -> Result<Vec<DagStepExecutionDbModel>>;
+    fn get_pending_root_steps(
+        &self,
+        dag_id: &str,
+    ) -> impl std::future::Future<Output = Result<Vec<DagStepExecutionDbModel>>> + Send;
 }
 
 /// SQLx implementation of DagRepository.
@@ -145,7 +212,6 @@ impl SqlxDagRepository {
     }
 }
 
-#[async_trait]
 impl DagRepository for SqlxDagRepository {
     // ========================================================================
     // DAG Execution CRUD

--- a/rust-srec/src/database/repositories/filter.rs
+++ b/rust-srec/src/database/repositories/filter.rs
@@ -1,24 +1,41 @@
 //! Filter repository.
 
-use async_trait::async_trait;
 use sqlx::SqlitePool;
 
 use crate::database::models::FilterDbModel;
 use crate::{Error, Result};
 
 /// Filter repository trait.
-#[async_trait]
+#[dynosaur::dynosaur(pub DynFilterRepository = dyn(box) FilterRepository)]
 pub trait FilterRepository: Send + Sync {
-    async fn get_filter(&self, id: &str) -> Result<FilterDbModel>;
-    async fn get_filters_for_streamer(&self, streamer_id: &str) -> Result<Vec<FilterDbModel>>;
-    async fn create_filter(&self, filter: &FilterDbModel) -> Result<()>;
-    async fn update_filter(&self, filter: &FilterDbModel) -> Result<()>;
-    async fn delete_filter(&self, id: &str) -> Result<()>;
-    async fn delete_filters_for_streamer(&self, streamer_id: &str) -> Result<()>;
+    fn get_filter(
+        &self,
+        id: &str,
+    ) -> impl std::future::Future<Output = Result<FilterDbModel>> + Send;
+    fn get_filters_for_streamer(
+        &self,
+        streamer_id: &str,
+    ) -> impl std::future::Future<Output = Result<Vec<FilterDbModel>>> + Send;
+    fn create_filter(
+        &self,
+        filter: &FilterDbModel,
+    ) -> impl std::future::Future<Output = Result<()>> + Send;
+    fn update_filter(
+        &self,
+        filter: &FilterDbModel,
+    ) -> impl std::future::Future<Output = Result<()>> + Send;
+    fn delete_filter(&self, id: &str) -> impl std::future::Future<Output = Result<()>> + Send;
+    fn delete_filters_for_streamer(
+        &self,
+        streamer_id: &str,
+    ) -> impl std::future::Future<Output = Result<()>> + Send;
 
     /// Alias for get_filters_for_streamer.
-    async fn get_by_streamer(&self, streamer_id: &str) -> Result<Vec<FilterDbModel>> {
-        self.get_filters_for_streamer(streamer_id).await
+    fn get_by_streamer(
+        &self,
+        streamer_id: &str,
+    ) -> impl std::future::Future<Output = Result<Vec<FilterDbModel>>> + Send {
+        async move { self.get_filters_for_streamer(streamer_id).await }
     }
 }
 
@@ -34,7 +51,6 @@ impl SqlxFilterRepository {
     }
 }
 
-#[async_trait]
 impl FilterRepository for SqlxFilterRepository {
     async fn get_filter(&self, id: &str) -> Result<FilterDbModel> {
         sqlx::query_as::<_, FilterDbModel>("SELECT * FROM filters WHERE id = ?")

--- a/rust-srec/src/database/repositories/job.rs
+++ b/rust-srec/src/database/repositories/job.rs
@@ -7,118 +7,187 @@ use crate::database::models::{
 };
 use crate::database::retry::retry_on_sqlite_busy;
 use crate::{Error, Result};
-use async_trait::async_trait;
 use sqlx::SqlitePool;
 
 /// Job repository trait.
-#[async_trait]
+#[dynosaur::dynosaur(pub DynJobRepository = dyn(box) JobRepository)]
 pub trait JobRepository: Send + Sync {
-    async fn get_job(&self, id: &str) -> Result<JobDbModel>;
-    async fn list_pending_jobs(&self, job_type: &str) -> Result<Vec<JobDbModel>>;
-    async fn list_jobs_by_status(&self, status: &str) -> Result<Vec<JobDbModel>>;
-    async fn list_recent_jobs(&self, limit: i32) -> Result<Vec<JobDbModel>>;
-    async fn create_job(&self, job: &JobDbModel) -> Result<()>;
-    async fn update_job_status(&self, id: &str, status: &str) -> Result<()>;
+    fn get_job(&self, id: &str) -> impl std::future::Future<Output = Result<JobDbModel>> + Send;
+    fn list_pending_jobs(
+        &self,
+        job_type: &str,
+    ) -> impl std::future::Future<Output = Result<Vec<JobDbModel>>> + Send;
+    fn list_jobs_by_status(
+        &self,
+        status: &str,
+    ) -> impl std::future::Future<Output = Result<Vec<JobDbModel>>> + Send;
+    fn list_recent_jobs(
+        &self,
+        limit: i32,
+    ) -> impl std::future::Future<Output = Result<Vec<JobDbModel>>> + Send;
+    fn create_job(&self, job: &JobDbModel) -> impl std::future::Future<Output = Result<()>> + Send;
+    fn update_job_status(
+        &self,
+        id: &str,
+        status: &str,
+    ) -> impl std::future::Future<Output = Result<()>> + Send;
     /// Mark a job as FAILED and set error/completed_at.
     /// Returns the number of rows updated (0 means the job was already in a terminal state).
-    async fn mark_job_failed(&self, id: &str, error: &str) -> Result<u64>;
+    fn mark_job_failed(
+        &self,
+        id: &str,
+        error: &str,
+    ) -> impl std::future::Future<Output = Result<u64>> + Send;
     /// Mark a job as CANCELLED and set completed_at.
     /// Returns the number of rows updated (0 means the job was already in a terminal state).
-    async fn mark_job_cancelled(&self, id: &str) -> Result<u64>;
+    fn mark_job_cancelled(&self, id: &str) -> impl std::future::Future<Output = Result<u64>> + Send;
     /// Reset a job for retry (PENDING, clear started/completed/error, increment retry_count).
-    async fn reset_job_for_retry(&self, id: &str) -> Result<()>;
+    fn reset_job_for_retry(&self, id: &str) -> impl std::future::Future<Output = Result<()>> + Send;
     /// Count pending jobs, optionally filtered by job types.
-    async fn count_pending_jobs(&self, job_types: Option<&[String]>) -> Result<u64>;
+    fn count_pending_jobs(
+        &self,
+        job_types: Option<&[String]>,
+    ) -> impl std::future::Future<Output = Result<u64>> + Send;
     /// Upsert (replace) the latest execution progress snapshot for a job.
-    async fn upsert_job_execution_progress(
+    fn upsert_job_execution_progress(
         &self,
         progress: &JobExecutionProgressDbModel,
-    ) -> Result<()>;
+    ) -> impl std::future::Future<Output = Result<()>> + Send;
     /// Get the latest execution progress snapshot for a job.
-    async fn get_job_execution_progress(
+    fn get_job_execution_progress(
         &self,
         job_id: &str,
-    ) -> Result<Option<JobExecutionProgressDbModel>>;
+    ) -> impl std::future::Future<Output = Result<Option<JobExecutionProgressDbModel>>> + Send;
     /// Atomically claim (transition) the next pending job to PROCESSING.
     /// Returns the claimed job, if any.
     ///
     /// This is intended for the hot dequeue path to avoid a list+update race and
     /// to reduce DB round-trips.
-    async fn claim_next_pending_job(
+    fn claim_next_pending_job(
         &self,
         job_types: Option<&[String]>,
-    ) -> Result<Option<JobDbModel>>;
+    ) -> impl std::future::Future<Output = Result<Option<JobDbModel>>> + Send;
     /// Fetch only the `execution_info` field for a job.
-    async fn get_job_execution_info(&self, id: &str) -> Result<Option<String>>;
+    fn get_job_execution_info(
+        &self,
+        id: &str,
+    ) -> impl std::future::Future<Output = Result<Option<String>>> + Send;
     /// Update only the `execution_info` field for a job.
-    async fn update_job_execution_info(&self, id: &str, execution_info: &str) -> Result<()>;
-    async fn update_job_state(&self, id: &str, state: &str) -> Result<()>;
-    async fn update_job(&self, job: &JobDbModel) -> Result<()>;
+    fn update_job_execution_info(
+        &self,
+        id: &str,
+        execution_info: &str,
+    ) -> impl std::future::Future<Output = Result<()>> + Send;
+    fn update_job_state(
+        &self,
+        id: &str,
+        state: &str,
+    ) -> impl std::future::Future<Output = Result<()>> + Send;
+    fn update_job(&self, job: &JobDbModel) -> impl std::future::Future<Output = Result<()>> + Send;
     /// Update a job only if its current status matches `expected_status`.
     /// Returns the number of rows updated.
-    async fn update_job_if_status(&self, job: &JobDbModel, expected_status: &str) -> Result<u64>;
+    fn update_job_if_status(
+        &self,
+        job: &JobDbModel,
+        expected_status: &str,
+    ) -> impl std::future::Future<Output = Result<u64>> + Send;
     /// Reset processing jobs to pending (for recovery on startup).
-    async fn reset_processing_jobs(&self) -> Result<i32>;
-    async fn cleanup_old_jobs(&self, retention_days: i32) -> Result<i32>;
-    async fn delete_job(&self, id: &str) -> Result<()>;
+    fn reset_processing_jobs(&self) -> impl std::future::Future<Output = Result<i32>> + Send;
+    fn cleanup_old_jobs(
+        &self,
+        retention_days: i32,
+    ) -> impl std::future::Future<Output = Result<i32>> + Send;
+    fn delete_job(&self, id: &str) -> impl std::future::Future<Output = Result<()>> + Send;
 
     // Purge methods
     /// Purge completed/failed jobs older than the specified number of days.
     /// Deletes jobs in batches to avoid long-running transactions.
     /// Returns the number of jobs deleted.
-    async fn purge_jobs_older_than(&self, days: u32, batch_size: u32) -> Result<u64>;
+    fn purge_jobs_older_than(
+        &self,
+        days: u32,
+        batch_size: u32,
+    ) -> impl std::future::Future<Output = Result<u64>> + Send;
 
     /// Get IDs of jobs that are eligible for purging.
     /// Returns job IDs for completed/failed jobs older than the specified days.
-    async fn get_purgeable_jobs(&self, days: u32, limit: u32) -> Result<Vec<String>>;
+    fn get_purgeable_jobs(
+        &self,
+        days: u32,
+        limit: u32,
+    ) -> impl std::future::Future<Output = Result<Vec<String>>> + Send;
 
     // Execution logs
-    async fn add_execution_log(&self, log: &JobExecutionLogDbModel) -> Result<()>;
+    fn add_execution_log(
+        &self,
+        log: &JobExecutionLogDbModel,
+    ) -> impl std::future::Future<Output = Result<()>> + Send;
     /// Add multiple execution logs in one transaction.
-    async fn add_execution_logs(&self, logs: &[JobExecutionLogDbModel]) -> Result<()>;
-    async fn get_execution_logs(&self, job_id: &str) -> Result<Vec<JobExecutionLogDbModel>>;
+    fn add_execution_logs(
+        &self,
+        logs: &[JobExecutionLogDbModel],
+    ) -> impl std::future::Future<Output = Result<()>> + Send;
+    fn get_execution_logs(
+        &self,
+        job_id: &str,
+    ) -> impl std::future::Future<Output = Result<Vec<JobExecutionLogDbModel>>> + Send;
     /// List execution logs with pagination, returning (logs, total_count).
-    async fn list_execution_logs(
+    fn list_execution_logs(
         &self,
         job_id: &str,
         pagination: &Pagination,
-    ) -> Result<(Vec<JobExecutionLogDbModel>, u64)>;
-    async fn delete_execution_logs_for_job(&self, job_id: &str) -> Result<()>;
+    ) -> impl std::future::Future<Output = Result<(Vec<JobExecutionLogDbModel>, u64)>> + Send;
+    fn delete_execution_logs_for_job(
+        &self,
+        job_id: &str,
+    ) -> impl std::future::Future<Output = Result<()>> + Send;
 
     // Filtering and pagination
     /// List jobs with optional filters and pagination.
     /// Returns a tuple of (jobs, total_count).
-    async fn list_jobs_filtered(
+    fn list_jobs_filtered(
         &self,
         filters: &JobFilters,
         pagination: &Pagination,
-    ) -> Result<(Vec<JobDbModel>, u64)>;
+    ) -> impl std::future::Future<Output = Result<(Vec<JobDbModel>, u64)>> + Send;
     /// List jobs with optional filters and pagination, without running a `COUNT(*)`.
-    async fn list_jobs_page_filtered(
+    fn list_jobs_page_filtered(
         &self,
         filters: &JobFilters,
         pagination: &Pagination,
-    ) -> Result<Vec<JobDbModel>>;
+    ) -> impl std::future::Future<Output = Result<Vec<JobDbModel>>> + Send;
 
     // Statistics
     /// Get job counts by status.
-    async fn get_job_counts_by_status(&self) -> Result<JobCounts>;
+    fn get_job_counts_by_status(&self)
+    -> impl std::future::Future<Output = Result<JobCounts>> + Send;
 
     /// Get average processing time for completed jobs in seconds.
-    async fn get_avg_processing_time(&self) -> Result<Option<f64>>;
+    fn get_avg_processing_time(
+        &self,
+    ) -> impl std::future::Future<Output = Result<Option<f64>>> + Send;
 
     // Atomic pipeline operations
 
     /// Cancel all pending/processing jobs in a pipeline.
     /// Returns the number of jobs cancelled.
-    async fn cancel_jobs_by_pipeline(&self, pipeline_id: &str) -> Result<u64>;
+    fn cancel_jobs_by_pipeline(
+        &self,
+        pipeline_id: &str,
+    ) -> impl std::future::Future<Output = Result<u64>> + Send;
 
     /// Get all jobs in a pipeline.
-    async fn get_jobs_by_pipeline(&self, pipeline_id: &str) -> Result<Vec<JobDbModel>>;
+    fn get_jobs_by_pipeline(
+        &self,
+        pipeline_id: &str,
+    ) -> impl std::future::Future<Output = Result<Vec<JobDbModel>>> + Send;
 
     /// Delete all jobs in a pipeline and their associated data (logs, progress).
     /// Returns the number of jobs deleted.
-    async fn delete_jobs_by_pipeline(&self, pipeline_id: &str) -> Result<u64>;
+    fn delete_jobs_by_pipeline(
+        &self,
+        pipeline_id: &str,
+    ) -> impl std::future::Future<Output = Result<u64>> + Send;
 }
 
 /// SQLx implementation of JobRepository.
@@ -133,7 +202,6 @@ impl SqlxJobRepository {
     }
 }
 
-#[async_trait]
 impl JobRepository for SqlxJobRepository {
     async fn get_job(&self, id: &str) -> Result<JobDbModel> {
         sqlx::query_as::<_, JobDbModel>("SELECT * FROM job WHERE id = ?")

--- a/rust-srec/src/database/repositories/notification.rs
+++ b/rust-srec/src/database/repositories/notification.rs
@@ -1,6 +1,5 @@
 //! Notification repository.
 
-use async_trait::async_trait;
 use sqlx::SqlitePool;
 
 use crate::database::models::{
@@ -9,39 +8,79 @@ use crate::database::models::{
 use crate::{Error, Result};
 
 /// Notification repository trait.
-#[async_trait]
+#[dynosaur::dynosaur(pub DynNotificationRepository = dyn(box) NotificationRepository)]
 pub trait NotificationRepository: Send + Sync {
     // Channels
-    async fn get_channel(&self, id: &str) -> Result<NotificationChannelDbModel>;
-    async fn list_channels(&self) -> Result<Vec<NotificationChannelDbModel>>;
-    async fn create_channel(&self, channel: &NotificationChannelDbModel) -> Result<()>;
-    async fn update_channel(&self, channel: &NotificationChannelDbModel) -> Result<()>;
-    async fn delete_channel(&self, id: &str) -> Result<()>;
+    fn get_channel(
+        &self,
+        id: &str,
+    ) -> impl std::future::Future<Output = Result<NotificationChannelDbModel>> + Send;
+    fn list_channels(
+        &self,
+    ) -> impl std::future::Future<Output = Result<Vec<NotificationChannelDbModel>>> + Send;
+    fn create_channel(
+        &self,
+        channel: &NotificationChannelDbModel,
+    ) -> impl std::future::Future<Output = Result<()>> + Send;
+    fn update_channel(
+        &self,
+        channel: &NotificationChannelDbModel,
+    ) -> impl std::future::Future<Output = Result<()>> + Send;
+    fn delete_channel(&self, id: &str) -> impl std::future::Future<Output = Result<()>> + Send;
 
     // Subscriptions
-    async fn get_subscriptions_for_channel(&self, channel_id: &str) -> Result<Vec<String>>;
-    async fn get_channels_for_event(
+    fn get_subscriptions_for_channel(
+        &self,
+        channel_id: &str,
+    ) -> impl std::future::Future<Output = Result<Vec<String>>> + Send;
+    fn get_channels_for_event(
         &self,
         event_name: &str,
-    ) -> Result<Vec<NotificationChannelDbModel>>;
-    async fn subscribe(&self, channel_id: &str, event_name: &str) -> Result<()>;
-    async fn unsubscribe(&self, channel_id: &str, event_name: &str) -> Result<()>;
-    async fn unsubscribe_all(&self, channel_id: &str) -> Result<()>;
+    ) -> impl std::future::Future<Output = Result<Vec<NotificationChannelDbModel>>> + Send;
+    fn subscribe(
+        &self,
+        channel_id: &str,
+        event_name: &str,
+    ) -> impl std::future::Future<Output = Result<()>> + Send;
+    fn unsubscribe(
+        &self,
+        channel_id: &str,
+        event_name: &str,
+    ) -> impl std::future::Future<Output = Result<()>> + Send;
+    fn unsubscribe_all(
+        &self,
+        channel_id: &str,
+    ) -> impl std::future::Future<Output = Result<()>> + Send;
 
     // Dead Letter Queue
-    async fn add_to_dead_letter(&self, entry: &NotificationDeadLetterDbModel) -> Result<()>;
-    async fn list_dead_letters(
+    fn add_to_dead_letter(
+        &self,
+        entry: &NotificationDeadLetterDbModel,
+    ) -> impl std::future::Future<Output = Result<()>> + Send;
+    fn list_dead_letters(
         &self,
         channel_id: Option<&str>,
         limit: i32,
-    ) -> Result<Vec<NotificationDeadLetterDbModel>>;
-    async fn get_dead_letter(&self, id: &str) -> Result<NotificationDeadLetterDbModel>;
-    async fn delete_dead_letter(&self, id: &str) -> Result<()>;
-    async fn cleanup_old_dead_letters(&self, retention_days: i32) -> Result<i32>;
+    ) -> impl std::future::Future<Output = Result<Vec<NotificationDeadLetterDbModel>>> + Send;
+    fn get_dead_letter(
+        &self,
+        id: &str,
+    ) -> impl std::future::Future<Output = Result<NotificationDeadLetterDbModel>> + Send;
+    fn delete_dead_letter(
+        &self,
+        id: &str,
+    ) -> impl std::future::Future<Output = Result<()>> + Send;
+    fn cleanup_old_dead_letters(
+        &self,
+        retention_days: i32,
+    ) -> impl std::future::Future<Output = Result<i32>> + Send;
 
     // Event log
-    async fn add_event_log(&self, entry: &NotificationEventLogDbModel) -> Result<()>;
-    async fn list_event_logs(
+    fn add_event_log(
+        &self,
+        entry: &NotificationEventLogDbModel,
+    ) -> impl std::future::Future<Output = Result<()>> + Send;
+    fn list_event_logs(
         &self,
         event_type: Option<&str>,
         streamer_id: Option<&str>,
@@ -49,7 +88,7 @@ pub trait NotificationRepository: Send + Sync {
         priority: Option<&str>,
         offset: i32,
         limit: i32,
-    ) -> Result<Vec<NotificationEventLogDbModel>>;
+    ) -> impl std::future::Future<Output = Result<Vec<NotificationEventLogDbModel>>> + Send;
 }
 
 /// SQLx implementation of NotificationRepository.
@@ -64,7 +103,6 @@ impl SqlxNotificationRepository {
     }
 }
 
-#[async_trait]
 impl NotificationRepository for SqlxNotificationRepository {
     async fn get_channel(&self, id: &str) -> Result<NotificationChannelDbModel> {
         sqlx::query_as::<_, NotificationChannelDbModel>(

--- a/rust-srec/src/database/repositories/preset.rs
+++ b/rust-srec/src/database/repositories/preset.rs
@@ -4,7 +4,6 @@ use std::sync::Arc;
 
 use crate::Result;
 use crate::database::models::{JobPreset, Pagination};
-use async_trait::async_trait;
 use sqlx::SqlitePool;
 
 /// Filter parameters for job presets.
@@ -19,41 +18,60 @@ pub struct JobPresetFilters {
 }
 
 /// Repository for managing job presets.
-#[async_trait]
+#[dynosaur::dynosaur(pub DynJobPresetRepository = dyn(box) JobPresetRepository)]
 pub trait JobPresetRepository: Send + Sync {
     /// Get a preset by ID.
-    async fn get_preset(&self, id: &str) -> Result<Option<JobPreset>>;
+    fn get_preset(
+        &self,
+        id: &str,
+    ) -> impl std::future::Future<Output = Result<Option<JobPreset>>> + Send;
 
     /// Get a preset by name.
-    async fn get_preset_by_name(&self, name: &str) -> Result<Option<JobPreset>>;
+    fn get_preset_by_name(
+        &self,
+        name: &str,
+    ) -> impl std::future::Future<Output = Result<Option<JobPreset>>> + Send;
 
     /// Check if a preset name exists (optionally excluding a specific ID).
-    async fn name_exists(&self, name: &str, exclude_id: Option<&str>) -> Result<bool>;
+    fn name_exists(
+        &self,
+        name: &str,
+        exclude_id: Option<&str>,
+    ) -> impl std::future::Future<Output = Result<bool>> + Send;
 
     /// List all presets.
-    async fn list_presets(&self) -> Result<Vec<JobPreset>>;
+    fn list_presets(&self) -> impl std::future::Future<Output = Result<Vec<JobPreset>>> + Send;
 
     /// List presets filtered by category.
-    async fn list_presets_by_category(&self, category: Option<&str>) -> Result<Vec<JobPreset>>;
+    fn list_presets_by_category(
+        &self,
+        category: Option<&str>,
+    ) -> impl std::future::Future<Output = Result<Vec<JobPreset>>> + Send;
 
     /// List presets with filtering, searching, and pagination.
-    async fn list_presets_filtered(
+    fn list_presets_filtered(
         &self,
         filters: &JobPresetFilters,
         pagination: &Pagination,
-    ) -> Result<(Vec<JobPreset>, u64)>;
+    ) -> impl std::future::Future<Output = Result<(Vec<JobPreset>, u64)>> + Send;
 
     /// List all unique categories.
-    async fn list_categories(&self) -> Result<Vec<String>>;
+    fn list_categories(&self) -> impl std::future::Future<Output = Result<Vec<String>>> + Send;
 
     /// Create a new preset.
-    async fn create_preset(&self, preset: &JobPreset) -> Result<()>;
+    fn create_preset(
+        &self,
+        preset: &JobPreset,
+    ) -> impl std::future::Future<Output = Result<()>> + Send;
 
     /// Update an existing preset.
-    async fn update_preset(&self, preset: &JobPreset) -> Result<()>;
+    fn update_preset(
+        &self,
+        preset: &JobPreset,
+    ) -> impl std::future::Future<Output = Result<()>> + Send;
 
     /// Delete a preset.
-    async fn delete_preset(&self, id: &str) -> Result<()>;
+    fn delete_preset(&self, id: &str) -> impl std::future::Future<Output = Result<()>> + Send;
 }
 
 /// SQLite implementation of JobPresetRepository.
@@ -69,7 +87,6 @@ impl SqliteJobPresetRepository {
     }
 }
 
-#[async_trait]
 impl JobPresetRepository for SqliteJobPresetRepository {
     async fn get_preset(&self, id: &str) -> Result<Option<JobPreset>> {
         let preset = sqlx::query_as::<_, JobPreset>(
@@ -317,32 +334,49 @@ pub struct PipelinePresetFilters {
 }
 
 /// Repository for managing pipeline presets (workflow sequences).
-#[async_trait]
+#[dynosaur::dynosaur(pub DynPipelinePresetRepository = dyn(box) PipelinePresetRepository)]
 pub trait PipelinePresetRepository: Send + Sync {
     /// List all pipeline presets.
-    async fn list_pipeline_presets(&self) -> Result<Vec<PipelinePreset>>;
+    fn list_pipeline_presets(
+        &self,
+    ) -> impl std::future::Future<Output = Result<Vec<PipelinePreset>>> + Send;
 
     /// List pipeline presets with filtering, searching, and pagination.
-    async fn list_pipeline_presets_filtered(
+    fn list_pipeline_presets_filtered(
         &self,
         filters: &PipelinePresetFilters,
         pagination: &Pagination,
-    ) -> Result<(Vec<PipelinePreset>, u64)>;
+    ) -> impl std::future::Future<Output = Result<(Vec<PipelinePreset>, u64)>> + Send;
 
     /// Get a pipeline preset by ID.
-    async fn get_pipeline_preset(&self, id: &str) -> Result<Option<PipelinePreset>>;
+    fn get_pipeline_preset(
+        &self,
+        id: &str,
+    ) -> impl std::future::Future<Output = Result<Option<PipelinePreset>>> + Send;
 
     /// Get a pipeline preset by name.
-    async fn get_pipeline_preset_by_name(&self, name: &str) -> Result<Option<PipelinePreset>>;
+    fn get_pipeline_preset_by_name(
+        &self,
+        name: &str,
+    ) -> impl std::future::Future<Output = Result<Option<PipelinePreset>>> + Send;
 
     /// Create a new pipeline preset.
-    async fn create_pipeline_preset(&self, preset: &PipelinePreset) -> Result<()>;
+    fn create_pipeline_preset(
+        &self,
+        preset: &PipelinePreset,
+    ) -> impl std::future::Future<Output = Result<()>> + Send;
 
     /// Update an existing pipeline preset.
-    async fn update_pipeline_preset(&self, preset: &PipelinePreset) -> Result<()>;
+    fn update_pipeline_preset(
+        &self,
+        preset: &PipelinePreset,
+    ) -> impl std::future::Future<Output = Result<()>> + Send;
 
     /// Delete a pipeline preset.
-    async fn delete_pipeline_preset(&self, id: &str) -> Result<()>;
+    fn delete_pipeline_preset(
+        &self,
+        id: &str,
+    ) -> impl std::future::Future<Output = Result<()>> + Send;
 }
 
 /// SQLite implementation of PipelinePresetRepository.
@@ -358,7 +392,6 @@ impl SqlitePipelinePresetRepository {
     }
 }
 
-#[async_trait]
 impl PipelinePresetRepository for SqlitePipelinePresetRepository {
     async fn list_pipeline_presets(&self) -> Result<Vec<PipelinePreset>> {
         let presets = sqlx::query_as::<_, PipelinePreset>(

--- a/rust-srec/src/database/repositories/refresh_token.rs
+++ b/rust-srec/src/database/repositories/refresh_token.rs
@@ -1,35 +1,49 @@
 //! Refresh token repository for database operations.
 
-use async_trait::async_trait;
 use sqlx::SqlitePool;
 
 use crate::Result;
 use crate::database::models::RefreshTokenDbModel;
 
 /// Refresh token repository trait for token data access operations.
-#[async_trait]
+#[dynosaur::dynosaur(pub DynRefreshTokenRepository = dyn(box) RefreshTokenRepository)]
 pub trait RefreshTokenRepository: Send + Sync {
     /// Create a new refresh token in the database.
-    async fn create(&self, token: &RefreshTokenDbModel) -> Result<()>;
+    fn create(
+        &self,
+        token: &RefreshTokenDbModel,
+    ) -> impl std::future::Future<Output = Result<()>> + Send;
 
     /// Find a refresh token by its hash.
-    async fn find_by_token_hash(&self, hash: &str) -> Result<Option<RefreshTokenDbModel>>;
+    fn find_by_token_hash(
+        &self,
+        hash: &str,
+    ) -> impl std::future::Future<Output = Result<Option<RefreshTokenDbModel>>> + Send;
 
     /// Find all active (non-revoked, non-expired) tokens for a user.
-    async fn find_active_by_user(&self, user_id: &str) -> Result<Vec<RefreshTokenDbModel>>;
+    fn find_active_by_user(
+        &self,
+        user_id: &str,
+    ) -> impl std::future::Future<Output = Result<Vec<RefreshTokenDbModel>>> + Send;
 
     /// Revoke a specific token by its ID.
-    async fn revoke(&self, id: &str) -> Result<()>;
+    fn revoke(&self, id: &str) -> impl std::future::Future<Output = Result<()>> + Send;
 
     /// Revoke all tokens for a specific user.
-    async fn revoke_all_for_user(&self, user_id: &str) -> Result<()>;
+    fn revoke_all_for_user(
+        &self,
+        user_id: &str,
+    ) -> impl std::future::Future<Output = Result<()>> + Send;
 
     /// Clean up expired tokens from the database.
     /// Returns the number of tokens deleted.
-    async fn cleanup_expired(&self) -> Result<u64>;
+    fn cleanup_expired(&self) -> impl std::future::Future<Output = Result<u64>> + Send;
 
     /// Count active tokens for a user.
-    async fn count_active_by_user(&self, user_id: &str) -> Result<i64>;
+    fn count_active_by_user(
+        &self,
+        user_id: &str,
+    ) -> impl std::future::Future<Output = Result<i64>> + Send;
 }
 
 /// SQLx implementation of RefreshTokenRepository.
@@ -45,7 +59,6 @@ impl SqlxRefreshTokenRepository {
     }
 }
 
-#[async_trait]
 impl RefreshTokenRepository for SqlxRefreshTokenRepository {
     async fn create(&self, token: &RefreshTokenDbModel) -> Result<()> {
         sqlx::query(

--- a/rust-srec/src/database/repositories/session.rs
+++ b/rust-srec/src/database/repositories/session.rs
@@ -1,6 +1,5 @@
 //! Session repository.
 
-use async_trait::async_trait;
 use sqlx::SqlitePool;
 
 use crate::database::models::{
@@ -11,83 +10,121 @@ use crate::database::retry::retry_on_sqlite_busy;
 use crate::{Error, Result};
 
 /// Session repository trait.
-#[async_trait]
+#[dynosaur::dynosaur(pub DynSessionRepository = dyn(box) SessionRepository)]
 pub trait SessionRepository: Send + Sync {
     // Live Sessions
-    async fn get_session(&self, id: &str) -> Result<LiveSessionDbModel>;
-    async fn get_active_session_for_streamer(
+    fn get_session(
+        &self,
+        id: &str,
+    ) -> impl std::future::Future<Output = Result<LiveSessionDbModel>> + Send;
+    fn get_active_session_for_streamer(
         &self,
         streamer_id: &str,
-    ) -> Result<Option<LiveSessionDbModel>>;
-    async fn list_sessions_for_streamer(
+    ) -> impl std::future::Future<Output = Result<Option<LiveSessionDbModel>>> + Send;
+    fn list_sessions_for_streamer(
         &self,
         streamer_id: &str,
         limit: i32,
-    ) -> Result<Vec<LiveSessionDbModel>>;
-    async fn create_session(&self, session: &LiveSessionDbModel) -> Result<()>;
-    async fn end_session(&self, id: &str, end_time: i64) -> Result<()>;
-    async fn resume_session(&self, id: &str) -> Result<()>;
-    async fn update_session_titles(&self, id: &str, titles: &str) -> Result<()>;
-    async fn delete_session(&self, id: &str) -> Result<()>;
-    async fn delete_sessions_batch(&self, ids: &[String]) -> Result<u64>;
+    ) -> impl std::future::Future<Output = Result<Vec<LiveSessionDbModel>>> + Send;
+    fn create_session(
+        &self,
+        session: &LiveSessionDbModel,
+    ) -> impl std::future::Future<Output = Result<()>> + Send;
+    fn end_session(
+        &self,
+        id: &str,
+        end_time: i64,
+    ) -> impl std::future::Future<Output = Result<()>> + Send;
+    fn resume_session(&self, id: &str) -> impl std::future::Future<Output = Result<()>> + Send;
+    fn update_session_titles(
+        &self,
+        id: &str,
+        titles: &str,
+    ) -> impl std::future::Future<Output = Result<()>> + Send;
+    fn delete_session(&self, id: &str) -> impl std::future::Future<Output = Result<()>> + Send;
+    fn delete_sessions_batch(
+        &self,
+        ids: &[String],
+    ) -> impl std::future::Future<Output = Result<u64>> + Send;
 
     // Filtering and pagination
     /// List sessions with optional filters and pagination.
     /// Returns a tuple of (sessions, total_count).
-    async fn list_sessions_filtered(
+    fn list_sessions_filtered(
         &self,
         filters: &SessionFilters,
         pagination: &Pagination,
-    ) -> Result<(Vec<LiveSessionDbModel>, u64)>;
+    ) -> impl std::future::Future<Output = Result<(Vec<LiveSessionDbModel>, u64)>> + Send;
 
     // Media Outputs
-    async fn get_media_output(&self, id: &str) -> Result<MediaOutputDbModel>;
-    async fn get_media_outputs_for_session(
+    fn get_media_output(
+        &self,
+        id: &str,
+    ) -> impl std::future::Future<Output = Result<MediaOutputDbModel>> + Send;
+    fn get_media_outputs_for_session(
         &self,
         session_id: &str,
-    ) -> Result<Vec<MediaOutputDbModel>>;
-    async fn create_media_output(&self, output: &MediaOutputDbModel) -> Result<()>;
-    async fn delete_media_output(&self, id: &str) -> Result<()>;
+    ) -> impl std::future::Future<Output = Result<Vec<MediaOutputDbModel>>> + Send;
+    fn create_media_output(
+        &self,
+        output: &MediaOutputDbModel,
+    ) -> impl std::future::Future<Output = Result<()>> + Send;
+    fn delete_media_output(
+        &self,
+        id: &str,
+    ) -> impl std::future::Future<Output = Result<()>> + Send;
 
     /// Get the count of media outputs for a session.
-    async fn get_output_count(&self, session_id: &str) -> Result<u32>;
+    fn get_output_count(
+        &self,
+        session_id: &str,
+    ) -> impl std::future::Future<Output = Result<u32>> + Send;
 
     /// List media outputs with optional filters and pagination.
     /// Returns a tuple of (outputs, total_count).
-    async fn list_outputs_filtered(
+    fn list_outputs_filtered(
         &self,
         filters: &OutputFilters,
         pagination: &Pagination,
-    ) -> Result<(Vec<MediaOutputDbModel>, u64)>;
+    ) -> impl std::future::Future<Output = Result<(Vec<MediaOutputDbModel>, u64)>> + Send;
 
-    async fn create_session_segment(&self, segment: &SessionSegmentDbModel) -> Result<()>;
-    async fn list_session_segments_for_session(
+    fn create_session_segment(
+        &self,
+        segment: &SessionSegmentDbModel,
+    ) -> impl std::future::Future<Output = Result<()>> + Send;
+    fn list_session_segments_for_session(
         &self,
         session_id: &str,
         limit: i32,
-    ) -> Result<Vec<SessionSegmentDbModel>>;
+    ) -> impl std::future::Future<Output = Result<Vec<SessionSegmentDbModel>>> + Send;
 
-    async fn list_session_segments_page(
+    fn list_session_segments_page(
         &self,
         session_id: &str,
         pagination: &Pagination,
-    ) -> Result<Vec<SessionSegmentDbModel>>;
+    ) -> impl std::future::Future<Output = Result<Vec<SessionSegmentDbModel>>> + Send;
 
     // Danmu Statistics
-    async fn get_danmu_statistics(
+    fn get_danmu_statistics(
         &self,
         session_id: &str,
-    ) -> Result<Option<DanmuStatisticsDbModel>>;
-    async fn create_danmu_statistics(&self, stats: &DanmuStatisticsDbModel) -> Result<()>;
-    async fn update_danmu_statistics(&self, stats: &DanmuStatisticsDbModel) -> Result<()>;
-    async fn upsert_danmu_statistics(
+    ) -> impl std::future::Future<Output = Result<Option<DanmuStatisticsDbModel>>> + Send;
+    fn create_danmu_statistics(
+        &self,
+        stats: &DanmuStatisticsDbModel,
+    ) -> impl std::future::Future<Output = Result<()>> + Send;
+    fn update_danmu_statistics(
+        &self,
+        stats: &DanmuStatisticsDbModel,
+    ) -> impl std::future::Future<Output = Result<()>> + Send;
+    fn upsert_danmu_statistics(
         &self,
         session_id: &str,
         total_danmus: i64,
         danmu_rate_timeseries: Option<&str>,
         top_talkers: Option<&str>,
         word_frequency: Option<&str>,
-    ) -> Result<()>;
+    ) -> impl std::future::Future<Output = Result<()>> + Send;
 }
 
 /// SQLx implementation of SessionRepository.
@@ -102,7 +139,6 @@ impl SqlxSessionRepository {
     }
 }
 
-#[async_trait]
 impl SessionRepository for SqlxSessionRepository {
     async fn get_session(&self, id: &str) -> Result<LiveSessionDbModel> {
         sqlx::query_as::<_, LiveSessionDbModel>("SELECT * FROM live_sessions WHERE id = ?")

--- a/rust-srec/src/database/repositories/streamer.rs
+++ b/rust-srec/src/database/repositories/streamer.rs
@@ -1,6 +1,5 @@
 //! Streamer repository.
 
-use async_trait::async_trait;
 use sqlx::SqlitePool;
 
 use crate::database::models::StreamerDbModel;
@@ -9,46 +8,106 @@ use crate::{Error, Result};
 use chrono::{DateTime, Utc};
 
 /// Streamer repository trait.
-#[async_trait]
+#[dynosaur::dynosaur(pub DynStreamerRepository = dyn(box) StreamerRepository)]
 pub trait StreamerRepository: Send + Sync {
-    async fn get_streamer(&self, id: &str) -> Result<StreamerDbModel>;
-    async fn get_streamer_by_url(&self, url: &str) -> Result<StreamerDbModel>;
-    async fn list_streamers(&self) -> Result<Vec<StreamerDbModel>>;
-    async fn list_all_streamers(&self) -> Result<Vec<StreamerDbModel>>;
-    async fn list_streamers_by_state(&self, state: &str) -> Result<Vec<StreamerDbModel>>;
-    async fn list_streamers_by_priority(&self, priority: &str) -> Result<Vec<StreamerDbModel>>;
-    async fn list_streamers_by_platform(&self, platform_id: &str) -> Result<Vec<StreamerDbModel>>;
-    async fn list_streamers_by_template(&self, template_id: &str) -> Result<Vec<StreamerDbModel>>;
-    async fn list_active_streamers(&self) -> Result<Vec<StreamerDbModel>>;
-    async fn create_streamer(&self, streamer: &StreamerDbModel) -> Result<()>;
-    async fn update_streamer(&self, streamer: &StreamerDbModel) -> Result<()>;
-    async fn update_streamer_state(&self, id: &str, state: &str) -> Result<()>;
-    async fn update_streamer_priority(&self, id: &str, priority: &str) -> Result<()>;
-    async fn increment_error_count(&self, id: &str) -> Result<i32>;
-    async fn reset_error_count(&self, id: &str) -> Result<()>;
-    async fn set_disabled_until(&self, id: &str, until: Option<i64>) -> Result<()>;
-    async fn update_last_live_time(&self, id: &str, time: i64) -> Result<()>;
-    async fn update_avatar(&self, id: &str, avatar_url: Option<&str>) -> Result<()>;
-    async fn delete_streamer(&self, id: &str) -> Result<()>;
+    fn get_streamer(
+        &self,
+        id: &str,
+    ) -> impl std::future::Future<Output = Result<StreamerDbModel>> + Send;
+    fn get_streamer_by_url(
+        &self,
+        url: &str,
+    ) -> impl std::future::Future<Output = Result<StreamerDbModel>> + Send;
+    fn list_streamers(
+        &self,
+    ) -> impl std::future::Future<Output = Result<Vec<StreamerDbModel>>> + Send;
+    fn list_all_streamers(
+        &self,
+    ) -> impl std::future::Future<Output = Result<Vec<StreamerDbModel>>> + Send;
+    fn list_streamers_by_state(
+        &self,
+        state: &str,
+    ) -> impl std::future::Future<Output = Result<Vec<StreamerDbModel>>> + Send;
+    fn list_streamers_by_priority(
+        &self,
+        priority: &str,
+    ) -> impl std::future::Future<Output = Result<Vec<StreamerDbModel>>> + Send;
+    fn list_streamers_by_platform(
+        &self,
+        platform_id: &str,
+    ) -> impl std::future::Future<Output = Result<Vec<StreamerDbModel>>> + Send;
+    fn list_streamers_by_template(
+        &self,
+        template_id: &str,
+    ) -> impl std::future::Future<Output = Result<Vec<StreamerDbModel>>> + Send;
+    fn list_active_streamers(
+        &self,
+    ) -> impl std::future::Future<Output = Result<Vec<StreamerDbModel>>> + Send;
+    fn create_streamer(
+        &self,
+        streamer: &StreamerDbModel,
+    ) -> impl std::future::Future<Output = Result<()>> + Send;
+    fn update_streamer(
+        &self,
+        streamer: &StreamerDbModel,
+    ) -> impl std::future::Future<Output = Result<()>> + Send;
+    fn update_streamer_state(
+        &self,
+        id: &str,
+        state: &str,
+    ) -> impl std::future::Future<Output = Result<()>> + Send;
+    fn update_streamer_priority(
+        &self,
+        id: &str,
+        priority: &str,
+    ) -> impl std::future::Future<Output = Result<()>> + Send;
+    fn increment_error_count(
+        &self,
+        id: &str,
+    ) -> impl std::future::Future<Output = Result<i32>> + Send;
+    fn reset_error_count(&self, id: &str) -> impl std::future::Future<Output = Result<()>> + Send;
+    fn set_disabled_until(
+        &self,
+        id: &str,
+        until: Option<i64>,
+    ) -> impl std::future::Future<Output = Result<()>> + Send;
+    fn update_last_live_time(
+        &self,
+        id: &str,
+        time: i64,
+    ) -> impl std::future::Future<Output = Result<()>> + Send;
+    fn update_avatar(
+        &self,
+        id: &str,
+        avatar_url: Option<&str>,
+    ) -> impl std::future::Future<Output = Result<()>> + Send;
+    fn delete_streamer(&self, id: &str) -> impl std::future::Future<Output = Result<()>> + Send;
 
     // Methods for StreamerManager
-    async fn clear_streamer_error_state(&self, id: &str) -> Result<()>;
-    async fn clear_streamer_last_error(&self, id: &str) -> Result<()>;
-    async fn record_streamer_error(
+    fn clear_streamer_error_state(
+        &self,
+        id: &str,
+    ) -> impl std::future::Future<Output = Result<()>> + Send;
+    fn clear_streamer_last_error(
+        &self,
+        id: &str,
+    ) -> impl std::future::Future<Output = Result<()>> + Send;
+    fn record_streamer_error(
         &self,
         id: &str,
         error_count: i32,
         disabled_until: Option<DateTime<Utc>>,
         error: Option<&str>,
-    ) -> Result<()>;
-    async fn record_streamer_success(
+    ) -> impl std::future::Future<Output = Result<()>> + Send;
+    fn record_streamer_success(
         &self,
         id: &str,
         last_live_time: Option<DateTime<Utc>>,
-    ) -> Result<()>;
+    ) -> impl std::future::Future<Output = Result<()>> + Send;
 }
 
 /// SQLx implementation of StreamerRepository.
+#[derive(Clone)]
 pub struct SqlxStreamerRepository {
     pool: SqlitePool,
     write_pool: SqlitePool,
@@ -60,7 +119,6 @@ impl SqlxStreamerRepository {
     }
 }
 
-#[async_trait]
 impl StreamerRepository for SqlxStreamerRepository {
     async fn get_streamer(&self, id: &str) -> Result<StreamerDbModel> {
         sqlx::query_as::<_, StreamerDbModel>("SELECT * FROM streamers WHERE id = ?")

--- a/rust-srec/src/database/repositories/user.rs
+++ b/rust-srec/src/database/repositories/user.rs
@@ -1,48 +1,64 @@
 //! User repository for database operations.
 
-use async_trait::async_trait;
 use sqlx::SqlitePool;
 
 use crate::Result;
 use crate::database::models::UserDbModel;
 
 /// User repository trait for user data access operations.
-#[async_trait]
+#[dynosaur::dynosaur(pub DynUserRepository = dyn(box) UserRepository)]
 pub trait UserRepository: Send + Sync {
     /// Create a new user in the database.
-    async fn create(&self, user: &UserDbModel) -> Result<()>;
+    fn create(&self, user: &UserDbModel) -> impl std::future::Future<Output = Result<()>> + Send;
 
     /// Find a user by their unique ID.
-    async fn find_by_id(&self, id: &str) -> Result<Option<UserDbModel>>;
+    fn find_by_id(
+        &self,
+        id: &str,
+    ) -> impl std::future::Future<Output = Result<Option<UserDbModel>>> + Send;
 
     /// Find a user by their username.
-    async fn find_by_username(&self, username: &str) -> Result<Option<UserDbModel>>;
+    fn find_by_username(
+        &self,
+        username: &str,
+    ) -> impl std::future::Future<Output = Result<Option<UserDbModel>>> + Send;
 
     /// Find a user by their email address.
-    async fn find_by_email(&self, email: &str) -> Result<Option<UserDbModel>>;
+    fn find_by_email(
+        &self,
+        email: &str,
+    ) -> impl std::future::Future<Output = Result<Option<UserDbModel>>> + Send;
 
     /// Update an existing user.
-    async fn update(&self, user: &UserDbModel) -> Result<()>;
+    fn update(&self, user: &UserDbModel) -> impl std::future::Future<Output = Result<()>> + Send;
 
     /// Delete a user by their ID.
-    async fn delete(&self, id: &str) -> Result<()>;
+    fn delete(&self, id: &str) -> impl std::future::Future<Output = Result<()>> + Send;
 
     /// List users with pagination.
-    async fn list(&self, limit: i64, offset: i64) -> Result<Vec<UserDbModel>>;
+    fn list(
+        &self,
+        limit: i64,
+        offset: i64,
+    ) -> impl std::future::Future<Output = Result<Vec<UserDbModel>>> + Send;
 
     /// Update the last login timestamp (epoch ms) for a user.
-    async fn update_last_login(&self, id: &str, time_ms: i64) -> Result<()>;
+    fn update_last_login(
+        &self,
+        id: &str,
+        time_ms: i64,
+    ) -> impl std::future::Future<Output = Result<()>> + Send;
 
     /// Update a user's password hash.
-    async fn update_password(
+    fn update_password(
         &self,
         id: &str,
         password_hash: &str,
         clear_must_change: bool,
-    ) -> Result<()>;
+    ) -> impl std::future::Future<Output = Result<()>> + Send;
 
     /// Count total number of users.
-    async fn count(&self) -> Result<i64>;
+    fn count(&self) -> impl std::future::Future<Output = Result<i64>> + Send;
 }
 
 /// SQLx implementation of UserRepository.
@@ -58,7 +74,6 @@ impl SqlxUserRepository {
     }
 }
 
-#[async_trait]
 impl UserRepository for SqlxUserRepository {
     async fn create(&self, user: &UserDbModel) -> Result<()> {
         sqlx::query(

--- a/rust-srec/src/downloader/engine/ffmpeg.rs
+++ b/rust-srec/src/downloader/engine/ffmpeg.rs
@@ -1,6 +1,5 @@
 //! FFmpeg download engine implementation.
 
-use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use pipeline_common::expand_filename_template;
 use std::path::PathBuf;
@@ -157,7 +156,6 @@ impl Default for FfmpegEngine {
     }
 }
 
-#[async_trait]
 impl DownloadEngine for FfmpegEngine {
     fn engine_type(&self) -> EngineType {
         EngineType::Ffmpeg

--- a/rust-srec/src/downloader/engine/mesio/engine.rs
+++ b/rust-srec/src/downloader/engine/mesio/engine.rs
@@ -11,7 +11,6 @@
 //! Progress tracking is handled by the writers internally via `WriterTask` and
 //! `WriterState`, eliminating the need for duplicate tracking in the engine.
 
-use async_trait::async_trait;
 use axum::http::HeaderMap;
 use mesio::flv::FlvProtocolConfig;
 use mesio::{FlvProtocolBuilder, HlsProtocolBuilder, MesioDownloaderFactory, ProtocolType};
@@ -103,7 +102,6 @@ impl Default for MesioEngine {
     }
 }
 
-#[async_trait]
 impl DownloadEngine for MesioEngine {
     fn engine_type(&self) -> EngineType {
         EngineType::Mesio

--- a/rust-srec/src/downloader/engine/mod.rs
+++ b/rust-srec/src/downloader/engine/mod.rs
@@ -30,6 +30,6 @@ pub use mesio::{DownloadStats, FlvDownloader, HlsDownloader, MesioEngine, config
 pub use streamlink::StreamlinkEngine;
 pub use traits::{
     DownloadConfig, DownloadEngine, DownloadFailureKind, DownloadHandle, DownloadInfo,
-    DownloadProgress, DownloadStatus, EngineStartError, EngineType, IoErrorKindSer, SegmentEvent,
-    SegmentInfo,
+    DownloadProgress, DownloadStatus, DynDownloadEngine, EngineStartError, EngineType,
+    IoErrorKindSer, SegmentEvent, SegmentInfo,
 };

--- a/rust-srec/src/downloader/engine/streamlink.rs
+++ b/rust-srec/src/downloader/engine/streamlink.rs
@@ -1,6 +1,5 @@
 //! Streamlink download engine implementation.
 
-use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use pipeline_common::expand_filename_template;
 use std::path::PathBuf;
@@ -214,7 +213,6 @@ impl Default for StreamlinkEngine {
     }
 }
 
-#[async_trait]
 impl DownloadEngine for StreamlinkEngine {
     fn engine_type(&self) -> EngineType {
         EngineType::Streamlink

--- a/rust-srec/src/downloader/engine/traits.rs
+++ b/rust-srec/src/downloader/engine/traits.rs
@@ -1,6 +1,5 @@
 //! Download engine trait and related types.
 
-use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use flv_fix::FlvPipelineConfig;
 use hls_fix::HlsPipelineConfig;
@@ -665,7 +664,7 @@ pub struct DownloadInfo {
 }
 
 /// Trait for download engines.
-#[async_trait]
+#[dynosaur::dynosaur(pub DynDownloadEngine = dyn(box) DownloadEngine)]
 pub trait DownloadEngine: Send + Sync {
     /// Get the engine type.
     fn engine_type(&self) -> EngineType;
@@ -674,13 +673,18 @@ pub trait DownloadEngine: Send + Sync {
     ///
     /// Returns a handle that can be used to monitor and cancel the download.
     /// The engine should emit events through the handle's event channel.
-    async fn start(&self, handle: Arc<DownloadHandle>)
-    -> std::result::Result<(), EngineStartError>;
+    fn start(
+        &self,
+        handle: Arc<DownloadHandle>,
+    ) -> impl std::future::Future<Output = std::result::Result<(), EngineStartError>> + Send;
 
     /// Stop a download.
     ///
     /// This should gracefully stop the download and clean up resources.
-    async fn stop(&self, handle: &DownloadHandle) -> Result<()>;
+    fn stop(
+        &self,
+        handle: &DownloadHandle,
+    ) -> impl std::future::Future<Output = Result<()>> + Send;
 
     /// Check if the engine is available (e.g., binary exists).
     fn is_available(&self) -> bool;

--- a/rust-srec/src/downloader/manager.rs
+++ b/rust-srec/src/downloader/manager.rs
@@ -26,7 +26,7 @@ use crate::Result;
 use crate::database::models::engine::{
     FfmpegEngineConfig, MesioEngineConfig, StreamlinkEngineConfig,
 };
-use crate::database::repositories::config::ConfigRepository;
+use crate::database::repositories::config::{ConfigRepository, DynConfigRepository};
 use crate::downloader::SegmentInfo;
 
 fn parse_engine_config<T: DeserializeOwned>(engine: &'static str, raw: &str) -> Result<T> {
@@ -263,7 +263,7 @@ pub struct DownloadManager {
     /// Broadcast sender for download events
     event_tx: broadcast::Sender<DownloadManagerEvent>,
     /// Config repository for resolving custom engines.
-    config_repo: Option<Arc<dyn ConfigRepository>>,
+    config_repo: Option<Arc<DynConfigRepository<'static>>>,
 }
 
 /// Type of configuration that was updated.
@@ -523,7 +523,7 @@ impl DownloadManager {
     }
 
     /// Set the config repository.
-    pub fn with_config_repo(mut self, config_repo: Arc<dyn ConfigRepository>) -> Self {
+    pub fn with_config_repo(mut self, config_repo: Arc<DynConfigRepository<'static>>) -> Self {
         self.config_repo = Some(config_repo);
         self
     }

--- a/rust-srec/src/downloader/manager.rs
+++ b/rust-srec/src/downloader/manager.rs
@@ -17,6 +17,7 @@ use tracing::{debug, error, info, warn};
 
 use super::engine::{
     DownloadConfig, DownloadEngine, DownloadFailureKind, DownloadHandle, DownloadInfo,
+    DynDownloadEngine,
     DownloadProgress, DownloadStatus, EngineStartError, EngineType, FfmpegEngine, IoErrorKindSer,
     MesioEngine, SegmentEvent, StreamlinkEngine,
 };
@@ -246,7 +247,7 @@ pub struct DownloadManager {
     /// Pending configuration updates keyed by download_id.
     pending_updates: Arc<DashMap<String, PendingConfigUpdate>>,
     /// Engine registry.
-    engines: RwLock<HashMap<EngineType, Arc<dyn DownloadEngine>>>,
+    engines: RwLock<HashMap<EngineType, Arc<DynDownloadEngine<'static>>>>,
     /// Circuit breaker manager.
     circuit_breakers: CircuitBreakerManager,
     /// Output-root write gate. Optional so existing tests and simple callers
@@ -483,15 +484,15 @@ impl DownloadManager {
             let mut engines = manager.engines.write();
             engines.insert(
                 EngineType::Ffmpeg,
-                Arc::new(FfmpegEngine::new()) as Arc<dyn DownloadEngine>,
+                DynDownloadEngine::new_arc(FfmpegEngine::new()),
             );
             engines.insert(
                 EngineType::Streamlink,
-                Arc::new(StreamlinkEngine::new()) as Arc<dyn DownloadEngine>,
+                DynDownloadEngine::new_arc(StreamlinkEngine::new()),
             );
             engines.insert(
                 EngineType::Mesio,
-                Arc::new(MesioEngine::new()) as Arc<dyn DownloadEngine>,
+                DynDownloadEngine::new_arc(MesioEngine::new()),
             );
         }
 
@@ -529,14 +530,14 @@ impl DownloadManager {
     }
 
     /// Register a download engine.
-    pub fn register_engine(&mut self, engine: Arc<dyn DownloadEngine>) {
+    pub fn register_engine(&mut self, engine: Arc<DynDownloadEngine<'static>>) {
         let engine_type = engine.engine_type();
         self.engines.write().insert(engine_type, engine);
         debug!("Registered download engine: {}", engine_type);
     }
 
     /// Get an engine by type.
-    pub fn get_engine(&self, engine_type: EngineType) -> Option<Arc<dyn DownloadEngine>> {
+    pub fn get_engine(&self, engine_type: EngineType) -> Option<Arc<DynDownloadEngine<'static>>> {
         self.engines.read().get(&engine_type).cloned()
     }
 
@@ -685,7 +686,7 @@ impl DownloadManager {
         &self,
         engine_id: Option<&str>,
         overrides: Option<&serde_json::Value>,
-    ) -> Result<(Arc<dyn DownloadEngine>, EngineType, EngineKey)> {
+    ) -> Result<(Arc<DynDownloadEngine<'static>>, EngineType, EngineKey)> {
         let default_engine = self.config.read().default_engine;
         let target_id = engine_id.unwrap_or(default_engine.as_str());
 
@@ -702,14 +703,14 @@ impl DownloadManager {
             let engine_type = self.resolve_engine_type(target_id).await?;
             let key = EngineKey::with_override(engine_type, engine_id, override_hash);
 
-            let engine: Arc<dyn DownloadEngine> = match engine_type {
+            let engine: Arc<DynDownloadEngine<'static>> = match engine_type {
                 EngineType::Ffmpeg => {
                     let base_config = self
                         .load_engine_config_or_default::<FfmpegEngineConfig>(target_id)
                         .await;
                     let merged_config =
                         Self::apply_override_best_effort(base_config, override_config);
-                    Arc::new(FfmpegEngine::with_config(merged_config))
+                    DynDownloadEngine::new_arc(FfmpegEngine::with_config(merged_config))
                 }
                 EngineType::Streamlink => {
                     let base_config = self
@@ -717,7 +718,7 @@ impl DownloadManager {
                         .await;
                     let merged_config =
                         Self::apply_override_best_effort(base_config, override_config);
-                    Arc::new(StreamlinkEngine::with_config(merged_config))
+                    DynDownloadEngine::new_arc(StreamlinkEngine::with_config(merged_config))
                 }
                 EngineType::Mesio => {
                     let base_config = self
@@ -725,7 +726,7 @@ impl DownloadManager {
                         .await;
                     let merged_config =
                         Self::apply_override_best_effort(base_config, override_config);
-                    Arc::new(MesioEngine::with_config(merged_config))
+                    DynDownloadEngine::new_arc(MesioEngine::with_config(merged_config))
                 }
             };
 
@@ -759,21 +760,21 @@ impl DownloadManager {
                             })?;
 
                         let key = EngineKey::custom(engine_type, id);
-                        let engine: Arc<dyn DownloadEngine> = match engine_type {
+                        let engine: Arc<DynDownloadEngine<'static>> = match engine_type {
                             EngineType::Ffmpeg => {
                                 let engine_config: FfmpegEngineConfig =
                                     parse_engine_config("ffmpeg", &config.config)?;
-                                Arc::new(FfmpegEngine::with_config(engine_config))
+                                DynDownloadEngine::new_arc(FfmpegEngine::with_config(engine_config))
                             }
                             EngineType::Streamlink => {
                                 let engine_config: StreamlinkEngineConfig =
                                     parse_engine_config("streamlink", &config.config)?;
-                                Arc::new(StreamlinkEngine::with_config(engine_config))
+                                DynDownloadEngine::new_arc(StreamlinkEngine::with_config(engine_config))
                             }
                             EngineType::Mesio => {
                                 let engine_config: MesioEngineConfig =
                                     parse_engine_config("mesio", &config.config)?;
-                                Arc::new(MesioEngine::with_config(engine_config))
+                                DynDownloadEngine::new_arc(MesioEngine::with_config(engine_config))
                             }
                         };
 
@@ -911,7 +912,7 @@ impl DownloadManager {
     async fn start_download_with_engine(
         &self,
         config: DownloadConfig,
-        engine: Arc<dyn DownloadEngine>,
+        engine: Arc<DynDownloadEngine<'static>>,
         engine_type: EngineType,
         engine_key: EngineKey,
         is_high_priority: bool,

--- a/rust-srec/src/monitor/detector.rs
+++ b/rust-srec/src/monitor/detector.rs
@@ -8,6 +8,7 @@ use chrono::{DateTime, Utc};
 use dashmap::DashMap;
 use platforms_parser::extractor::error::ExtractorError;
 use platforms_parser::extractor::factory::ExtractorFactory;
+use platforms_parser::extractor::platform_extractor::PlatformExtractor;
 use serde::{Deserialize, Serialize};
 use tracing::{debug, error, trace, warn};
 

--- a/rust-srec/src/notification/channels/discord.rs
+++ b/rust-srec/src/notification/channels/discord.rs
@@ -7,7 +7,6 @@
 
 use std::time::Duration;
 
-use async_trait::async_trait;
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
@@ -187,7 +186,6 @@ impl DiscordChannel {
     }
 }
 
-#[async_trait]
 impl NotificationChannel for DiscordChannel {
     fn channel_type(&self) -> &'static str {
         "discord"

--- a/rust-srec/src/notification/channels/email.rs
+++ b/rust-srec/src/notification/channels/email.rs
@@ -1,6 +1,5 @@
 //! Email notification channel using SMTP.
 
-use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use tracing::{debug, warn};
 
@@ -141,7 +140,6 @@ impl EmailChannel {
     }
 }
 
-#[async_trait]
 impl NotificationChannel for EmailChannel {
     fn channel_type(&self) -> &'static str {
         "email"

--- a/rust-srec/src/notification/channels/gotify.rs
+++ b/rust-srec/src/notification/channels/gotify.rs
@@ -2,7 +2,6 @@
 //!
 //! Sends messages via the Gotify REST API (`POST /message?token=<app_token>`).
 
-use async_trait::async_trait;
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
@@ -101,7 +100,6 @@ impl GotifyChannel {
     }
 }
 
-#[async_trait]
 impl NotificationChannel for GotifyChannel {
     fn channel_type(&self) -> &'static str {
         "gotify"

--- a/rust-srec/src/notification/channels/mod.rs
+++ b/rust-srec/src/notification/channels/mod.rs
@@ -18,14 +18,13 @@ pub use gotify::{GotifyChannel, GotifyConfig};
 pub use telegram::{TelegramChannel, TelegramConfig};
 pub use webhook::{WebhookAuth, WebhookChannel, WebhookConfig};
 
-use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 
 use super::events::NotificationEvent;
 use crate::Result;
 
 /// Trait for notification channels.
-#[async_trait]
+#[dynosaur::dynosaur(pub DynNotificationChannel = dyn(box) NotificationChannel)]
 pub trait NotificationChannel: Send + Sync {
     /// Get the channel type name.
     fn channel_type(&self) -> &'static str;
@@ -34,10 +33,13 @@ pub trait NotificationChannel: Send + Sync {
     fn is_enabled(&self) -> bool;
 
     /// Send a notification through this channel.
-    async fn send(&self, event: &NotificationEvent) -> Result<()>;
+    fn send(
+        &self,
+        event: &NotificationEvent,
+    ) -> impl std::future::Future<Output = Result<()>> + Send;
 
     /// Test the channel configuration.
-    async fn test(&self) -> Result<()>;
+    fn test(&self) -> impl std::future::Future<Output = Result<()>> + Send;
 }
 
 /// Channel configuration wrapper.

--- a/rust-srec/src/notification/channels/telegram.rs
+++ b/rust-srec/src/notification/channels/telegram.rs
@@ -6,7 +6,6 @@
 
 use std::time::Duration;
 
-use async_trait::async_trait;
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
@@ -175,7 +174,6 @@ impl TelegramChannel {
     }
 }
 
-#[async_trait]
 impl NotificationChannel for TelegramChannel {
     fn channel_type(&self) -> &'static str {
         "telegram"

--- a/rust-srec/src/notification/channels/webhook.rs
+++ b/rust-srec/src/notification/channels/webhook.rs
@@ -1,6 +1,5 @@
 //! Generic webhook notification channel.
 
-use async_trait::async_trait;
 use reqwest::{Client, header::HeaderMap};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
@@ -150,7 +149,6 @@ impl WebhookChannel {
     }
 }
 
-#[async_trait]
 impl NotificationChannel for WebhookChannel {
     fn channel_type(&self) -> &'static str {
         "webhook"

--- a/rust-srec/src/notification/service.rs
+++ b/rust-srec/src/notification/service.rs
@@ -28,7 +28,8 @@ use tracing::{debug, info, warn};
 use uuid::Uuid;
 
 use super::channels::{
-    ChannelConfig, DiscordChannel, EmailChannel, GotifyChannel, NotificationChannel,
+    ChannelConfig, DiscordChannel, DynNotificationChannel, EmailChannel, GotifyChannel,
+    NotificationChannel,
     TelegramChannel, WebhookChannel,
 };
 use super::events::canonicalize_subscription_event_name;
@@ -40,7 +41,7 @@ use crate::database::models::{
     NotificationChannelDbModel, NotificationDeadLetterDbModel, NotificationEventLogDbModel,
     TelegramChannelSettings, WebhookChannelSettings,
 };
-use crate::database::repositories::NotificationRepository;
+use crate::database::repositories::{DynNotificationRepository, NotificationRepository};
 use crate::downloader::DownloadManagerEvent;
 use crate::monitor::MonitorEvent;
 use crate::pipeline::PipelineEvent;
@@ -177,7 +178,7 @@ struct RuntimeChannel {
     db_channel_id: Option<String>,
     display_name: String,
     channel_type: String,
-    channel: Arc<dyn NotificationChannel>,
+    channel: Arc<DynNotificationChannel<'static>>,
 }
 
 /// A notification pending delivery.
@@ -228,7 +229,7 @@ struct RetryParams {
     dead_letters: Arc<DashMap<u64, DeadLetterEntry>>,
     dead_letter_cleanup_ts: Arc<AtomicU64>,
     circuit_breakers: Arc<DashMap<String, CircuitBreakerState>>,
-    notification_repo: Option<Arc<dyn NotificationRepository>>,
+    notification_repo: Option<Arc<DynNotificationRepository<'static>>>,
     config: NotificationServiceConfig,
     next_dead_letter_id: Arc<AtomicU64>,
     cancellation_token: CancellationToken,
@@ -241,7 +242,7 @@ struct ProcessingParams {
     dead_letters: Arc<DashMap<u64, DeadLetterEntry>>,
     dead_letter_cleanup_ts: Arc<AtomicU64>,
     circuit_breakers: Arc<DashMap<String, CircuitBreakerState>>,
-    notification_repo: Option<Arc<dyn NotificationRepository>>,
+    notification_repo: Option<Arc<DynNotificationRepository<'static>>>,
     config: NotificationServiceConfig,
     next_dead_letter_id: Arc<AtomicU64>,
     cancellation_token: CancellationToken,
@@ -250,7 +251,7 @@ struct ProcessingParams {
 /// The notification service.
 pub struct NotificationService {
     config: NotificationServiceConfig,
-    notification_repo: Option<Arc<dyn NotificationRepository>>,
+    notification_repo: Option<Arc<DynNotificationRepository<'static>>>,
     web_push_service: Option<Arc<WebPushService>>,
     web_push_tx: parking_lot::RwLock<Option<mpsc::Sender<WebPushQueuedEvent>>>,
     web_push_worker_started: AtomicBool,
@@ -306,7 +307,7 @@ impl NotificationService {
 
     pub fn with_repository(
         config: NotificationServiceConfig,
-        notification_repo: Arc<dyn NotificationRepository>,
+        notification_repo: Arc<DynNotificationRepository<'static>>,
     ) -> Self {
         let mut service = Self::with_config(config);
         service.notification_repo = Some(notification_repo);
@@ -444,12 +445,22 @@ impl NotificationService {
         let mut used_keys: HashSet<String> = HashSet::new();
 
         for (idx, channel_config) in self.config.channels.iter().enumerate() {
-            let channel: Arc<dyn NotificationChannel> = match channel_config {
-                ChannelConfig::Discord(c) => Arc::new(DiscordChannel::new(c.clone())),
-                ChannelConfig::Email(c) => Arc::new(EmailChannel::new(c.clone())),
-                ChannelConfig::Gotify(c) => Arc::new(GotifyChannel::new(c.clone())),
-                ChannelConfig::Telegram(c) => Arc::new(TelegramChannel::new(c.clone())),
-                ChannelConfig::Webhook(c) => Arc::new(WebhookChannel::new(c.clone())),
+            let channel: Arc<DynNotificationChannel<'static>> = match channel_config {
+                ChannelConfig::Discord(c) => {
+                    DynNotificationChannel::new_arc(DiscordChannel::new(c.clone()))
+                }
+                ChannelConfig::Email(c) => {
+                    DynNotificationChannel::new_arc(EmailChannel::new(c.clone()))
+                }
+                ChannelConfig::Gotify(c) => {
+                    DynNotificationChannel::new_arc(GotifyChannel::new(c.clone()))
+                }
+                ChannelConfig::Telegram(c) => {
+                    DynNotificationChannel::new_arc(TelegramChannel::new(c.clone()))
+                }
+                ChannelConfig::Webhook(c) => {
+                    DynNotificationChannel::new_arc(WebhookChannel::new(c.clone()))
+                }
             };
 
             if channel.is_enabled() {
@@ -507,12 +518,22 @@ impl NotificationService {
 
     /// Add a channel dynamically.
     pub fn add_channel(&self, config: ChannelConfig) {
-        let channel: Arc<dyn NotificationChannel> = match &config {
-            ChannelConfig::Discord(c) => Arc::new(DiscordChannel::new(c.clone())),
-            ChannelConfig::Email(c) => Arc::new(EmailChannel::new(c.clone())),
-            ChannelConfig::Gotify(c) => Arc::new(GotifyChannel::new(c.clone())),
-            ChannelConfig::Telegram(c) => Arc::new(TelegramChannel::new(c.clone())),
-            ChannelConfig::Webhook(c) => Arc::new(WebhookChannel::new(c.clone())),
+        let channel: Arc<DynNotificationChannel<'static>> = match &config {
+            ChannelConfig::Discord(c) => {
+                DynNotificationChannel::new_arc(DiscordChannel::new(c.clone()))
+            }
+            ChannelConfig::Email(c) => {
+                DynNotificationChannel::new_arc(EmailChannel::new(c.clone()))
+            }
+            ChannelConfig::Gotify(c) => {
+                DynNotificationChannel::new_arc(GotifyChannel::new(c.clone()))
+            }
+            ChannelConfig::Telegram(c) => {
+                DynNotificationChannel::new_arc(TelegramChannel::new(c.clone()))
+            }
+            ChannelConfig::Webhook(c) => {
+                DynNotificationChannel::new_arc(WebhookChannel::new(c.clone()))
+            }
         };
 
         if channel.is_enabled() {
@@ -678,23 +699,25 @@ impl NotificationService {
             })
             .unwrap_or(NotificationPriority::Normal);
 
-        let runtime_channel: Arc<dyn NotificationChannel> = match channel_type {
+        let runtime_channel: Arc<DynNotificationChannel<'static>> = match channel_type {
             ChannelType::Discord => {
                 let settings: DiscordChannelSettings =
                     serde_json::from_value(settings_json.clone())?;
-                Arc::new(DiscordChannel::new(super::channels::DiscordConfig {
-                    id: None,
-                    name: None,
-                    enabled: true,
-                    webhook_url: settings.webhook_url,
-                    username: settings.username,
-                    avatar_url: settings.avatar_url,
-                    min_priority,
-                }))
+                DynNotificationChannel::new_arc(DiscordChannel::new(
+                    super::channels::DiscordConfig {
+                        id: None,
+                        name: None,
+                        enabled: true,
+                        webhook_url: settings.webhook_url,
+                        username: settings.username,
+                        avatar_url: settings.avatar_url,
+                        min_priority,
+                    },
+                ))
             }
             ChannelType::Email => {
                 let settings: EmailChannelSettings = serde_json::from_value(settings_json.clone())?;
-                Arc::new(EmailChannel::new(super::channels::EmailConfig {
+                DynNotificationChannel::new_arc(EmailChannel::new(super::channels::EmailConfig {
                     id: None,
                     name: None,
                     enabled: true,
@@ -723,19 +746,21 @@ impl NotificationService {
             ChannelType::Telegram => {
                 let settings: TelegramChannelSettings =
                     serde_json::from_value(settings_json.clone())?;
-                Arc::new(TelegramChannel::new(super::channels::TelegramConfig {
-                    id: None,
-                    name: None,
-                    enabled: true,
-                    bot_token: settings.bot_token,
-                    chat_id: settings.chat_id,
-                    parse_mode: settings_json
-                        .get("parse_mode")
-                        .and_then(|v| v.as_str())
-                        .unwrap_or("HTML")
-                        .to_string(),
-                    min_priority,
-                }))
+                DynNotificationChannel::new_arc(TelegramChannel::new(
+                    super::channels::TelegramConfig {
+                        id: None,
+                        name: None,
+                        enabled: true,
+                        bot_token: settings.bot_token,
+                        chat_id: settings.chat_id,
+                        parse_mode: settings_json
+                            .get("parse_mode")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("HTML")
+                            .to_string(),
+                        min_priority,
+                    },
+                ))
             }
             ChannelType::Webhook => {
                 let settings: WebhookChannelSettings =
@@ -764,7 +789,7 @@ impl NotificationService {
                     None
                 };
 
-                Arc::new(WebhookChannel::new(super::channels::WebhookConfig {
+                DynNotificationChannel::new_arc(WebhookChannel::new(super::channels::WebhookConfig {
                     id: None,
                     name: None,
                     enabled: settings.enabled.unwrap_or(true),
@@ -779,7 +804,7 @@ impl NotificationService {
             ChannelType::Gotify => {
                 let settings: GotifyChannelSettings =
                     serde_json::from_value(settings_json.clone())?;
-                Arc::new(GotifyChannel::new(super::channels::GotifyConfig {
+                DynNotificationChannel::new_arc(GotifyChannel::new(super::channels::GotifyConfig {
                     id: None,
                     name: None,
                     enabled: true,
@@ -1970,7 +1995,6 @@ mod tests {
         attempts: Arc<std::sync::atomic::AtomicU32>,
     }
 
-    #[async_trait::async_trait]
     impl NotificationChannel for TestChannel {
         fn channel_type(&self) -> &'static str {
             self.channel_type
@@ -2015,7 +2039,7 @@ mod tests {
             db_channel_id: None,
             display_name: "ok".to_string(),
             channel_type: "test".to_string(),
-            channel: Arc::new(TestChannel {
+            channel: DynNotificationChannel::new_arc(TestChannel {
                 channel_type: "ok",
                 fail_for_attempts: 0,
                 attempts: ok_attempts.clone(),
@@ -2034,7 +2058,7 @@ mod tests {
             db_channel_id: None,
             display_name: "flaky".to_string(),
             channel_type: "test".to_string(),
-            channel: Arc::new(TestChannel {
+            channel: DynNotificationChannel::new_arc(TestChannel {
                 channel_type: "flaky",
                 fail_for_attempts: 1,
                 attempts: flaky_attempts.clone(),
@@ -2147,27 +2171,27 @@ mod tests {
         }
     }
 
+    #[derive(Clone)]
     struct MockNotificationRepo {
-        channels: tokio::sync::Mutex<Vec<NotificationChannelDbModel>>,
-        subscriptions: tokio::sync::Mutex<HashMap<String, Vec<String>>>,
-        subscribe_calls: tokio::sync::Mutex<Vec<(String, String)>>,
-        unsubscribe_calls: tokio::sync::Mutex<Vec<(String, String)>>,
-        dead_letters: tokio::sync::Mutex<Vec<NotificationDeadLetterDbModel>>,
+        channels: Arc<tokio::sync::Mutex<Vec<NotificationChannelDbModel>>>,
+        subscriptions: Arc<tokio::sync::Mutex<HashMap<String, Vec<String>>>>,
+        subscribe_calls: Arc<tokio::sync::Mutex<Vec<(String, String)>>>,
+        unsubscribe_calls: Arc<tokio::sync::Mutex<Vec<(String, String)>>>,
+        dead_letters: Arc<tokio::sync::Mutex<Vec<NotificationDeadLetterDbModel>>>,
     }
 
     impl MockNotificationRepo {
         fn new() -> Self {
             Self {
-                channels: tokio::sync::Mutex::new(Vec::new()),
-                subscriptions: tokio::sync::Mutex::new(HashMap::new()),
-                subscribe_calls: tokio::sync::Mutex::new(Vec::new()),
-                unsubscribe_calls: tokio::sync::Mutex::new(Vec::new()),
-                dead_letters: tokio::sync::Mutex::new(Vec::new()),
+                channels: Arc::new(tokio::sync::Mutex::new(Vec::new())),
+                subscriptions: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
+                subscribe_calls: Arc::new(tokio::sync::Mutex::new(Vec::new())),
+                unsubscribe_calls: Arc::new(tokio::sync::Mutex::new(Vec::new())),
+                dead_letters: Arc::new(tokio::sync::Mutex::new(Vec::new())),
             }
         }
     }
 
-    #[async_trait::async_trait]
     impl NotificationRepository for MockNotificationRepo {
         async fn get_channel(&self, _id: &str) -> Result<NotificationChannelDbModel> {
             unimplemented!()
@@ -2281,9 +2305,11 @@ mod tests {
 
     #[tokio::test]
     async fn db_subscriptions_filter_delivery() {
-        let repo = Arc::new(MockNotificationRepo::new());
-        let service =
-            NotificationService::with_repository(NotificationServiceConfig::default(), repo);
+        let repo = MockNotificationRepo::new();
+        let service = NotificationService::with_repository(
+            NotificationServiceConfig::default(),
+            DynNotificationRepository::new_arc(repo.clone()),
+        );
 
         let subscribed_attempts = Arc::new(std::sync::atomic::AtomicU32::new(0));
         let unsubscribed_attempts = Arc::new(std::sync::atomic::AtomicU32::new(0));
@@ -2293,7 +2319,7 @@ mod tests {
             db_channel_id: Some("channel-1".to_string()),
             display_name: "Channel 1".to_string(),
             channel_type: "WEBHOOK".to_string(),
-            channel: Arc::new(TestChannel {
+            channel: DynNotificationChannel::new_arc(TestChannel {
                 channel_type: "subscribed",
                 fail_for_attempts: 0,
                 attempts: subscribed_attempts.clone(),
@@ -2312,7 +2338,7 @@ mod tests {
             db_channel_id: Some("channel-2".to_string()),
             display_name: "Channel 2".to_string(),
             channel_type: "WEBHOOK".to_string(),
-            channel: Arc::new(TestChannel {
+            channel: DynNotificationChannel::new_arc(TestChannel {
                 channel_type: "unsubscribed",
                 fail_for_attempts: 0,
                 attempts: unsubscribed_attempts.clone(),
@@ -2346,14 +2372,17 @@ mod tests {
 
     #[tokio::test]
     async fn dead_letters_persisted_to_repository() {
-        let repo = Arc::new(MockNotificationRepo::new());
+        let repo = MockNotificationRepo::new();
         let config = NotificationServiceConfig {
             max_retries: 1,
             initial_retry_delay_ms: 1,
             max_retry_delay_ms: 5,
             ..Default::default()
         };
-        let service = NotificationService::with_repository(config, repo.clone());
+        let service = NotificationService::with_repository(
+            config,
+            DynNotificationRepository::new_arc(repo.clone()),
+        );
 
         let attempts = Arc::new(std::sync::atomic::AtomicU32::new(0));
         let fail_channel = Arc::new(RuntimeChannel {
@@ -2361,7 +2390,7 @@ mod tests {
             db_channel_id: Some("channel-1".to_string()),
             display_name: "Channel 1".to_string(),
             channel_type: "WEBHOOK".to_string(),
-            channel: Arc::new(TestChannel {
+            channel: DynNotificationChannel::new_arc(TestChannel {
                 channel_type: "fail",
                 fail_for_attempts: 1,
                 attempts: attempts.clone(),
@@ -2399,10 +2428,10 @@ mod tests {
 
     #[tokio::test]
     async fn reload_from_db_normalizes_and_migrates_subscription_names() {
-        let repo = Arc::new(MockNotificationRepo::new());
+        let repo = MockNotificationRepo::new();
         let service = NotificationService::with_repository(
             NotificationServiceConfig::default(),
-            repo.clone(),
+            DynNotificationRepository::new_arc(repo.clone()),
         );
 
         let db_channel = NotificationChannelDbModel {

--- a/rust-srec/src/pipeline/dag_scheduler.rs
+++ b/rust-srec/src/pipeline/dag_scheduler.rs
@@ -14,7 +14,9 @@ use crate::database::models::{
     DagExecutionDbModel, DagExecutionStatus, DagPipelineDefinition, DagStepExecutionDbModel,
     DagStepStatus, JobDbModel, PipelineStep, ReadyStep,
 };
-use crate::database::repositories::{DagRepository, JobRepository};
+use crate::database::repositories::{
+    DagRepository, DynDagRepository, DynJobRepository, JobRepository,
+};
 use crate::pipeline::{Job, JobQueue, JobStatus};
 use crate::{Error, Result};
 
@@ -64,16 +66,16 @@ pub struct DagCreationResult {
 /// DAG Scheduler for orchestrating DAG pipeline execution.
 pub struct DagScheduler {
     job_queue: Arc<JobQueue>,
-    dag_repository: Arc<dyn DagRepository>,
-    job_repository: Arc<dyn JobRepository>,
+    dag_repository: Arc<DynDagRepository<'static>>,
+    job_repository: Arc<DynJobRepository<'static>>,
 }
 
 impl DagScheduler {
     /// Create a new DagScheduler.
     pub fn new(
         job_queue: Arc<JobQueue>,
-        dag_repository: Arc<dyn DagRepository>,
-        job_repository: Arc<dyn JobRepository>,
+        dag_repository: Arc<DynDagRepository<'static>>,
+        job_repository: Arc<DynJobRepository<'static>>,
     ) -> Self {
         Self {
             job_queue,
@@ -880,7 +882,6 @@ mod tests {
 
     struct NoopJobRepository;
 
-    #[async_trait::async_trait]
     impl JobRepository for NoopJobRepository {
         async fn create_job(&self, _job: &crate::database::models::JobDbModel) -> Result<()> {
             unimplemented!("not needed for these tests")
@@ -1109,14 +1110,14 @@ mod tests {
     #[tokio::test]
     async fn test_cancel_dag_marks_parent_cancelled() {
         let pool = setup_test_pool().await;
-        let dag_repo = Arc::new(crate::database::repositories::dag::SqlxDagRepository::new(
+        let dag_repo = DynDagRepository::new_arc(crate::database::repositories::dag::SqlxDagRepository::new(
             pool.clone(),
             pool,
         ));
         let scheduler = DagScheduler::new(
             Arc::new(JobQueue::new()),
             dag_repo.clone(),
-            Arc::new(NoopJobRepository),
+            DynJobRepository::new_arc(NoopJobRepository),
         );
 
         let dag_def = DagPipelineDefinition::new(

--- a/rust-srec/src/pipeline/job_queue.rs
+++ b/rust-srec/src/pipeline/job_queue.rs
@@ -20,7 +20,10 @@ use crate::database::models::{
     JobDbModel, JobExecutionLogDbModel, JobFilters, JobStatus as DbJobStatus, MediaFileType,
     MediaOutputDbModel, Pagination, TitleEntry,
 };
-use crate::database::repositories::{JobRepository, SessionRepository, StreamerRepository};
+use crate::database::repositories::{
+    DynJobRepository, DynSessionRepository, DynStreamerRepository, JobRepository,
+    SessionRepository, StreamerRepository,
+};
 use crate::pipeline::processors::utils as processor_utils;
 use crate::utils::json::{self, JsonContext};
 use crate::{Error, Result};
@@ -531,11 +534,11 @@ pub struct JobQueue {
     /// Notify when new jobs are added.
     notify: Arc<Notify>,
     /// Job repository for database persistence.
-    job_repository: Option<Arc<dyn JobRepository>>,
+    job_repository: Option<Arc<DynJobRepository<'static>>>,
     /// Session repository for persisting media outputs (e.g., thumbnails).
-    session_repo: std::sync::OnceLock<Arc<dyn SessionRepository>>,
+    session_repo: std::sync::OnceLock<Arc<DynSessionRepository<'static>>>,
     /// Streamer repository for looking up streamer metadata (e.g., name).
-    streamer_repo: std::sync::OnceLock<Arc<dyn StreamerRepository>>,
+    streamer_repo: std::sync::OnceLock<Arc<DynStreamerRepository<'static>>>,
     /// In-memory cache of jobs (for quick lookups).
     jobs_cache: DashMap<String, Job>,
     /// Cancellation tokens for processing jobs.
@@ -582,7 +585,7 @@ impl JobQueue {
     }
 
     /// Create a new job queue with a job repository for database persistence.
-    pub fn with_repository(config: JobQueueConfig, repository: Arc<dyn JobRepository>) -> Self {
+    pub fn with_repository(config: JobQueueConfig, repository: Arc<DynJobRepository<'static>>) -> Self {
         let (progress_tx, progress_rx) = tokio::sync::mpsc::channel::<JobProgressUpdate>(1024);
         let cancellation_tokens: DashMap<String, CancellationToken> = DashMap::new();
         let progress_cache: DashMap<String, JobProgressSnapshot> = DashMap::new();
@@ -609,19 +612,19 @@ impl JobQueue {
     }
 
     /// Set the job repository for database persistence.
-    pub fn set_repository(&mut self, repository: Arc<dyn JobRepository>) {
+    pub fn set_repository(&mut self, repository: Arc<DynJobRepository<'static>>) {
         self.job_repository = Some(repository);
     }
 
     /// Set the session repository for persisting media outputs (e.g., thumbnails).
     /// This can only be called once.
-    pub fn set_session_repo(&self, repo: Arc<dyn SessionRepository>) {
+    pub fn set_session_repo(&self, repo: Arc<DynSessionRepository<'static>>) {
         let _ = self.session_repo.set(repo);
     }
 
     /// Set the streamer repository for looking up streamer metadata.
     /// This can only be called once.
-    pub fn set_streamer_repo(&self, repo: Arc<dyn StreamerRepository>) {
+    pub fn set_streamer_repo(&self, repo: Arc<DynStreamerRepository<'static>>) {
         let _ = self.streamer_repo.set(repo);
     }
 
@@ -2085,7 +2088,7 @@ impl JobQueue {
 }
 
 fn spawn_progress_aggregator(
-    repo: Option<Arc<dyn JobRepository>>,
+    repo: Option<Arc<DynJobRepository<'static>>>,
     mut rx: tokio::sync::mpsc::Receiver<JobProgressUpdate>,
     cancellation_tokens: DashMap<String, CancellationToken>,
     progress_cache: DashMap<String, JobProgressSnapshot>,

--- a/rust-srec/src/pipeline/manager.rs
+++ b/rust-srec/src/pipeline/manager.rs
@@ -37,7 +37,8 @@ use crate::database::models::{
 use crate::database::repositories::config::{ConfigRepository, SqlxConfigRepository};
 use crate::database::repositories::streamer::{SqlxStreamerRepository, StreamerRepository};
 use crate::database::repositories::{
-    DagRepository, JobPresetRepository, JobRepository, PipelinePresetRepository, SessionRepository,
+    DagRepository, DynJobPresetRepository, DynPipelinePresetRepository, JobPresetRepository,
+    JobRepository, PipelinePresetRepository, SessionRepository,
 };
 use crate::downloader::DownloadManagerEvent;
 use crate::utils::filename::sanitize_filename;
@@ -233,9 +234,9 @@ pub struct PipelineManager<
     /// Job purge service for automatic cleanup of old jobs.
     purge_service: Option<Arc<JobPurgeService>>,
     /// Job preset repository for resolving named pipeline steps.
-    preset_repo: Option<Arc<dyn JobPresetRepository>>,
+    preset_repo: Option<Arc<DynJobPresetRepository<'static>>>,
     /// Pipeline preset repository for resolving workflow steps.
-    pipeline_preset_repo: Option<Arc<dyn PipelinePresetRepository>>,
+    pipeline_preset_repo: Option<Arc<DynPipelinePresetRepository<'static>>>,
     /// Config service for resolving pipeline rules.
     config_service: Option<Arc<ConfigService<CR, SR>>>,
     /// Last observed queue depth status (edge-trigger warnings).
@@ -482,7 +483,10 @@ where
     }
 
     /// Set the job preset repository.
-    pub fn with_preset_repository(mut self, preset_repo: Arc<dyn JobPresetRepository>) -> Self {
+    pub fn with_preset_repository(
+        mut self,
+        preset_repo: Arc<DynJobPresetRepository<'static>>,
+    ) -> Self {
         self.preset_repo = Some(preset_repo);
         self
     }
@@ -490,7 +494,7 @@ where
     /// Set the pipeline preset repository (for workflow expansion).
     pub fn with_pipeline_preset_repository(
         mut self,
-        pipeline_preset_repo: Arc<dyn PipelinePresetRepository>,
+        pipeline_preset_repo: Arc<DynPipelinePresetRepository<'static>>,
     ) -> Self {
         self.pipeline_preset_repo = Some(pipeline_preset_repo);
         self

--- a/rust-srec/src/pipeline/manager.rs
+++ b/rust-srec/src/pipeline/manager.rs
@@ -19,8 +19,9 @@ use super::dag_scheduler::{
 use super::job_queue::{Job, JobLogEntry, JobQueue, JobQueueConfig, JobStatus, QueueDepthStatus};
 use super::processors::{
     AssBurnInProcessor, AudioExtractProcessor, CompressionProcessor, CopyMoveProcessor,
-    DanmakuFactoryProcessor, DeleteProcessor, ExecuteCommandProcessor, MetadataProcessor,
-    Processor, RcloneProcessor, RemuxProcessor, TdlUploadProcessor, ThumbnailProcessor,
+    DanmakuFactoryProcessor, DeleteProcessor, DynProcessor, ExecuteCommandProcessor,
+    MetadataProcessor, Processor, RcloneProcessor, RemuxProcessor, TdlUploadProcessor,
+    ThumbnailProcessor,
 };
 use super::progress::JobProgressSnapshot;
 use super::purge::{JobPurgeService, PurgeConfig};
@@ -219,7 +220,7 @@ pub struct PipelineManager<
     /// IO worker pool.
     io_pool: WorkerPool,
     /// Processors.
-    processors: Vec<Arc<dyn Processor>>,
+    processors: Vec<Arc<DynProcessor<'static>>>,
     /// Event broadcaster.
     event_tx: broadcast::Sender<PipelineEvent>,
     /// Session repository for persistence (optional).
@@ -327,19 +328,19 @@ where
         let execute_timeout_secs = config.execute_timeout_secs;
 
         // Create default processors
-        let processors: Vec<Arc<dyn Processor>> = vec![
-            Arc::new(RemuxProcessor::new()),
-            Arc::new(DanmakuFactoryProcessor::new()),
-            Arc::new(AssBurnInProcessor::new()),
-            Arc::new(RcloneProcessor::new()),
-            Arc::new(TdlUploadProcessor::new()),
-            Arc::new(ExecuteCommandProcessor::new().with_timeout(execute_timeout_secs)),
-            Arc::new(ThumbnailProcessor::new()),
-            Arc::new(CopyMoveProcessor::new()),
-            Arc::new(AudioExtractProcessor::new()),
-            Arc::new(CompressionProcessor::new()),
-            Arc::new(MetadataProcessor::new()),
-            Arc::new(DeleteProcessor::new()),
+        let processors: Vec<Arc<DynProcessor<'static>>> = vec![
+            DynProcessor::new_arc(RemuxProcessor::new()),
+            DynProcessor::new_arc(DanmakuFactoryProcessor::new()),
+            DynProcessor::new_arc(AssBurnInProcessor::new()),
+            DynProcessor::new_arc(RcloneProcessor::new()),
+            DynProcessor::new_arc(TdlUploadProcessor::new()),
+            DynProcessor::new_arc(ExecuteCommandProcessor::new().with_timeout(execute_timeout_secs)),
+            DynProcessor::new_arc(ThumbnailProcessor::new()),
+            DynProcessor::new_arc(CopyMoveProcessor::new()),
+            DynProcessor::new_arc(AudioExtractProcessor::new()),
+            DynProcessor::new_arc(CompressionProcessor::new()),
+            DynProcessor::new_arc(MetadataProcessor::new()),
+            DynProcessor::new_arc(DeleteProcessor::new()),
         ];
 
         // Create throttle controller if enabled
@@ -404,19 +405,19 @@ where
         };
 
         // Create default processors
-        let processors: Vec<Arc<dyn Processor>> = vec![
-            Arc::new(RemuxProcessor::new()),
-            Arc::new(DanmakuFactoryProcessor::new()),
-            Arc::new(AssBurnInProcessor::new()),
-            Arc::new(RcloneProcessor::new()),
-            Arc::new(TdlUploadProcessor::new()),
-            Arc::new(ExecuteCommandProcessor::new().with_timeout(execute_timeout_secs)),
-            Arc::new(ThumbnailProcessor::new()),
-            Arc::new(CopyMoveProcessor::new()),
-            Arc::new(AudioExtractProcessor::new()),
-            Arc::new(CompressionProcessor::new()),
-            Arc::new(MetadataProcessor::new()),
-            Arc::new(DeleteProcessor::new()),
+        let processors: Vec<Arc<DynProcessor<'static>>> = vec![
+            DynProcessor::new_arc(RemuxProcessor::new()),
+            DynProcessor::new_arc(DanmakuFactoryProcessor::new()),
+            DynProcessor::new_arc(AssBurnInProcessor::new()),
+            DynProcessor::new_arc(RcloneProcessor::new()),
+            DynProcessor::new_arc(TdlUploadProcessor::new()),
+            DynProcessor::new_arc(ExecuteCommandProcessor::new().with_timeout(execute_timeout_secs)),
+            DynProcessor::new_arc(ThumbnailProcessor::new()),
+            DynProcessor::new_arc(CopyMoveProcessor::new()),
+            DynProcessor::new_arc(AudioExtractProcessor::new()),
+            DynProcessor::new_arc(CompressionProcessor::new()),
+            DynProcessor::new_arc(MetadataProcessor::new()),
+            DynProcessor::new_arc(DeleteProcessor::new()),
         ];
 
         // Create throttle controller if enabled
@@ -578,7 +579,7 @@ where
         info!("Starting Pipeline Manager");
 
         // Get CPU and IO processors
-        let cpu_processors: Vec<Arc<dyn Processor>> = self
+        let cpu_processors: Vec<Arc<DynProcessor<'static>>> = self
             .processors
             .iter()
             .filter(|p| p.processor_type() == super::processors::ProcessorType::Cpu)
@@ -590,7 +591,7 @@ where
             cpu_processors.iter().map(|p| p.name()).collect::<Vec<_>>()
         );
 
-        let io_processors: Vec<Arc<dyn Processor>> = self
+        let io_processors: Vec<Arc<DynProcessor<'static>>> = self
             .processors
             .iter()
             .filter(|p| p.processor_type() == super::processors::ProcessorType::Io)

--- a/rust-srec/src/pipeline/manager.rs
+++ b/rust-srec/src/pipeline/manager.rs
@@ -37,8 +37,9 @@ use crate::database::models::{
 use crate::database::repositories::config::{ConfigRepository, SqlxConfigRepository};
 use crate::database::repositories::streamer::{SqlxStreamerRepository, StreamerRepository};
 use crate::database::repositories::{
-    DagRepository, DynJobPresetRepository, DynPipelinePresetRepository, JobPresetRepository,
-    JobRepository, PipelinePresetRepository, SessionRepository,
+    DagRepository, DynDagRepository, DynJobPresetRepository, DynJobRepository,
+    DynPipelinePresetRepository, DynSessionRepository, DynStreamerRepository, JobPresetRepository,
+    PipelinePresetRepository, SessionRepository,
 };
 use crate::downloader::DownloadManagerEvent;
 use crate::utils::filename::sanitize_filename;
@@ -222,7 +223,7 @@ pub struct PipelineManager<
     /// Event broadcaster.
     event_tx: broadcast::Sender<PipelineEvent>,
     /// Session repository for persistence (optional).
-    session_repo: Option<Arc<dyn SessionRepository>>,
+    session_repo: Option<Arc<DynSessionRepository<'static>>>,
     /// Streamer repository for metadata lookup (optional).
     streamer_repo: Option<Arc<SR>>,
     /// Cancellation token.
@@ -260,9 +261,9 @@ pub struct PipelineManager<
     handled_dag_completions: DashMap<String, std::time::Instant>,
 
     /// DAG repository for DAG pipeline persistence.
-    dag_repository: Option<Arc<dyn DagRepository>>,
+    dag_repository: Option<Arc<DynDagRepository<'static>>>,
     /// Job repository reference (needed for DAG scheduler).
-    job_repository: Option<Arc<dyn JobRepository>>,
+    job_repository: Option<Arc<DynJobRepository<'static>>>,
     /// DAG scheduler for orchestrating DAG pipeline execution.
     dag_scheduler: Option<Arc<DagScheduler>>,
 }
@@ -382,7 +383,7 @@ where
     /// This enables database persistence and job recovery on startup.
     pub fn with_repository(
         config: PipelineManagerConfig,
-        job_repository: Arc<dyn JobRepository>,
+        job_repository: Arc<DynJobRepository<'static>>,
     ) -> Self {
         let (event_tx, _) = broadcast::channel(256);
         let job_queue = Arc::new(JobQueue::with_repository(
@@ -458,7 +459,7 @@ where
     /// Set the session repository for persistence.
     pub fn with_session_repository(
         mut self,
-        session_repository: Arc<dyn SessionRepository>,
+        session_repository: Arc<DynSessionRepository<'static>>,
     ) -> Self {
         self.session_repo = Some(session_repository.clone());
         // Also set session repo on job queue
@@ -467,10 +468,13 @@ where
     }
 
     /// Set the streamer repository for metadata lookup.
-    pub fn with_streamer_repository(mut self, streamer_repository: Arc<SR>) -> Self {
+    pub fn with_streamer_repository(mut self, streamer_repository: Arc<SR>) -> Self
+    where
+        SR: Clone,
+    {
         // Also set streamer repo on job queue for metadata resolution during dequeue
         self.job_queue
-            .set_streamer_repo(streamer_repository.clone() as Arc<dyn StreamerRepository>);
+            .set_streamer_repo(DynStreamerRepository::new_arc((*streamer_repository).clone()));
         self.streamer_repo = Some(streamer_repository);
         self
     }
@@ -508,7 +512,10 @@ where
 
     /// Set the DAG repository for DAG pipeline persistence.
     /// This also creates the DAG scheduler if job_repository is already set.
-    pub fn with_dag_repository(mut self, dag_repository: Arc<dyn DagRepository>) -> Self {
+    pub fn with_dag_repository(
+        mut self,
+        dag_repository: Arc<DynDagRepository<'static>>,
+    ) -> Self {
         self.dag_repository = Some(dag_repository.clone());
 
         // Create DAG scheduler if we have both repositories
@@ -3121,8 +3128,9 @@ mod tests {
         JobExecutionLogDbModel, LiveSessionDbModel, OutputFilters, PipelinePreset, SessionFilters,
         SessionSegmentDbModel,
     };
-    use crate::database::repositories::{PipelinePresetFilters, PipelinePresetRepository};
-    use async_trait::async_trait;
+    use crate::database::repositories::{
+        JobRepository, PipelinePresetFilters, PipelinePresetRepository,
+    };
     use std::collections::HashMap;
     use std::sync::Mutex;
 
@@ -3138,7 +3146,6 @@ mod tests {
         }
     }
 
-    #[async_trait]
     impl SessionRepository for TestSessionRepository {
         async fn get_session(&self, id: &str) -> Result<LiveSessionDbModel> {
             Ok(LiveSessionDbModel {
@@ -3277,14 +3284,15 @@ mod tests {
         }
     }
 
+    #[derive(Clone)]
     struct TestDagRepository {
-        dags: Mutex<HashMap<String, DagExecutionDbModel>>,
+        dags: Arc<Mutex<HashMap<String, DagExecutionDbModel>>>,
     }
 
     impl TestDagRepository {
         fn new() -> Self {
             Self {
-                dags: Mutex::new(HashMap::new()),
+                dags: Arc::new(Mutex::new(HashMap::new())),
             }
         }
 
@@ -3315,7 +3323,6 @@ mod tests {
         }
     }
 
-    #[async_trait]
     impl crate::database::repositories::JobRepository for TestJobRepository {
         async fn get_job(&self, id: &str) -> Result<JobDbModel> {
             self.jobs
@@ -3511,16 +3518,17 @@ mod tests {
 
     use std::sync::atomic::{AtomicUsize, Ordering};
 
+    #[derive(Clone)]
     struct TestDagRepositoryForRetry {
-        dags: Mutex<HashMap<String, DagExecutionDbModel>>,
-        reset_calls: AtomicUsize,
+        dags: Arc<Mutex<HashMap<String, DagExecutionDbModel>>>,
+        reset_calls: Arc<AtomicUsize>,
     }
 
     impl TestDagRepositoryForRetry {
         fn new() -> Self {
             Self {
-                dags: Mutex::new(HashMap::new()),
-                reset_calls: AtomicUsize::new(0),
+                dags: Arc::new(Mutex::new(HashMap::new())),
+                reset_calls: Arc::new(AtomicUsize::new(0)),
             }
         }
 
@@ -3536,7 +3544,6 @@ mod tests {
         }
     }
 
-    #[async_trait]
     impl DagRepository for TestDagRepositoryForRetry {
         async fn create_dag(&self, _dag: &DagExecutionDbModel) -> Result<()> {
             unimplemented!("not needed for these tests")
@@ -3704,7 +3711,6 @@ mod tests {
         }
     }
 
-    #[async_trait]
     impl DagRepository for TestDagRepository {
         async fn create_dag(&self, _dag: &DagExecutionDbModel) -> Result<()> {
             unimplemented!("not needed for these tests")
@@ -3887,8 +3893,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_retry_job_resets_failed_dag_when_job_is_dag_step() {
-        let job_repo = Arc::new(TestJobRepository::new());
-        let dag_repo = Arc::new(TestDagRepositoryForRetry::new());
+        let job_repo = DynJobRepository::new_arc(TestJobRepository::new());
+        let dag_repo = TestDagRepositoryForRetry::new();
 
         let dag_def = crate::database::models::DagPipelineDefinition::new(
             "test",
@@ -3922,13 +3928,13 @@ mod tests {
         job.error = Some("boom".to_string());
         job.completed_at = Some(chrono::Utc::now().timestamp_millis());
         let job_id = job.id.clone();
-        job_repo.insert(job);
+        job_repo.create_job(&job).await.unwrap();
 
         let mut config = PipelineManagerConfig::default();
         config.purge.retention_days = 0;
 
         let manager: PipelineManager = PipelineManager::with_repository(config, job_repo)
-            .with_dag_repository(dag_repo.clone());
+            .with_dag_repository(DynDagRepository::new_arc(dag_repo.clone()));
 
         let retried = manager.retry_job(&job_id).await.unwrap();
         assert_eq!(
@@ -3943,8 +3949,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_retry_job_resets_cancelled_dag_when_job_is_dag_step() {
-        let job_repo = Arc::new(TestJobRepository::new());
-        let dag_repo = Arc::new(TestDagRepositoryForRetry::new());
+        let job_repo = DynJobRepository::new_arc(TestJobRepository::new());
+        let dag_repo = TestDagRepositoryForRetry::new();
 
         let dag_def = DagExecutionDbModel::new(
             &crate::database::models::DagPipelineDefinition::new(
@@ -3982,13 +3988,13 @@ mod tests {
         job.error = Some("cancelled".to_string());
         job.completed_at = Some(chrono::Utc::now().timestamp_millis());
         let job_id = job.id.clone();
-        job_repo.insert(job);
+        job_repo.create_job(&job).await.unwrap();
 
         let mut config = PipelineManagerConfig::default();
         config.purge.retention_days = 0;
 
         let manager: PipelineManager = PipelineManager::with_repository(config, job_repo)
-            .with_dag_repository(dag_repo.clone());
+            .with_dag_repository(DynDagRepository::new_arc(dag_repo.clone()));
 
         let retried = manager.retry_job(&job_id).await.unwrap();
         assert_eq!(
@@ -4017,7 +4023,6 @@ mod tests {
         preset: PipelinePreset,
     }
 
-    #[async_trait]
     impl PipelinePresetRepository for TestPipelinePresetRepository {
         async fn list_pipeline_presets(&self) -> Result<Vec<PipelinePreset>> {
             Ok(vec![])
@@ -4069,7 +4074,7 @@ mod tests {
                 ),
             ],
         );
-        let repo = Arc::new(TestPipelinePresetRepository {
+        let repo = DynPipelinePresetRepository::new_arc(TestPipelinePresetRepository {
             preset: PipelinePreset::new("wf", workflow_dag),
         });
 
@@ -4364,7 +4369,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_session_complete_waits_for_session_end_time() {
-        let session_repo = Arc::new(TestSessionRepository::new(None));
+        let session_repo = DynSessionRepository::new_arc(TestSessionRepository::new(None));
         let manager: PipelineManager = PipelineManager::new().with_session_repository(session_repo);
 
         let session_id = "session-1".to_string();
@@ -4411,7 +4416,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_session_complete_triggers_after_session_end_time() {
-        let session_repo = Arc::new(TestSessionRepository::new(Some(
+        let session_repo = DynSessionRepository::new_arc(TestSessionRepository::new(Some(
             chrono::Utc::now().timestamp_millis(),
         )));
         let manager: PipelineManager = PipelineManager::new().with_session_repository(session_repo);
@@ -4451,7 +4456,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_session_complete_waits_for_paired_dags() {
-        let session_repo = Arc::new(TestSessionRepository::new(Some(
+        let session_repo = DynSessionRepository::new_arc(TestSessionRepository::new(Some(
             chrono::Utc::now().timestamp_millis(),
         )));
         let manager: PipelineManager = PipelineManager::new().with_session_repository(session_repo);
@@ -4504,13 +4509,13 @@ mod tests {
 
     #[tokio::test]
     async fn test_session_complete_recovers_segment_dag_completion_without_context() {
-        let session_repo = Arc::new(TestSessionRepository::new(Some(
+        let session_repo = DynSessionRepository::new_arc(TestSessionRepository::new(Some(
             chrono::Utc::now().timestamp_millis(),
         )));
-        let dag_repo = Arc::new(TestDagRepository::new());
+        let dag_repo = TestDagRepository::new();
         let manager: PipelineManager = PipelineManager::new()
             .with_session_repository(session_repo)
-            .with_dag_repository(dag_repo.clone());
+            .with_dag_repository(DynDagRepository::new_arc(dag_repo.clone()));
 
         let session_id = "session-1".to_string();
         let streamer_id = "streamer-1".to_string();
@@ -4566,13 +4571,13 @@ mod tests {
 
     #[tokio::test]
     async fn test_session_complete_recovers_paired_dag_completion_without_context() {
-        let session_repo = Arc::new(TestSessionRepository::new(Some(
+        let session_repo = DynSessionRepository::new_arc(TestSessionRepository::new(Some(
             chrono::Utc::now().timestamp_millis(),
         )));
-        let dag_repo = Arc::new(TestDagRepository::new());
+        let dag_repo = TestDagRepository::new();
         let manager: PipelineManager = PipelineManager::new()
             .with_session_repository(session_repo)
-            .with_dag_repository(dag_repo.clone());
+            .with_dag_repository(DynDagRepository::new_arc(dag_repo.clone()));
 
         let session_id = "session-1".to_string();
         let streamer_id = "streamer-1".to_string();
@@ -4634,8 +4639,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_paired_segment_recovers_segment_dag_completion_without_context() {
-        let dag_repo = Arc::new(TestDagRepository::new());
-        let manager: PipelineManager = PipelineManager::new().with_dag_repository(dag_repo.clone());
+        let dag_repo = TestDagRepository::new();
+        let manager: PipelineManager = PipelineManager::new()
+            .with_dag_repository(DynDagRepository::new_arc(dag_repo.clone()));
 
         let session_id = "session-1".to_string();
         let streamer_id = "streamer-1".to_string();

--- a/rust-srec/src/pipeline/processors/ass_burnin.rs
+++ b/rust-srec/src/pipeline/processors/ass_burnin.rs
@@ -8,7 +8,6 @@
 //!
 //! This processor is manifest-aware (prefers `video_inputs` + `danmu_inputs`) and batch-safe.
 
-use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
@@ -318,7 +317,6 @@ impl Default for AssBurnInProcessor {
     }
 }
 
-#[async_trait]
 impl Processor for AssBurnInProcessor {
     fn processor_type(&self) -> ProcessorType {
         ProcessorType::Cpu

--- a/rust-srec/src/pipeline/processors/audio_extract.rs
+++ b/rust-srec/src/pipeline/processors/audio_extract.rs
@@ -5,7 +5,6 @@
 //! stream copy without re-encoding.
 //!
 
-use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use std::path::Path;
 use tokio::process::Command;
@@ -474,7 +473,6 @@ impl Default for AudioExtractProcessor {
     }
 }
 
-#[async_trait]
 impl Processor for AudioExtractProcessor {
     fn processor_type(&self) -> ProcessorType {
         ProcessorType::Cpu

--- a/rust-srec/src/pipeline/processors/compression.rs
+++ b/rust-srec/src/pipeline/processors/compression.rs
@@ -4,7 +4,6 @@
 //! supporting multiple input files in a single archive.
 //!
 
-use async_trait::async_trait;
 use flate2::Compression;
 use flate2::write::GzEncoder;
 use serde::{Deserialize, Serialize};
@@ -527,7 +526,6 @@ impl Default for CompressionProcessor {
     }
 }
 
-#[async_trait]
 impl Processor for CompressionProcessor {
     fn processor_type(&self) -> ProcessorType {
         ProcessorType::Cpu

--- a/rust-srec/src/pipeline/processors/copy_move.rs
+++ b/rust-srec/src/pipeline/processors/copy_move.rs
@@ -11,7 +11,6 @@
 //! - `{platform}` - Platform name
 //! - Time placeholders: `%Y`, `%m`, `%d`, `%H`, `%M`, `%S`, etc.
 
-use async_trait::async_trait;
 use regex::RegexSet;
 use serde::{Deserialize, Serialize};
 use std::io::ErrorKind;
@@ -133,7 +132,6 @@ impl Default for CopyMoveProcessor {
     }
 }
 
-#[async_trait]
 impl Processor for CopyMoveProcessor {
     fn processor_type(&self) -> ProcessorType {
         ProcessorType::Io

--- a/rust-srec/src/pipeline/processors/danmaku_factory.rs
+++ b/rust-srec/src/pipeline/processors/danmaku_factory.rs
@@ -6,7 +6,6 @@
 //! - Runs DanmakuFactory to generate `.ass` files
 //! - Returns outputs that include the original inputs plus generated `.ass` paths for downstream steps
 
-use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
@@ -186,7 +185,6 @@ impl Default for DanmakuFactoryProcessor {
     }
 }
 
-#[async_trait]
 impl Processor for DanmakuFactoryProcessor {
     fn processor_type(&self) -> ProcessorType {
         ProcessorType::Cpu

--- a/rust-srec/src/pipeline/processors/delete.rs
+++ b/rust-srec/src/pipeline/processors/delete.rs
@@ -3,7 +3,6 @@
 //! This processor handles file deletion with retry logic for locked files.
 //!
 
-use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use std::path::Path;
 use tokio::fs;
@@ -137,7 +136,6 @@ impl Default for DeleteProcessor {
     }
 }
 
-#[async_trait]
 impl Processor for DeleteProcessor {
     fn processor_type(&self) -> ProcessorType {
         ProcessorType::Io

--- a/rust-srec/src/pipeline/processors/execute.rs
+++ b/rust-srec/src/pipeline/processors/execute.rs
@@ -1,6 +1,5 @@
 //! Execute command processor for running arbitrary shell commands.
 
-use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 use std::path::Path;
@@ -200,7 +199,6 @@ impl Default for ExecuteCommandProcessor {
     }
 }
 
-#[async_trait]
 impl Processor for ExecuteCommandProcessor {
     fn processor_type(&self) -> ProcessorType {
         ProcessorType::Cpu
@@ -233,7 +231,7 @@ impl Processor for ExecuteCommandProcessor {
 
         let command = Self::substitute_variables(&config.command, input);
 
-        let _ = ctx.info(format!("Executing command: {}", command));
+        ctx.info(format!("Executing command: {}", command));
 
         // Take snapshot of output directory before execution (if scanning enabled)
         let before_snapshot: Option<HashSet<String>> = if let Some(ref dir) = config.scan_output_dir
@@ -250,7 +248,7 @@ impl Processor for ExecuteCommandProcessor {
                     crate::utils::fs::ensure_dir_all_with_op("creating output directory", dir_path)
                         .await
                 {
-                    let _ = ctx.warn(format!("Failed to create output directory {}: {}", dir, e));
+                    ctx.warn(format!("Failed to create output directory {}: {}", dir, e));
                 }
             }
 
@@ -296,7 +294,7 @@ impl Processor for ExecuteCommandProcessor {
             Ok(Ok(output)) => output,
             Ok(Err(e)) => return Err(e),
             Err(_) => {
-                let _ = ctx.error(format!("Command timed out after {}s", self.timeout_secs));
+                ctx.error(format!("Command timed out after {}s", self.timeout_secs));
                 // Child process cleanup depends on implementation details of utils::run_command_with_logs
                 // ideally that helper should handle cancellation/timeout cleanups if possible.
                 // For now, we return timeout error.
@@ -313,7 +311,7 @@ impl Processor for ExecuteCommandProcessor {
                 .map(|l| l.message.clone())
                 .unwrap_or_else(|| "Command failed".to_string());
 
-            let _ = ctx.error(format!(
+            ctx.error(format!(
                 "Command failed with status: {}",
                 command_output.status
             ));
@@ -326,7 +324,7 @@ impl Processor for ExecuteCommandProcessor {
 
         let duration = command_output.duration;
 
-        let _ = ctx.info(format!("Command completed in {:.2}s", duration));
+        ctx.info(format!("Command completed in {:.2}s", duration));
 
         // Get file sizes for metrics if paths exist
         let input_path = input.inputs.first().map(|s| s.as_str()).unwrap_or("");
@@ -368,7 +366,7 @@ impl Processor for ExecuteCommandProcessor {
                     input.inputs.clone()
                 }
             } else {
-                let _ = ctx.info(format!(
+                ctx.info(format!(
                     "Detected {} new files in output directory",
                     new_files.len()
                 ));

--- a/rust-srec/src/pipeline/processors/metadata.rs
+++ b/rust-srec/src/pipeline/processors/metadata.rs
@@ -4,7 +4,6 @@
 //! using ffmpeg. It supports common container formats like MP4, MKV, and FLV.
 //!
 
-use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::Path;
@@ -393,7 +392,6 @@ impl Default for MetadataProcessor {
     }
 }
 
-#[async_trait]
 impl Processor for MetadataProcessor {
     fn processor_type(&self) -> ProcessorType {
         ProcessorType::Cpu

--- a/rust-srec/src/pipeline/processors/mod.rs
+++ b/rust-srec/src/pipeline/processors/mod.rs
@@ -28,5 +28,6 @@ pub use remux::RemuxProcessor;
 pub use tdl::TdlUploadProcessor;
 pub use thumbnail::ThumbnailProcessor;
 pub use traits::{
-    JobLogSink, Processor, ProcessorContext, ProcessorInput, ProcessorOutput, ProcessorType,
+    DynProcessor, JobLogSink, Processor, ProcessorContext, ProcessorInput, ProcessorOutput,
+    ProcessorType,
 };

--- a/rust-srec/src/pipeline/processors/rclone.rs
+++ b/rust-srec/src/pipeline/processors/rclone.rs
@@ -1,6 +1,5 @@
 //! Rclone processor for cloud storage operations.
 
-use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 use tokio::io::AsyncWriteExt;
@@ -475,7 +474,6 @@ impl Default for RcloneProcessor {
     }
 }
 
-#[async_trait]
 impl Processor for RcloneProcessor {
     fn processor_type(&self) -> ProcessorType {
         ProcessorType::Io

--- a/rust-srec/src/pipeline/processors/remux.rs
+++ b/rust-srec/src/pipeline/processors/remux.rs
@@ -1,6 +1,5 @@
 //! Remux/transcode processor for converting video formats.
 
-use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use std::path::Path;
 use tokio::process::Command;
@@ -719,7 +718,6 @@ impl Default for RemuxProcessor {
     }
 }
 
-#[async_trait]
 impl Processor for RemuxProcessor {
     fn processor_type(&self) -> ProcessorType {
         ProcessorType::Cpu
@@ -821,7 +819,7 @@ impl Processor for RemuxProcessor {
                 let input_path_string = make_absolute(input_path).await;
                 let input_path = input_path_string.as_str();
                 if let Err(e) = tokio::fs::remove_file(input_path).await {
-                    let _ = ctx.warn(format!("Failed to remove input file {}: {}", input_path, e));
+                    ctx.warn(format!("Failed to remove input file {}: {}", input_path, e));
                     logs.push(create_log_entry(
                         crate::pipeline::job_queue::LogLevel::Warn,
                         format!("Failed to remove input file {}: {}", input_path, e),

--- a/rust-srec/src/pipeline/processors/tdl.rs
+++ b/rust-srec/src/pipeline/processors/tdl.rs
@@ -1,6 +1,5 @@
 //! Telegram upload processor using the `tdl` CLI (https://github.com/iyear/tdl).
 
-use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use tokio::process::Command;
@@ -230,7 +229,6 @@ impl Default for TdlUploadProcessor {
     }
 }
 
-#[async_trait]
 impl Processor for TdlUploadProcessor {
     fn processor_type(&self) -> ProcessorType {
         ProcessorType::Io

--- a/rust-srec/src/pipeline/processors/thumbnail.rs
+++ b/rust-srec/src/pipeline/processors/thumbnail.rs
@@ -1,6 +1,5 @@
 //! Thumbnail processor for extracting video thumbnails.
 
-use async_trait::async_trait;
 use std::path::Path;
 use tokio::process::Command;
 use tracing::debug;
@@ -315,7 +314,6 @@ impl Default for ThumbnailProcessor {
     }
 }
 
-#[async_trait]
 impl Processor for ThumbnailProcessor {
     fn processor_type(&self) -> ProcessorType {
         ProcessorType::Cpu

--- a/rust-srec/src/pipeline/processors/traits.rs
+++ b/rust-srec/src/pipeline/processors/traits.rs
@@ -1,6 +1,5 @@
 //! Processor trait and related types.
 
-use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
@@ -223,7 +222,7 @@ pub struct ProcessorOutput {
 }
 
 /// Trait for pipeline processors.
-#[async_trait]
+#[dynosaur::dynosaur(pub DynProcessor = dyn(box) Processor)]
 pub trait Processor: Send + Sync {
     /// Get the processor type.
     fn processor_type(&self) -> ProcessorType;
@@ -243,11 +242,11 @@ pub trait Processor: Send + Sync {
     /// This method MUST be cancel-safe. The worker pool may cancel the future if the job times out
     /// or if the application is shutting down. Implementations should ensure that cancellation
     /// does not leave the system in an inconsistent state (e.g., partial files should be cleaned up).
-    async fn process(
+    fn process(
         &self,
         input: &ProcessorInput,
         ctx: &ProcessorContext,
-    ) -> Result<ProcessorOutput>;
+    ) -> impl std::future::Future<Output = Result<ProcessorOutput>> + Send;
 
     /// Get the processor name.
     fn name(&self) -> &'static str;

--- a/rust-srec/src/pipeline/purge.rs
+++ b/rust-srec/src/pipeline/purge.rs
@@ -12,7 +12,7 @@ use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, warn};
 
 use crate::Result;
-use crate::database::repositories::JobRepository;
+use crate::database::repositories::{DynJobRepository, JobRepository};
 
 /// Configuration for job purging.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -126,13 +126,13 @@ impl TimeWindow {
 /// Job Purge Service for automatic cleanup of old jobs.
 pub struct JobPurgeService {
     config: PurgeConfig,
-    job_repository: Arc<dyn JobRepository>,
+    job_repository: Arc<DynJobRepository<'static>>,
     time_window: Option<TimeWindow>,
 }
 
 impl JobPurgeService {
     /// Create a new JobPurgeService.
-    pub fn new(config: PurgeConfig, job_repository: Arc<dyn JobRepository>) -> Self {
+    pub fn new(config: PurgeConfig, job_repository: Arc<DynJobRepository<'static>>) -> Self {
         let time_window = config
             .time_window
             .as_ref()

--- a/rust-srec/src/pipeline/worker_pool.rs
+++ b/rust-srec/src/pipeline/worker_pool.rs
@@ -13,7 +13,7 @@ use super::dag_scheduler::{
     DagCompletionInfo, DagJobCompletedUpdate, DagJobFailedUpdate, DagScheduler,
 };
 use super::job_queue::{JobExecutionInfo, JobQueue, JobResult};
-use super::processors::{JobLogSink, Processor, ProcessorContext, ProcessorInput};
+use super::processors::{DynProcessor, JobLogSink, Processor, ProcessorContext, ProcessorInput};
 
 /// Type of worker.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -209,7 +209,7 @@ impl WorkerPool {
     }
 
     /// Start the worker pool.
-    pub fn start(&self, job_queue: Arc<JobQueue>, processors: Vec<Arc<dyn Processor>>) {
+    pub fn start(&self, job_queue: Arc<JobQueue>, processors: Vec<Arc<DynProcessor<'static>>>) {
         self.start_with_dag_scheduler(job_queue, processors, None, None);
     }
 
@@ -217,7 +217,7 @@ impl WorkerPool {
     pub fn start_with_dag_scheduler(
         &self,
         job_queue: Arc<JobQueue>,
-        processors: Vec<Arc<dyn Processor>>,
+        processors: Vec<Arc<DynProcessor<'static>>>,
         dag_scheduler: Option<Arc<DagScheduler>>,
         dag_notify_tx: Option<tokio::sync::mpsc::Sender<DagCompletionInfo>>,
     ) {
@@ -1057,7 +1057,6 @@ async fn cleanup_partial_outputs(outputs: &[String]) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use async_trait::async_trait;
     use std::time::Duration;
     use tempfile::TempDir;
 
@@ -1065,7 +1064,6 @@ mod tests {
 
     struct SleepProcessor;
 
-    #[async_trait]
     impl Processor for SleepProcessor {
         fn processor_type(&self) -> ProcessorType {
             ProcessorType::Cpu
@@ -1091,7 +1089,6 @@ mod tests {
 
     struct TimeoutPublishProcessor;
 
-    #[async_trait]
     impl Processor for TimeoutPublishProcessor {
         fn processor_type(&self) -> ProcessorType {
             ProcessorType::Cpu
@@ -1169,7 +1166,7 @@ mod tests {
             },
         );
 
-        pool.start(job_queue.clone(), vec![Arc::new(SleepProcessor)]);
+        pool.start(job_queue.clone(), vec![DynProcessor::new_arc(SleepProcessor)]);
 
         let job = Job::new(
             "sleep",
@@ -1229,7 +1226,7 @@ mod tests {
             },
         );
 
-        pool.start(job_queue.clone(), vec![Arc::new(TimeoutPublishProcessor)]);
+        pool.start(job_queue.clone(), vec![DynProcessor::new_arc(TimeoutPublishProcessor)]);
 
         let job = Job::new(
             "timeout-publish",

--- a/rust-srec/src/scheduler/actor/mod.rs
+++ b/rust-srec/src/scheduler/actor/mod.rs
@@ -36,7 +36,8 @@ pub use metrics::{
     create_scheduler_metrics,
 };
 pub use monitor_adapter::{
-    BatchChecker, CheckError, MonitorBatchChecker, MonitorStatusChecker, NoOpBatchChecker,
+    BatchChecker, CheckError, DynBatchChecker, MonitorBatchChecker, MonitorStatusChecker,
+    NoOpBatchChecker,
     NoOpStatusChecker, StatusChecker,
 };
 pub use platform_actor::PlatformActor;

--- a/rust-srec/src/scheduler/actor/mod.rs
+++ b/rust-srec/src/scheduler/actor/mod.rs
@@ -36,9 +36,8 @@ pub use metrics::{
     create_scheduler_metrics,
 };
 pub use monitor_adapter::{
-    BatchChecker, CheckError, DynBatchChecker, MonitorBatchChecker, MonitorStatusChecker,
-    NoOpBatchChecker,
-    NoOpStatusChecker, StatusChecker,
+    BatchChecker, CheckError, DynBatchChecker, DynStatusChecker, MonitorBatchChecker,
+    MonitorStatusChecker, NoOpBatchChecker, NoOpStatusChecker, StatusChecker,
 };
 pub use platform_actor::PlatformActor;
 pub use registry::{ActorRegistry, ActorTaskResult, RegistryError};

--- a/rust-srec/src/scheduler/actor/monitor_adapter.rs
+++ b/rust-srec/src/scheduler/actor/monitor_adapter.rs
@@ -73,16 +73,16 @@ pub trait StatusChecker: Send + Sync + 'static {
 /// This trait abstracts batch detection operations, allowing
 /// PlatformActors to perform batch checks without direct coupling
 /// to the BatchDetector implementation.
-#[async_trait]
-pub trait BatchChecker: Send + Sync + 'static {
+#[dynosaur::dynosaur(pub DynBatchChecker = dyn(box) BatchChecker)]
+pub trait BatchChecker: Send + Sync {
     /// Perform a batch status check for multiple streamers.
     ///
     /// Returns results for each streamer in the batch.
-    async fn batch_check(
+    fn batch_check(
         &self,
         platform_id: &str,
         streamers: Vec<StreamerMetadata>,
-    ) -> Result<Vec<BatchDetectionResult>, CheckError>;
+    ) -> impl std::future::Future<Output = Result<Vec<BatchDetectionResult>, CheckError>> + Send;
 }
 
 /// Error type for check operations.
@@ -220,7 +220,6 @@ where
     }
 }
 
-#[async_trait]
 impl<SR, FR, SSR, CR> BatchChecker for MonitorBatchChecker<SR, FR, SSR, CR>
 where
     SR: crate::database::repositories::StreamerRepository + Send + Sync + 'static,
@@ -400,7 +399,6 @@ impl StatusChecker for NoOpStatusChecker {
 #[derive(Clone)]
 pub struct NoOpBatchChecker;
 
-#[async_trait]
 impl BatchChecker for NoOpBatchChecker {
     async fn batch_check(
         &self,

--- a/rust-srec/src/scheduler/actor/monitor_adapter.rs
+++ b/rust-srec/src/scheduler/actor/monitor_adapter.rs
@@ -6,7 +6,6 @@
 
 use std::sync::Arc;
 
-use async_trait::async_trait;
 
 use crate::monitor::{FilterReason, LiveStatus, ProcessStatusResult};
 use crate::streamer::StreamerMetadata;
@@ -18,16 +17,16 @@ use super::messages::{BatchDetectionResult, CheckResult};
 /// This trait abstracts the status checking operation, allowing
 /// StreamerActors to perform checks without direct coupling to
 /// the StreamMonitor implementation.
-#[async_trait]
-pub trait StatusChecker: Send + Sync + 'static {
+#[dynosaur::dynosaur(pub DynStatusChecker = dyn(box) StatusChecker)]
+pub trait StatusChecker: Send + Sync {
     /// Check the status of a streamer.
     ///
     /// Returns a tuple of `(CheckResult, LiveStatus)` with the detected state.
     /// The `LiveStatus` can be used for `process_status()` if the caller decides to emit events.
-    async fn check_status(
+    fn check_status(
         &self,
         streamer: &StreamerMetadata,
-    ) -> Result<(CheckResult, LiveStatus), CheckError>;
+    ) -> impl std::future::Future<Output = Result<(CheckResult, LiveStatus), CheckError>> + Send;
 
     /// Process a detected status and return whether monitor side effects were applied.
     ///
@@ -39,18 +38,18 @@ pub trait StatusChecker: Send + Sync + 'static {
     /// The scheduler actor relies on this distinction to avoid entering a sticky runtime `Live`
     /// state when a LIVE observation was suppressed and no [`crate::monitor::MonitorEvent::StreamerLive`]
     /// event was emitted.
-    async fn process_status(
+    fn process_status(
         &self,
         streamer: &StreamerMetadata,
         status: LiveStatus,
-    ) -> Result<ProcessStatusResult, CheckError>;
+    ) -> impl std::future::Future<Output = Result<ProcessStatusResult, CheckError>> + Send;
 
     /// Handle an error during status checking.
-    async fn handle_error(
+    fn handle_error(
         &self,
         streamer: &StreamerMetadata,
         error: &str,
-    ) -> Result<(), CheckError>;
+    ) -> impl std::future::Future<Output = Result<(), CheckError>> + Send;
 
     /// Set the streamer to temporarily disabled due to an infrastructure-level
     /// block (engine circuit breaker, output-root write gate, etc.).
@@ -61,11 +60,11 @@ pub trait StatusChecker: Send + Sync + 'static {
     ///
     /// See [`crate::monitor::InfraBlockReason`] for the per-reason
     /// behavior (which state is written, whether `last_error` is overwritten).
-    async fn set_infra_blocked(
+    fn set_infra_blocked(
         &self,
         streamer: &StreamerMetadata,
         reason: crate::monitor::InfraBlockReason,
-    ) -> Result<(), CheckError>;
+    ) -> impl std::future::Future<Output = Result<(), CheckError>> + Send;
 }
 
 /// Trait for batch status checking.
@@ -145,7 +144,6 @@ where
     }
 }
 
-#[async_trait]
 impl<SR, FR, SSR, CR> StatusChecker for MonitorStatusChecker<SR, FR, SSR, CR>
 where
     SR: crate::database::repositories::StreamerRepository + Send + Sync + 'static,
@@ -354,7 +352,6 @@ fn convert_live_status_to_check_result(status: &LiveStatus) -> CheckResult {
 #[derive(Clone)]
 pub struct NoOpStatusChecker;
 
-#[async_trait]
 impl StatusChecker for NoOpStatusChecker {
     async fn check_status(
         &self,

--- a/rust-srec/src/scheduler/actor/platform_actor.rs
+++ b/rust-srec/src/scheduler/actor/platform_actor.rs
@@ -24,7 +24,7 @@ use super::messages::{
     StreamerMessage,
 };
 use super::metrics::ActorMetrics;
-use super::monitor_adapter::{BatchChecker, NoOpBatchChecker};
+use super::monitor_adapter::{BatchChecker, DynBatchChecker, NoOpBatchChecker};
 use super::streamer_actor::{ActorError, ActorOutcome, ActorResult};
 use crate::domain::StreamerState;
 use crate::streamer::StreamerMetadata;
@@ -72,7 +72,7 @@ pub struct PlatformActor {
     /// Metrics handle.
     metrics: ActorMetrics,
     /// Batch checker for performing actual batch checks.
-    batch_checker: std::sync::Arc<dyn BatchChecker>,
+    batch_checker: std::sync::Arc<DynBatchChecker<'static>>,
     /// Flag to indicate batch timer needs to be reset after config change.
     timer_needs_reset: bool,
 }
@@ -94,7 +94,7 @@ impl PlatformActor {
             platform_id,
             config,
             cancellation_token,
-            std::sync::Arc::new(NoOpBatchChecker),
+            DynBatchChecker::new_arc(NoOpBatchChecker),
         )
     }
 
@@ -112,7 +112,7 @@ impl PlatformActor {
             platform_id,
             config,
             cancellation_token,
-            std::sync::Arc::new(NoOpBatchChecker),
+            DynBatchChecker::new_arc(NoOpBatchChecker),
         )
     }
 
@@ -128,7 +128,7 @@ impl PlatformActor {
         platform_id: impl Into<String>,
         config: PlatformConfig,
         cancellation_token: CancellationToken,
-        batch_checker: std::sync::Arc<dyn BatchChecker>,
+        batch_checker: std::sync::Arc<DynBatchChecker<'static>>,
     ) -> (Self, ActorHandle<PlatformMessage>) {
         let platform_id = platform_id.into();
         let (tx, rx) = mpsc::channel(DEFAULT_MAILBOX_CAPACITY);
@@ -179,7 +179,7 @@ impl PlatformActor {
         platform_id: impl Into<String>,
         config: PlatformConfig,
         cancellation_token: CancellationToken,
-        batch_checker: std::sync::Arc<dyn BatchChecker>,
+        batch_checker: std::sync::Arc<DynBatchChecker<'static>>,
     ) -> (Self, ActorHandle<PlatformMessage>) {
         let platform_id = platform_id.into();
         let (tx, rx) = mpsc::channel(DEFAULT_MAILBOX_CAPACITY);

--- a/rust-srec/src/scheduler/actor/registry.rs
+++ b/rust-srec/src/scheduler/actor/registry.rs
@@ -389,8 +389,8 @@ mod tests {
         }
     }
 
-    fn create_noop_checker() -> Arc<dyn super::super::monitor_adapter::StatusChecker> {
-        Arc::new(NoOpStatusChecker)
+    fn create_noop_checker() -> Arc<super::super::monitor_adapter::DynStatusChecker<'static>> {
+        super::super::monitor_adapter::DynStatusChecker::new_arc(NoOpStatusChecker)
     }
 
     #[test]

--- a/rust-srec/src/scheduler/actor/streamer_actor.rs
+++ b/rust-srec/src/scheduler/actor/streamer_actor.rs
@@ -32,7 +32,7 @@ use super::messages::{
     StreamerConfig, StreamerMessage,
 };
 use super::metrics::ActorMetrics;
-use super::monitor_adapter::StatusChecker;
+use super::monitor_adapter::{DynStatusChecker, StatusChecker};
 use crate::domain::{Priority, StreamerState};
 use crate::downloader::DownloadStopCause;
 use crate::monitor::{LiveStatus, ProcessStatusResult, ProcessStatusSuppression};
@@ -113,7 +113,7 @@ pub struct StreamerActor {
     /// State persistence path (optional).
     state_path: Option<PathBuf>,
     /// Status checker for performing actual status checks.
-    status_checker: Arc<dyn StatusChecker>,
+    status_checker: Arc<DynStatusChecker<'static>>,
 }
 
 /// Default priority mailbox capacity (smaller than normal mailbox).
@@ -134,7 +134,7 @@ impl StreamerActor {
         metadata_store: Arc<DashMap<String, StreamerMetadata>>,
         config: StreamerConfig,
         cancellation_token: CancellationToken,
-        status_checker: Arc<dyn StatusChecker>,
+        status_checker: Arc<DynStatusChecker<'static>>,
     ) -> (Self, ActorHandle<StreamerMessage>) {
         let (tx, rx) = mpsc::channel(DEFAULT_MAILBOX_CAPACITY);
         let is_high_priority = config.priority == Priority::High;
@@ -177,7 +177,7 @@ impl StreamerActor {
         metadata_store: Arc<DashMap<String, StreamerMetadata>>,
         config: StreamerConfig,
         cancellation_token: CancellationToken,
-        status_checker: Arc<dyn StatusChecker>,
+        status_checker: Arc<DynStatusChecker<'static>>,
     ) -> (Self, ActorHandle<StreamerMessage>) {
         let (tx, rx) = mpsc::channel(DEFAULT_MAILBOX_CAPACITY);
         let (priority_tx, priority_rx) = mpsc::channel(DEFAULT_PRIORITY_MAILBOX_CAPACITY);
@@ -223,7 +223,7 @@ impl StreamerActor {
         config: StreamerConfig,
         cancellation_token: CancellationToken,
         platform_actor: mpsc::Sender<PlatformMessage>,
-        status_checker: Arc<dyn StatusChecker>,
+        status_checker: Arc<DynStatusChecker<'static>>,
     ) -> (Self, ActorHandle<StreamerMessage>) {
         let (mut actor, handle) = Self::with_priority_channel(
             streamer_id,
@@ -1332,7 +1332,7 @@ impl StreamerActor {
         default_config: StreamerConfig,
         cancellation_token: CancellationToken,
         state_dir: Option<&PathBuf>,
-        status_checker: std::sync::Arc<dyn StatusChecker>,
+        status_checker: std::sync::Arc<DynStatusChecker<'static>>,
     ) -> (Self, ActorHandle<StreamerMessage>) {
         let (mut actor, handle) = Self::new(
             streamer_id.clone(),
@@ -1372,7 +1372,7 @@ impl StreamerActor {
         default_config: StreamerConfig,
         cancellation_token: CancellationToken,
         state_dir: Option<&PathBuf>,
-        status_checker: std::sync::Arc<dyn StatusChecker>,
+        status_checker: std::sync::Arc<DynStatusChecker<'static>>,
     ) -> (Self, ActorHandle<StreamerMessage>) {
         let (mut actor, handle) = Self::with_priority_channel(
             streamer_id.clone(),
@@ -1522,7 +1522,6 @@ mod tests {
     use crate::domain::Priority;
     use crate::monitor::{ProcessStatusResult, ProcessStatusSuppression};
     use crate::scheduler::actor::monitor_adapter::{CheckError, NoOpStatusChecker};
-    use async_trait::async_trait;
     use std::collections::VecDeque;
     use std::sync::Arc;
     use std::sync::Mutex;
@@ -1564,8 +1563,8 @@ mod tests {
         }
     }
 
-    fn create_noop_checker() -> Arc<dyn StatusChecker> {
-        Arc::new(NoOpStatusChecker)
+    fn create_noop_checker() -> Arc<DynStatusChecker<'static>> {
+        DynStatusChecker::new_arc(NoOpStatusChecker)
     }
 
     #[derive(Debug)]
@@ -1583,7 +1582,6 @@ mod tests {
         }
     }
 
-    #[async_trait]
     impl StatusChecker for SequenceStatusChecker {
         async fn check_status(
             &self,
@@ -2122,7 +2120,7 @@ mod tests {
         let config = create_test_config();
         let token = CancellationToken::new();
 
-        let checker: Arc<dyn StatusChecker> = Arc::new(SequenceStatusChecker::new(
+        let checker: Arc<DynStatusChecker<'static>> = DynStatusChecker::new_arc(SequenceStatusChecker::new(
             vec![(
                 CheckResult::success(StreamerState::Live),
                 LiveStatus::Live {
@@ -2169,7 +2167,7 @@ mod tests {
         let config = create_test_config();
         let token = CancellationToken::new();
 
-        let checker: Arc<dyn StatusChecker> = Arc::new(SequenceStatusChecker::new(
+        let checker: Arc<DynStatusChecker<'static>> = DynStatusChecker::new_arc(SequenceStatusChecker::new(
             vec![
                 (
                     CheckResult::success(StreamerState::Live),
@@ -2234,7 +2232,7 @@ mod tests {
         let config = create_test_config();
         let token = CancellationToken::new();
 
-        let checker: Arc<dyn StatusChecker> = Arc::new(SequenceStatusChecker::new(
+        let checker: Arc<DynStatusChecker<'static>> = DynStatusChecker::new_arc(SequenceStatusChecker::new(
             vec![(
                 CheckResult::success(StreamerState::Live),
                 LiveStatus::Live {
@@ -2303,7 +2301,7 @@ mod tests {
         let config = create_test_config();
         let token = CancellationToken::new();
 
-        let checker: Arc<dyn StatusChecker> = Arc::new(SequenceStatusChecker::new(
+        let checker: Arc<DynStatusChecker<'static>> = DynStatusChecker::new_arc(SequenceStatusChecker::new(
             vec![(
                 CheckResult::success(StreamerState::Live),
                 LiveStatus::Live {

--- a/rust-srec/src/scheduler/actor/supervisor.rs
+++ b/rust-srec/src/scheduler/actor/supervisor.rs
@@ -18,7 +18,9 @@ use tracing::{debug, error, info, warn};
 
 use super::handle::ActorHandle;
 use super::messages::{PlatformConfig, PlatformMessage, StreamerConfig, StreamerMessage};
-use super::monitor_adapter::{BatchChecker, NoOpBatchChecker, NoOpStatusChecker, StatusChecker};
+use super::monitor_adapter::{
+    DynBatchChecker, NoOpBatchChecker, NoOpStatusChecker, StatusChecker,
+};
 use super::platform_actor::PlatformActor;
 use super::registry::{ActorRegistry, ActorTaskResult};
 use super::restart_tracker::{RestartTracker, RestartTrackerConfig};
@@ -103,7 +105,7 @@ pub struct Supervisor {
     /// Status checker for streamer actors.
     status_checker: Arc<dyn StatusChecker>,
     /// Batch checker for platform actors.
-    batch_checker: Arc<dyn BatchChecker>,
+    batch_checker: Arc<DynBatchChecker<'static>>,
 }
 
 impl Supervisor {
@@ -135,7 +137,7 @@ impl Supervisor {
             config,
             metadata_store,
             Arc::new(NoOpStatusChecker),
-            Arc::new(NoOpBatchChecker),
+            DynBatchChecker::new_arc(NoOpBatchChecker),
         )
     }
 
@@ -148,7 +150,7 @@ impl Supervisor {
         config: SupervisorConfig,
         metadata_store: Arc<DashMap<String, StreamerMetadata>>,
         status_checker: Arc<dyn StatusChecker>,
-        batch_checker: Arc<dyn BatchChecker>,
+        batch_checker: Arc<DynBatchChecker<'static>>,
     ) -> Self {
         Self {
             registry: ActorRegistry::new(cancellation_token.clone()),

--- a/rust-srec/src/scheduler/actor/supervisor.rs
+++ b/rust-srec/src/scheduler/actor/supervisor.rs
@@ -19,7 +19,7 @@ use tracing::{debug, error, info, warn};
 use super::handle::ActorHandle;
 use super::messages::{PlatformConfig, PlatformMessage, StreamerConfig, StreamerMessage};
 use super::monitor_adapter::{
-    DynBatchChecker, NoOpBatchChecker, NoOpStatusChecker, StatusChecker,
+    DynBatchChecker, DynStatusChecker, NoOpBatchChecker, NoOpStatusChecker,
 };
 use super::platform_actor::PlatformActor;
 use super::registry::{ActorRegistry, ActorTaskResult};
@@ -103,7 +103,7 @@ pub struct Supervisor {
     /// Platform actor senders for streamer-platform association.
     platform_senders: HashMap<String, mpsc::Sender<PlatformMessage>>,
     /// Status checker for streamer actors.
-    status_checker: Arc<dyn StatusChecker>,
+    status_checker: Arc<DynStatusChecker<'static>>,
     /// Batch checker for platform actors.
     batch_checker: Arc<DynBatchChecker<'static>>,
 }
@@ -136,7 +136,7 @@ impl Supervisor {
             cancellation_token,
             config,
             metadata_store,
-            Arc::new(NoOpStatusChecker),
+            DynStatusChecker::new_arc(NoOpStatusChecker),
             DynBatchChecker::new_arc(NoOpBatchChecker),
         )
     }
@@ -149,7 +149,7 @@ impl Supervisor {
         cancellation_token: CancellationToken,
         config: SupervisorConfig,
         metadata_store: Arc<DashMap<String, StreamerMetadata>>,
-        status_checker: Arc<dyn StatusChecker>,
+        status_checker: Arc<DynStatusChecker<'static>>,
         batch_checker: Arc<DynBatchChecker<'static>>,
     ) -> Self {
         Self {

--- a/rust-srec/src/scheduler/service.rs
+++ b/rust-srec/src/scheduler/service.rs
@@ -33,8 +33,9 @@ use crate::monitor::StreamMonitor;
 use crate::streamer::{StreamerManager, StreamerMetadata};
 
 use super::actor::{
-    ActorHandle, ConfigRouter, ConfigScope, DownloadEndPolicy, DynBatchChecker, MonitorBatchChecker,
-    MonitorStatusChecker, PlatformConfig, PlatformMapping, PlatformMessage, RoutingPlan,
+    ActorHandle, ConfigRouter, ConfigScope, DownloadEndPolicy, DynBatchChecker, DynStatusChecker,
+    MonitorBatchChecker, MonitorStatusChecker, PlatformConfig, PlatformMapping, PlatformMessage,
+    RoutingPlan,
     ShutdownReport, StreamerConfig, StreamerMessage, Supervisor, SupervisorConfig,
     TaskCompletionAction,
 };
@@ -298,7 +299,7 @@ impl<R: StreamerRepository + Send + Sync + 'static> Scheduler<R> {
         CR: ConfigRepository + Send + Sync + 'static,
     {
         // Create status and batch checkers directly from the StreamMonitor
-        let status_checker = Arc::new(MonitorStatusChecker::new(monitor.clone()));
+        let status_checker = DynStatusChecker::new_arc(MonitorStatusChecker::new(monitor.clone()));
         let batch_checker = DynBatchChecker::new_arc(MonitorBatchChecker::new(monitor.clone()));
 
         // Pass the shared metadata store to the supervisor

--- a/rust-srec/src/scheduler/service.rs
+++ b/rust-srec/src/scheduler/service.rs
@@ -24,7 +24,8 @@ use tracing::{debug, error, info, trace, warn};
 use crate::Result;
 use crate::config::{ConfigEventBroadcaster, ConfigUpdateEvent};
 use crate::database::repositories::{
-    ConfigRepository, FilterRepository, SessionRepository, StreamerRepository,
+    ConfigRepository, DynConfigRepository, FilterRepository, SessionRepository,
+    StreamerRepository,
 };
 use crate::domain::Priority;
 use crate::downloader::{DownloadManagerEvent, DownloadStopCause};
@@ -32,7 +33,7 @@ use crate::monitor::StreamMonitor;
 use crate::streamer::{StreamerManager, StreamerMetadata};
 
 use super::actor::{
-    ActorHandle, ConfigRouter, ConfigScope, DownloadEndPolicy, MonitorBatchChecker,
+    ActorHandle, ConfigRouter, ConfigScope, DownloadEndPolicy, DynBatchChecker, MonitorBatchChecker,
     MonitorStatusChecker, PlatformConfig, PlatformMapping, PlatformMessage, RoutingPlan,
     ShutdownReport, StreamerConfig, StreamerMessage, Supervisor, SupervisorConfig,
     TaskCompletionAction,
@@ -113,7 +114,7 @@ pub struct Scheduler<R: StreamerRepository + Send + Sync + 'static> {
     /// Scheduler configuration.
     config: SchedulerConfig,
     /// Config repository for pulling fresh global timing config on hot reload.
-    config_repo: Option<Arc<dyn ConfigRepository>>,
+    config_repo: Option<Arc<DynConfigRepository<'static>>>,
     /// Cancellation token for graceful shutdown.
     cancellation_token: CancellationToken,
     /// Supervisor for managing actor lifecycle.
@@ -298,7 +299,7 @@ impl<R: StreamerRepository + Send + Sync + 'static> Scheduler<R> {
     {
         // Create status and batch checkers directly from the StreamMonitor
         let status_checker = Arc::new(MonitorStatusChecker::new(monitor.clone()));
-        let batch_checker = Arc::new(MonitorBatchChecker::new(monitor.clone()));
+        let batch_checker = DynBatchChecker::new_arc(MonitorBatchChecker::new(monitor.clone()));
 
         // Pass the shared metadata store to the supervisor
         let metadata_store = streamer_manager.metadata_store();
@@ -329,7 +330,7 @@ impl<R: StreamerRepository + Send + Sync + 'static> Scheduler<R> {
     }
 
     /// Attach a config repository to enable hot reloading of global scheduler timing config.
-    pub fn with_config_repo(mut self, config_repo: Arc<dyn ConfigRepository>) -> Self {
+    pub fn with_config_repo(mut self, config_repo: Arc<DynConfigRepository<'static>>) -> Self {
         self.config_repo = Some(config_repo);
         self
     }

--- a/rust-srec/src/services/container.rs
+++ b/rust-srec/src/services/container.rs
@@ -25,22 +25,22 @@ use crate::credentials::{
 use crate::danmu::{DanmuEvent, DanmuService, service::DanmuServiceConfig};
 use crate::database::maintenance::{MaintenanceConfig, MaintenanceScheduler};
 use crate::database::repositories::{
-    ConfigRepository, NotificationRepository, SqlxNotificationRepository,
+    ConfigRepository, DynNotificationRepository, SqlxNotificationRepository,
 };
 use crate::database::repositories::{
     SqlxCredentialStore,
     config::{DynConfigRepository, SqlxConfigRepository},
-    dag::SqlxDagRepository,
+    dag::{DynDagRepository, SqlxDagRepository},
     filter::{DynFilterRepository, SqlxFilterRepository},
-    job::SqlxJobRepository,
+    job::{DynJobRepository, SqlxJobRepository},
     preset::{
         DynJobPresetRepository, DynPipelinePresetRepository, SqliteJobPresetRepository,
         SqlitePipelinePresetRepository,
     },
-    refresh_token::SqlxRefreshTokenRepository,
-    session::SqlxSessionRepository,
-    streamer::SqlxStreamerRepository,
-    user::SqlxUserRepository,
+    refresh_token::{DynRefreshTokenRepository, SqlxRefreshTokenRepository},
+    session::{DynSessionRepository, SqlxSessionRepository},
+    streamer::{DynStreamerRepository, SqlxStreamerRepository},
+    user::{DynUserRepository, SqlxUserRepository},
 };
 use crate::domain::{Priority, StreamerState};
 use crate::downloader::{
@@ -306,7 +306,7 @@ pub struct ServiceContainer {
     /// Notification service.
     pub notification_service: Arc<NotificationService>,
     /// Notification repository.
-    pub notification_repository: Arc<dyn NotificationRepository>,
+    pub notification_repository: Arc<DynNotificationRepository<'static>>,
     /// Web push service for browser notifications (VAPID), if configured.
     pub web_push_service: Option<Arc<WebPushService>>,
     /// Metrics collector.
@@ -382,6 +382,9 @@ impl ServiceContainer {
         // Create additional repositories for StreamMonitor
         let filter_repo = Arc::new(SqlxFilterRepository::new(pool.clone(), write_pool.clone()));
         let session_repo = Arc::new(SqlxSessionRepository::new(pool.clone(), write_pool.clone()));
+        let session_repo_dyn: Arc<DynSessionRepository<'static>> = DynSessionRepository::new_arc(
+            SqlxSessionRepository::new(pool.clone(), write_pool.clone()),
+        );
 
         // Create config service with custom cache
         let cache = ConfigCache::with_ttl(cache_ttl);
@@ -408,10 +411,9 @@ impl ServiceContainer {
         );
 
         // Create notification service with default config (also used for credential events).
-        let notification_repository = Arc::new(SqlxNotificationRepository::new(
-            pool.clone(),
-            write_pool.clone(),
-        ));
+        let notification_repository = DynNotificationRepository::new_arc(
+            SqlxNotificationRepository::new(pool.clone(), write_pool.clone()),
+        );
         let web_push_service = WebPushService::from_env(pool.clone(), write_pool.clone())
             .unwrap_or_else(|e| {
                 warn!(error = %e, "Web push service disabled due to configuration error");
@@ -470,7 +472,8 @@ impl ServiceContainer {
         download_manager.set_output_root_gate(output_root_gate.clone());
 
         // Create job repository for pipeline persistence
-        let job_repo = Arc::new(SqlxJobRepository::new(pool.clone(), write_pool.clone()));
+        let job_repo =
+            DynJobRepository::new_arc(SqlxJobRepository::new(pool.clone(), write_pool.clone()));
 
         // Create job preset repository
         let preset_repo = DynJobPresetRepository::new_arc(SqliteJobPresetRepository::new(
@@ -503,12 +506,12 @@ impl ServiceContainer {
             global_config.pipeline_execute_timeout_secs.max(1) as u64;
         let pipeline_manager = Arc::new(
             PipelineManager::with_repository(pipeline_config, job_repo)
-                .with_session_repository(session_repo.clone())
+                .with_session_repository(session_repo_dyn.clone())
                 .with_streamer_repository(streamer_repo.clone())
                 .with_preset_repository(preset_repo)
                 .with_pipeline_preset_repository(pipeline_preset_repo)
                 .with_config_service(config_service.clone())
-                .with_dag_repository(Arc::new(SqlxDagRepository::new(
+                .with_dag_repository(DynDagRepository::new_arc(SqlxDagRepository::new(
                     pool.clone(),
                     write_pool.clone(),
                 ))),
@@ -520,7 +523,7 @@ impl ServiceContainer {
         // Create danmu service with default config
         let danmu_service = Arc::new(
             DanmuService::new(DanmuServiceConfig::default())
-                .with_session_repository(session_repo.clone()),
+                .with_session_repository(session_repo_dyn.clone()),
         );
 
         // Create metrics collector
@@ -641,6 +644,9 @@ impl ServiceContainer {
         let monitor_repos_start = Instant::now();
         let filter_repo = Arc::new(SqlxFilterRepository::new(pool.clone(), write_pool.clone()));
         let session_repo = Arc::new(SqlxSessionRepository::new(pool.clone(), write_pool.clone()));
+        let session_repo_dyn: Arc<DynSessionRepository<'static>> = DynSessionRepository::new_arc(
+            SqlxSessionRepository::new(pool.clone(), write_pool.clone()),
+        );
         let monitor_repos_ms = monitor_repos_start.elapsed().as_millis();
 
         // Create config service with custom cache
@@ -702,7 +708,8 @@ impl ServiceContainer {
 
         // Create job repository for pipeline persistence
         let pipeline_repo_start = Instant::now();
-        let job_repo = Arc::new(SqlxJobRepository::new(pool.clone(), write_pool.clone()));
+        let job_repo =
+            DynJobRepository::new_arc(SqlxJobRepository::new(pool.clone(), write_pool.clone()));
 
         // Create job preset repository
         let preset_repo = DynJobPresetRepository::new_arc(SqliteJobPresetRepository::new(
@@ -736,12 +743,12 @@ impl ServiceContainer {
             global_config.pipeline_execute_timeout_secs.max(1) as u64;
         let pipeline_manager = Arc::new(
             PipelineManager::with_repository(effective_pipeline_config, job_repo)
-                .with_session_repository(session_repo.clone())
+                .with_session_repository(session_repo_dyn.clone())
                 .with_streamer_repository(streamer_repo.clone())
                 .with_preset_repository(preset_repo)
                 .with_pipeline_preset_repository(pipeline_preset_repo)
                 .with_config_service(config_service.clone())
-                .with_dag_repository(Arc::new(SqlxDagRepository::new(
+                .with_dag_repository(DynDagRepository::new_arc(SqlxDagRepository::new(
                     pool.clone(),
                     write_pool.clone(),
                 ))),
@@ -756,15 +763,14 @@ impl ServiceContainer {
         // Create danmu service with custom config
         let danmu_service_start = Instant::now();
         let danmu_service =
-            Arc::new(DanmuService::new(danmu_config).with_session_repository(session_repo));
+            Arc::new(DanmuService::new(danmu_config).with_session_repository(session_repo_dyn));
         let danmu_service_ms = danmu_service_start.elapsed().as_millis();
 
         // Create notification service with default config
         let notification_service_start = Instant::now();
-        let notification_repository = Arc::new(SqlxNotificationRepository::new(
-            pool.clone(),
-            write_pool.clone(),
-        ));
+        let notification_repository = DynNotificationRepository::new_arc(
+            SqlxNotificationRepository::new(pool.clone(), write_pool.clone()),
+        );
         let web_push_service = WebPushService::from_env(pool.clone(), write_pool.clone())
             .unwrap_or_else(|e| {
                 warn!(error = %e, "Web push service disabled due to configuration error");
@@ -1065,11 +1071,11 @@ impl ServiceContainer {
         // Create AuthService if JWT is configured
         let auth_service = if let Some(ref jwt) = jwt_service {
             // Create user and refresh token repositories
-            let user_repo = Arc::new(SqlxUserRepository::new(
+            let user_repo = DynUserRepository::new_arc(SqlxUserRepository::new(
                 self.pool.clone(),
                 self.write_pool.clone(),
             ));
-            let token_repo = Arc::new(SqlxRefreshTokenRepository::new(
+            let token_repo = DynRefreshTokenRepository::new_arc(SqlxRefreshTokenRepository::new(
                 self.pool.clone(),
                 self.write_pool.clone(),
             ));
@@ -1104,7 +1110,7 @@ impl ServiceContainer {
 
         // Wire SessionRepository, FilterRepository, and PipelinePresetRepository into AppState
         state = state
-            .with_session_repository(Arc::new(SqlxSessionRepository::new(
+            .with_session_repository(DynSessionRepository::new_arc(SqlxSessionRepository::new(
                 self.pool.clone(),
                 self.write_pool.clone(),
             )))
@@ -1112,7 +1118,7 @@ impl ServiceContainer {
                 self.pool.clone(),
                 self.write_pool.clone(),
             )))
-            .with_streamer_repository(Arc::new(SqlxStreamerRepository::new(
+            .with_streamer_repository(DynStreamerRepository::new_arc(SqlxStreamerRepository::new(
                 self.pool.clone(),
                 self.write_pool.clone(),
             )))
@@ -1184,11 +1190,11 @@ impl ServiceContainer {
         ));
 
         // Create AuthService (always enabled when a JWT secret is provided)
-        let user_repo = Arc::new(SqlxUserRepository::new(
+        let user_repo = DynUserRepository::new_arc(SqlxUserRepository::new(
             self.pool.clone(),
             self.write_pool.clone(),
         ));
-        let token_repo = Arc::new(SqlxRefreshTokenRepository::new(
+        let token_repo = DynRefreshTokenRepository::new_arc(SqlxRefreshTokenRepository::new(
             self.pool.clone(),
             self.write_pool.clone(),
         ));
@@ -1217,7 +1223,7 @@ impl ServiceContainer {
 
         // Wire SessionRepository, FilterRepository, and PipelinePresetRepository into AppState
         state = state
-            .with_session_repository(Arc::new(SqlxSessionRepository::new(
+            .with_session_repository(DynSessionRepository::new_arc(SqlxSessionRepository::new(
                 self.pool.clone(),
                 self.write_pool.clone(),
             )))
@@ -1225,7 +1231,7 @@ impl ServiceContainer {
                 self.pool.clone(),
                 self.write_pool.clone(),
             )))
-            .with_streamer_repository(Arc::new(SqlxStreamerRepository::new(
+            .with_streamer_repository(DynStreamerRepository::new_arc(SqlxStreamerRepository::new(
                 self.pool.clone(),
                 self.write_pool.clone(),
             )))

--- a/rust-srec/src/services/container.rs
+++ b/rust-srec/src/services/container.rs
@@ -19,7 +19,8 @@ use crate::api::{
 };
 use crate::config::{ConfigCache, ConfigEventBroadcaster, ConfigService};
 use crate::credentials::{
-    CredentialRefreshService, CredentialResolver, platforms::BilibiliCredentialManager,
+    CredentialRefreshService, CredentialResolver, DynCredentialManager, DynCredentialStore,
+    platforms::BilibiliCredentialManager,
 };
 use crate::danmu::{DanmuEvent, DanmuService, service::DanmuServiceConfig};
 use crate::database::maintenance::{MaintenanceConfig, MaintenanceScheduler};
@@ -28,11 +29,14 @@ use crate::database::repositories::{
 };
 use crate::database::repositories::{
     SqlxCredentialStore,
-    config::SqlxConfigRepository,
+    config::{DynConfigRepository, SqlxConfigRepository},
     dag::SqlxDagRepository,
-    filter::SqlxFilterRepository,
+    filter::{DynFilterRepository, SqlxFilterRepository},
     job::SqlxJobRepository,
-    preset::{SqliteJobPresetRepository, SqlitePipelinePresetRepository},
+    preset::{
+        DynJobPresetRepository, DynPipelinePresetRepository, SqliteJobPresetRepository,
+        SqlitePipelinePresetRepository,
+    },
     refresh_token::SqlxRefreshTokenRepository,
     session::SqlxSessionRepository,
     streamer::SqlxStreamerRepository,
@@ -359,6 +363,11 @@ impl ServiceContainer {
 
         // Create repositories
         let config_repo = Arc::new(SqlxConfigRepository::new(pool.clone(), write_pool.clone()));
+        let dyn_config_repo: Arc<DynConfigRepository<'static>> =
+            DynConfigRepository::new_arc(SqlxConfigRepository::new(
+                pool.clone(),
+                write_pool.clone(),
+            ));
         let streamer_repo = Arc::new(SqlxStreamerRepository::new(
             pool.clone(),
             write_pool.clone(),
@@ -422,12 +431,13 @@ impl ServiceContainer {
 
         // Build credential refresh service (shared between StreamMonitor + API).
         let credential_resolver = Arc::new(CredentialResolver::new(config_repo.clone()));
-        let credential_store = Arc::new(SqlxCredentialStore::new(pool.clone(), write_pool.clone()));
+        let credential_store =
+            DynCredentialStore::new_arc(SqlxCredentialStore::new(pool.clone(), write_pool.clone()));
         let mut credential_service =
             CredentialRefreshService::new(credential_resolver, credential_store);
         credential_service.set_notification_service(Arc::clone(&notification_service));
         match BilibiliCredentialManager::new_lazy() {
-            Ok(manager) => credential_service.register_manager(Arc::new(manager)),
+            Ok(manager) => credential_service.register_manager(DynCredentialManager::new_arc(manager)),
             Err(e) => warn!(error = %e, "Failed to init bilibili credential manager; skipping"),
         }
         let credential_service = Arc::new(credential_service);
@@ -441,7 +451,8 @@ impl ServiceContainer {
             ..Default::default()
         };
         let download_manager = Arc::new(
-            DownloadManager::with_config(download_config).with_config_repo(config_repo.clone()),
+            DownloadManager::with_config(download_config)
+                .with_config_repo(dyn_config_repo.clone()),
         );
 
         // Build the output-root write gate (#508) now that StreamerManager
@@ -462,16 +473,17 @@ impl ServiceContainer {
         let job_repo = Arc::new(SqlxJobRepository::new(pool.clone(), write_pool.clone()));
 
         // Create job preset repository
-        let preset_repo = Arc::new(SqliteJobPresetRepository::new(
+        let preset_repo = DynJobPresetRepository::new_arc(SqliteJobPresetRepository::new(
             pool.clone().into(),
             write_pool.clone().into(),
         ));
 
         // Create pipeline preset repository
-        let pipeline_preset_repo = Arc::new(SqlitePipelinePresetRepository::new(
-            pool.clone().into(),
-            write_pool.clone().into(),
-        ));
+        let pipeline_preset_repo =
+            DynPipelinePresetRepository::new_arc(SqlitePipelinePresetRepository::new(
+                pool.clone().into(),
+                write_pool.clone().into(),
+            ));
 
         // Create pipeline manager with job repository for database persistence.
         // Wire global-config concurrency knobs into CPU/IO worker pool sizes.
@@ -553,7 +565,7 @@ impl ServiceContainer {
                 scheduler_config,
                 cancellation_token.child_token(),
             )
-            .with_config_repo(config_repo.clone()),
+            .with_config_repo(dyn_config_repo.clone()),
         ));
 
         info!("Service container initialized");
@@ -604,6 +616,11 @@ impl ServiceContainer {
         // Create repositories
         let repos_start = Instant::now();
         let config_repo = Arc::new(SqlxConfigRepository::new(pool.clone(), write_pool.clone()));
+        let dyn_config_repo: Arc<DynConfigRepository<'static>> =
+            DynConfigRepository::new_arc(SqlxConfigRepository::new(
+                pool.clone(),
+                write_pool.clone(),
+            ));
         let streamer_repo = Arc::new(SqlxStreamerRepository::new(
             pool.clone(),
             write_pool.clone(),
@@ -659,11 +676,12 @@ impl ServiceContainer {
         // Build credential refresh service (shared between StreamMonitor + API).
         let credential_service_start = Instant::now();
         let credential_resolver = Arc::new(CredentialResolver::new(config_repo.clone()));
-        let credential_store = Arc::new(SqlxCredentialStore::new(pool.clone(), write_pool.clone()));
+        let credential_store =
+            DynCredentialStore::new_arc(SqlxCredentialStore::new(pool.clone(), write_pool.clone()));
         let mut credential_service =
             CredentialRefreshService::new(credential_resolver, credential_store);
         match BilibiliCredentialManager::new_lazy() {
-            Ok(manager) => credential_service.register_manager(Arc::new(manager)),
+            Ok(manager) => credential_service.register_manager(DynCredentialManager::new_arc(manager)),
             Err(e) => warn!(error = %e, "Failed to init bilibili credential manager; skipping"),
         }
         let credential_service = Arc::new(credential_service);
@@ -678,7 +696,7 @@ impl ServiceContainer {
             (global_config.max_concurrent_downloads as i64).max(1) as usize;
         let download_manager = Arc::new(
             DownloadManager::with_config(effective_download_config)
-                .with_config_repo(config_repo.clone()),
+                .with_config_repo(dyn_config_repo.clone()),
         );
         let download_manager_ms = download_manager_start.elapsed().as_millis();
 
@@ -687,16 +705,17 @@ impl ServiceContainer {
         let job_repo = Arc::new(SqlxJobRepository::new(pool.clone(), write_pool.clone()));
 
         // Create job preset repository
-        let preset_repo = Arc::new(SqliteJobPresetRepository::new(
+        let preset_repo = DynJobPresetRepository::new_arc(SqliteJobPresetRepository::new(
             pool.clone().into(),
             write_pool.clone().into(),
         ));
 
         // Create pipeline preset repository (for workflow expansion)
-        let pipeline_preset_repo = Arc::new(SqlitePipelinePresetRepository::new(
-            pool.clone().into(),
-            write_pool.clone().into(),
-        ));
+        let pipeline_preset_repo =
+            DynPipelinePresetRepository::new_arc(SqlitePipelinePresetRepository::new(
+                pool.clone().into(),
+                write_pool.clone().into(),
+            ));
         let pipeline_repo_ms = pipeline_repo_start.elapsed().as_millis();
 
         // Create pipeline manager with job repository for database persistence.
@@ -829,7 +848,7 @@ impl ServiceContainer {
                 scheduler_config,
                 cancellation_token.child_token(),
             )
-            .with_config_repo(config_repo.clone()),
+            .with_config_repo(dyn_config_repo.clone()),
         ));
         let scheduler_ms = scheduler_start.elapsed().as_millis();
 
@@ -1089,7 +1108,7 @@ impl ServiceContainer {
                 self.pool.clone(),
                 self.write_pool.clone(),
             )))
-            .with_filter_repository(Arc::new(SqlxFilterRepository::new(
+            .with_filter_repository(DynFilterRepository::new_arc(SqlxFilterRepository::new(
                 self.pool.clone(),
                 self.write_pool.clone(),
             )))
@@ -1097,14 +1116,18 @@ impl ServiceContainer {
                 self.pool.clone(),
                 self.write_pool.clone(),
             )))
-            .with_pipeline_preset_repository(Arc::new(SqlitePipelinePresetRepository::new(
-                Arc::new(self.pool.clone()),
-                Arc::new(self.write_pool.clone()),
-            )))
-            .with_job_preset_repository(Arc::new(SqliteJobPresetRepository::new(
-                Arc::new(self.pool.clone()),
-                Arc::new(self.write_pool.clone()),
-            )))
+            .with_pipeline_preset_repository(DynPipelinePresetRepository::new_arc(
+                SqlitePipelinePresetRepository::new(
+                    Arc::new(self.pool.clone()),
+                    Arc::new(self.write_pool.clone()),
+                ),
+            ))
+            .with_job_preset_repository(DynJobPresetRepository::new_arc(
+                SqliteJobPresetRepository::new(
+                    Arc::new(self.pool.clone()),
+                    Arc::new(self.write_pool.clone()),
+                ),
+            ))
             .with_notification_repository(self.notification_repository.clone())
             .with_notification_service(self.notification_service.clone());
 
@@ -1198,7 +1221,7 @@ impl ServiceContainer {
                 self.pool.clone(),
                 self.write_pool.clone(),
             )))
-            .with_filter_repository(Arc::new(SqlxFilterRepository::new(
+            .with_filter_repository(DynFilterRepository::new_arc(SqlxFilterRepository::new(
                 self.pool.clone(),
                 self.write_pool.clone(),
             )))
@@ -1206,14 +1229,18 @@ impl ServiceContainer {
                 self.pool.clone(),
                 self.write_pool.clone(),
             )))
-            .with_pipeline_preset_repository(Arc::new(SqlitePipelinePresetRepository::new(
-                Arc::new(self.pool.clone()),
-                Arc::new(self.write_pool.clone()),
-            )))
-            .with_job_preset_repository(Arc::new(SqliteJobPresetRepository::new(
-                Arc::new(self.pool.clone()),
-                Arc::new(self.write_pool.clone()),
-            )))
+            .with_pipeline_preset_repository(DynPipelinePresetRepository::new_arc(
+                SqlitePipelinePresetRepository::new(
+                    Arc::new(self.pool.clone()),
+                    Arc::new(self.write_pool.clone()),
+                ),
+            ))
+            .with_job_preset_repository(DynJobPresetRepository::new_arc(
+                SqliteJobPresetRepository::new(
+                    Arc::new(self.pool.clone()),
+                    Arc::new(self.write_pool.clone()),
+                ),
+            ))
             .with_notification_repository(self.notification_repository.clone())
             .with_notification_service(self.notification_service.clone());
 

--- a/rust-srec/src/streamer/manager.rs
+++ b/rust-srec/src/streamer/manager.rs
@@ -767,7 +767,6 @@ where
 mod tests {
     use super::*;
     use crate::database::models::StreamerDbModel;
-    use async_trait::async_trait;
     use std::sync::Mutex;
 
     /// Mock streamer repository for testing.
@@ -789,7 +788,6 @@ mod tests {
         }
     }
 
-    #[async_trait]
     impl StreamerRepository for MockStreamerRepository {
         async fn list_all_streamers(&self) -> Result<Vec<StreamerDbModel>> {
             Ok(self.streamers.lock().unwrap().clone())

--- a/rust-srec/tests/job_execution_logs_persist.rs
+++ b/rust-srec/tests/job_execution_logs_persist.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use rust_srec::database;
 use rust_srec::database::models::Pagination;
 use rust_srec::database::repositories::JobRepository;
+use rust_srec::database::repositories::job::DynJobRepository;
 use rust_srec::database::repositories::SqlxJobRepository;
 use rust_srec::pipeline::{Job, JobExecutionInfo, JobLogEntry, JobQueue, JobQueueConfig, LogLevel};
 use tempfile::TempDir;
@@ -19,8 +20,11 @@ async fn update_execution_info_persists_logs_to_job_execution_logs() {
     let pool = database::init_pool(&db_url).await.unwrap();
     database::run_migrations(&pool).await.unwrap();
 
-    let repo = Arc::new(SqlxJobRepository::new(pool.clone(), pool));
-    let queue = JobQueue::with_repository(JobQueueConfig::default(), repo.clone());
+    let repo = Arc::new(SqlxJobRepository::new(pool.clone(), pool.clone()));
+    let queue = JobQueue::with_repository(
+        JobQueueConfig::default(),
+        DynJobRepository::new_arc(SqlxJobRepository::new(pool.clone(), pool)),
+    );
 
     let job = Job::new(
         "remux",

--- a/strev-cli/src/commands.rs
+++ b/strev-cli/src/commands.rs
@@ -10,7 +10,7 @@ use indicatif::{ProgressBar, ProgressStyle};
 use platforms_parser::{
     extractor::{
         ProxyConfig, factory::ExtractorFactory, factory_with_proxy,
-        platform_extractor::PlatformExtractor,
+        platform_extractor::{DynPlatformExtractor, PlatformExtractor},
     },
     media::{MediaInfo, StreamInfo},
 };
@@ -397,7 +397,7 @@ impl CommandExecutor {
         extras: Option<&str>,
         timeout_duration: Duration,
         retries: u32,
-    ) -> Result<(MediaInfo, Box<dyn PlatformExtractor>)> {
+    ) -> Result<(MediaInfo, Box<DynPlatformExtractor<'static>>)> {
         let mut last_error = None;
 
         for attempt in 0..=retries {


### PR DESCRIPTION
## Summary

Stacked on [#517](https://github.com/hua0512/rust-srec/pull/517). Finishes the `async-trait` removal started in PR #516.

The 23 traits that #516 left on `async-trait` (because they were used as `Arc<dyn T>` / `Box<dyn T>` / `&dyn T` somewhere) all switch to native `async fn in trait`, with [`dynosaur`](https://crates.io/crates/dynosaur) generating a `DynTrait` wrapper for the dyn call sites. Static callers pay zero overhead (no boxed future); dyn callers pay the same `Box<Pin<Future>>` cost they paid before, just from a different macro.

After this lands the workspace has **zero first-party `async-trait` usages** and the dep is dropped.

## Commits (5)

1. `chore(deps): add dynosaur 0.3 to workspace`
2. `refactor(async): migrate 8 low-risk traits to dynosaur (Phase 1)` — PlaylistProvider, CredentialStore, FilterRepository, JobPresetRepository, CredentialManager, ConfigRepository, PipelinePresetRepository, BatchChecker.
3. `refactor(async): migrate 12 medium-risk traits to dynosaur (Phase 2)` — DanmuProvider, DagRepository, StreamerRepository, RefreshTokenRepository, SegmentDownloader, SegmentTransformer, NotificationRepository, SessionRepository, UserRepository, NotificationChannel, JobRepository, DownloadEngine.
4. `refactor(async): migrate 3 high-fanout traits to dynosaur (Phase 3)` — StatusChecker (13 dyn call sites), PlatformExtractor (12 implementors), Processor (15 implementors).
5. `chore(deps): drop async-trait — no first-party usages remain`.

## Pattern applied per trait

```rust
#[dynosaur::dynosaur(pub DynFoo = dyn(box) Foo)]
pub trait Foo: Send + Sync {
    fn bar(&self) -> impl Future<Output = Result<T>> + Send;
}
```

- Trait def: replace `#[async_trait]` with `#[dynosaur::dynosaur(pub DynFoo = dyn(box) Foo)]`, rewrite each `async fn` to `fn ... -> impl Future + Send`.
- Impl blocks: drop `#[async_trait]`, keep `async fn` bodies unchanged.
- Dyn call sites: `Arc<dyn Foo>` → `Arc<DynFoo<'static>>`, `Box<dyn Foo>` → `Box<DynFoo<'static>>`, etc.
- Construction: `Arc::new(Concrete::new())` (where coerced to `Arc<dyn Foo>`) → `DynFoo::new_arc(Concrete::new())`. Same for `new_box`, `from_ref`, `from_mut`.

## Notes / surprises

- **`StatusChecker` dropped its `+ 'static` supertrait bound.** dynosaur's generated wrapper holds `&self` borrows that can't satisfy a `'static` lifetime on the underlying trait. The `Arc<DynStatusChecker<'static>>` annotation on every call site keeps the same implementor-lifetime expectation explicit.
- **Twitch-style recursion.** None of the migrated traits had the recursion pattern that bit `DanmuProtocol::decode_message` in #516, so no helper extraction was needed.
- **Test mocks.** A handful of test mocks holding `Mutex` state needed `#[derive(Clone)]` + `Arc<Mutex<...>>` so the test could keep one handle for assertions while passing `t.clone()` into `DynX::new_arc(...)` (dynosaur's `new_arc` takes `T: Trait` by value, not `Arc<T>`).
- **One trait needed dual concrete + dyn flavors.** In `services/container.rs`, `StreamMonitor` wants a generic `SSR: SessionRepository` (concrete) while `PipelineManager` and `DanmuService` want `Arc<DynSessionRepository<'static>>`. Solved by constructing both side-by-side from the same pool.
- **6 pre-existing `let _ = ctx.warn(...)` clippy hits** in `pipeline/processors/{execute,remux}.rs` surfaced once Processor's method futures became non-opaque; cleaned up.
- **`async-trait` still appears in `Cargo.lock`** as a transitive of `zbus` via `tauri-plugin-notification` / `tauri-plugin-single-instance`. That's third-party and out of scope.

## Test plan

- [x] `cargo build --workspace --exclude rust-srec-desktop` — clean
- [x] `cargo clippy --workspace --exclude rust-srec-desktop --all-targets -- -D warnings` — clean
- [x] `cargo test --workspace --exclude rust-srec-desktop` — 1093 pass / 2 unrelated `output_root_gate` root-uid failures (same baseline as #516, #517)
- [x] `rg '#\[async_trait' --type rust` returns zero hits
- [x] `cargo tree -i async-trait` shows only transitive Tauri usage
- [ ] Live smoke: kick off an HLS download (Twitch or PandaTV) and a danmu connection (Bilibili or Huya) to confirm the hot-path traits (`SegmentDownloader`, `SegmentTransformer`, `DanmuProvider`, `Processor`) work end-to-end. Static dispatch should be unchanged; only the dyn boundaries shifted from `async-trait`'s box to dynosaur's.
- [ ] `rust-srec-desktop` (Tauri) build on a host with `pkg-config` + glib-2.0