### PR TITLE
refactor(downloader): make terminal events compile-time exhaustive; fix #523 (dev branch cherry-pick)

### DIFF
--- a/rust-srec/src/api/routes/downloads.rs
+++ b/rust-srec/src/api/routes/downloads.rs
@@ -36,7 +36,7 @@ use crate::api::proto::{
     download_progress::client_message::Action, download_progress::ws_message::Payload,
 };
 use crate::api::server::AppState;
-use crate::downloader::DownloadManagerEvent;
+use crate::downloader::{DownloadManagerEvent, DownloadProgressEvent, DownloadTerminalEvent};
 
 /// Query parameters for WebSocket connection (JWT token).
 #[derive(Debug, Deserialize)]
@@ -260,27 +260,14 @@ fn map_event_to_protobuf(
     event: &DownloadManagerEvent,
     filter: &Option<String>,
 ) -> Option<WsMessage> {
-    let event_streamer_id = match event {
-        DownloadManagerEvent::DownloadStarted { streamer_id, .. } => streamer_id,
-        DownloadManagerEvent::Progress { streamer_id, .. } => streamer_id,
-        DownloadManagerEvent::SegmentCompleted { streamer_id, .. } => streamer_id,
-        DownloadManagerEvent::SegmentStarted { streamer_id, .. } => streamer_id,
-        DownloadManagerEvent::DownloadCompleted { streamer_id, .. } => streamer_id,
-        DownloadManagerEvent::DownloadFailed { streamer_id, .. } => streamer_id,
-        DownloadManagerEvent::DownloadCancelled { streamer_id, .. } => streamer_id,
-        DownloadManagerEvent::ConfigUpdated { streamer_id, .. } => streamer_id,
-        DownloadManagerEvent::ConfigUpdateFailed { streamer_id, .. } => streamer_id,
-        DownloadManagerEvent::DownloadRejected { streamer_id, .. } => streamer_id,
-    };
-
     if let Some(filter_id) = filter
-        && event_streamer_id != filter_id
+        && event.streamer_id() != filter_id.as_str()
     {
         return None;
     }
 
     match event {
-        DownloadManagerEvent::DownloadStarted {
+        DownloadManagerEvent::Progress(DownloadProgressEvent::DownloadStarted {
             download_id,
             streamer_id,
             session_id,
@@ -288,7 +275,7 @@ fn map_event_to_protobuf(
             cdn_host,
             download_url,
             ..
-        } => {
+        }) => {
             let now_ms = chrono::Utc::now().timestamp_millis();
             let meta = crate::api::proto::DownloadMeta {
                 download_id: download_id.clone(),
@@ -306,12 +293,12 @@ fn map_event_to_protobuf(
                 payload: Some(Payload::DownloadMeta(meta)),
             })
         }
-        DownloadManagerEvent::Progress {
+        DownloadManagerEvent::Progress(DownloadProgressEvent::Progress {
             download_id,
             progress,
             status,
             ..
-        } => {
+        }) => {
             let metrics = crate::api::proto::DownloadMetrics {
                 download_id: download_id.clone(),
                 status: status.as_str().to_string(),
@@ -327,7 +314,7 @@ fn map_event_to_protobuf(
                 payload: Some(Payload::DownloadMetrics(metrics)),
             })
         }
-        DownloadManagerEvent::SegmentCompleted {
+        DownloadManagerEvent::Progress(DownloadProgressEvent::SegmentCompleted {
             download_id,
             streamer_id,
             session_id,
@@ -340,7 +327,7 @@ fn map_event_to_protobuf(
             split_reason_code: _,
             split_reason_details_json: _,
             ..
-        } => {
+        }) => {
             let payload = SegmentCompleted {
                 download_id: download_id.clone(),
                 streamer_id: streamer_id.clone(),
@@ -361,7 +348,7 @@ fn map_event_to_protobuf(
                 payload: Some(Payload::SegmentCompleted(payload)),
             })
         }
-        DownloadManagerEvent::DownloadCompleted {
+        DownloadManagerEvent::Terminal(DownloadTerminalEvent::Completed {
             download_id,
             streamer_id,
             session_id,
@@ -370,7 +357,7 @@ fn map_event_to_protobuf(
             total_segments,
             file_path: _file_path,
             ..
-        } => {
+        }) => {
             let payload = DownloadCompleted {
                 download_id: download_id.clone(),
                 streamer_id: streamer_id.clone(),
@@ -384,14 +371,14 @@ fn map_event_to_protobuf(
                 payload: Some(Payload::DownloadCompleted(payload)),
             })
         }
-        DownloadManagerEvent::DownloadFailed {
+        DownloadManagerEvent::Terminal(DownloadTerminalEvent::Failed {
             download_id,
             streamer_id,
             session_id,
             error,
             recoverable,
             ..
-        } => {
+        }) => {
             let payload = DownloadFailed {
                 download_id: download_id.clone(),
                 streamer_id: streamer_id.clone(),
@@ -404,13 +391,13 @@ fn map_event_to_protobuf(
                 payload: Some(Payload::DownloadFailed(payload)),
             })
         }
-        DownloadManagerEvent::DownloadCancelled {
+        DownloadManagerEvent::Terminal(DownloadTerminalEvent::Cancelled {
             download_id,
             streamer_id,
             session_id,
             cause,
             ..
-        } => {
+        }) => {
             let payload = DownloadCancelled {
                 download_id: download_id.clone(),
                 streamer_id: streamer_id.clone(),
@@ -422,13 +409,13 @@ fn map_event_to_protobuf(
                 payload: Some(Payload::DownloadCancelled(payload)),
             })
         }
-        DownloadManagerEvent::DownloadRejected {
+        DownloadManagerEvent::Terminal(DownloadTerminalEvent::Rejected {
             streamer_id,
             session_id,
             reason,
             retry_after_secs,
             ..
-        } => {
+        }) => {
             let payload = DownloadRejected {
                 streamer_id: streamer_id.clone(),
                 session_id: session_id.clone(),
@@ -460,7 +447,7 @@ mod tests {
 
     #[test]
     fn test_filter_matches_streamer() {
-        let event = DownloadManagerEvent::DownloadStarted {
+        let event = DownloadManagerEvent::Progress(DownloadProgressEvent::DownloadStarted {
             download_id: "dl-1".to_string(),
             streamer_id: "streamer-123".to_string(),
             streamer_name: "streamer-123".to_string(),
@@ -468,7 +455,7 @@ mod tests {
             engine_type: EngineType::Ffmpeg,
             cdn_host: "cdn.example.com".to_string(),
             download_url: "https://cdn.example.com/stream".to_string(),
-        };
+        });
 
         // No filter - should pass
         let result = map_event_to_protobuf(&event, &None);
@@ -485,12 +472,12 @@ mod tests {
 
     #[test]
     fn test_config_events_not_broadcast() {
-        let event = DownloadManagerEvent::ConfigUpdated {
+        let event = DownloadManagerEvent::Progress(DownloadProgressEvent::ConfigUpdated {
             download_id: "dl-1".to_string(),
             streamer_id: "streamer-123".to_string(),
             streamer_name: "streamer-123".to_string(),
             update_type: ConfigUpdateType::Cookies,
-        };
+        });
 
         let result = map_event_to_protobuf(&event, &None);
         assert!(result.is_none());
@@ -498,7 +485,7 @@ mod tests {
 
     #[test]
     fn test_download_meta_event_mapping() {
-        let event = DownloadManagerEvent::DownloadStarted {
+        let event = DownloadManagerEvent::Progress(DownloadProgressEvent::DownloadStarted {
             download_id: "dl-1".to_string(),
             streamer_id: "streamer-123".to_string(),
             streamer_name: "streamer-123".to_string(),
@@ -506,7 +493,7 @@ mod tests {
             engine_type: EngineType::Ffmpeg,
             cdn_host: "cdn.example.com".to_string(),
             download_url: "https://cdn.example.com/stream".to_string(),
-        };
+        });
 
         let msg = map_event_to_protobuf(&event, &None).unwrap();
         assert_eq!(msg.event_type, EventType::DownloadMeta as i32);
@@ -523,7 +510,7 @@ mod tests {
 
     #[test]
     fn test_segment_completed_event_mapping() {
-        let event = DownloadManagerEvent::SegmentCompleted {
+        let event = DownloadManagerEvent::Progress(DownloadProgressEvent::SegmentCompleted {
             download_id: "dl-1".to_string(),
             streamer_id: "streamer-123".to_string(),
             streamer_name: "streamer-123".to_string(),
@@ -536,7 +523,7 @@ mod tests {
             size_bytes: 1024000,
             split_reason_code: None,
             split_reason_details_json: None,
-        };
+        });
 
         let msg = map_event_to_protobuf(&event, &None).unwrap();
         assert_eq!(msg.event_type, EventType::SegmentCompleted as i32);
@@ -556,7 +543,7 @@ mod tests {
 
     #[test]
     fn test_download_completed_event_mapping() {
-        let event = DownloadManagerEvent::DownloadCompleted {
+        let event = DownloadManagerEvent::Terminal(DownloadTerminalEvent::Completed {
             download_id: "dl-1".to_string(),
             streamer_id: "streamer-123".to_string(),
             streamer_name: "streamer-123".to_string(),
@@ -565,7 +552,7 @@ mod tests {
             total_duration_secs: 3600.0,
             total_segments: 360,
             file_path: Some("/path/to/video.mp4".to_string()),
-        };
+        });
 
         let msg = map_event_to_protobuf(&event, &None).unwrap();
         assert_eq!(msg.event_type, EventType::DownloadCompleted as i32);
@@ -583,7 +570,7 @@ mod tests {
     fn test_download_failed_event_mapping() {
         use crate::downloader::DownloadFailureKind;
 
-        let event = DownloadManagerEvent::DownloadFailed {
+        let event = DownloadManagerEvent::Terminal(DownloadTerminalEvent::Failed {
             download_id: "dl-1".to_string(),
             streamer_id: "streamer-123".to_string(),
             streamer_name: "streamer-123".to_string(),
@@ -591,7 +578,7 @@ mod tests {
             kind: DownloadFailureKind::Network,
             error: "Connection timeout".to_string(),
             recoverable: true,
-        };
+        });
 
         let msg = map_event_to_protobuf(&event, &None).unwrap();
         assert_eq!(msg.event_type, EventType::DownloadFailed as i32);
@@ -607,13 +594,13 @@ mod tests {
 
     #[test]
     fn test_download_cancelled_event_mapping() {
-        let event = DownloadManagerEvent::DownloadCancelled {
+        let event = DownloadManagerEvent::Terminal(DownloadTerminalEvent::Cancelled {
             download_id: "dl-1".to_string(),
             streamer_id: "streamer-123".to_string(),
             streamer_name: "streamer-123".to_string(),
             session_id: "session-1".to_string(),
             cause: crate::downloader::DownloadStopCause::User,
-        };
+        });
 
         let msg = map_event_to_protobuf(&event, &None).unwrap();
         assert_eq!(msg.event_type, EventType::DownloadCancelled as i32);
@@ -629,14 +616,14 @@ mod tests {
 
     #[test]
     fn test_download_rejected_event_mapping() {
-        let event = DownloadManagerEvent::DownloadRejected {
+        let event = DownloadManagerEvent::Terminal(DownloadTerminalEvent::Rejected {
             streamer_id: "streamer-123".to_string(),
             streamer_name: "streamer-123".to_string(),
             session_id: "session-1".to_string(),
             reason: "Circuit breaker open".to_string(),
             retry_after_secs: Some(60),
             kind: crate::downloader::DownloadRejectedKind::CircuitBreaker,
-        };
+        });
 
         let msg = map_event_to_protobuf(&event, &None).unwrap();
         assert_eq!(msg.event_type, EventType::DownloadRejected as i32);
@@ -654,7 +641,7 @@ mod tests {
 
     #[test]
     fn test_protobuf_round_trip_encoding() {
-        let event = DownloadManagerEvent::DownloadStarted {
+        let event = DownloadManagerEvent::Progress(DownloadProgressEvent::DownloadStarted {
             download_id: "dl-1".to_string(),
             streamer_id: "streamer-123".to_string(),
             streamer_name: "streamer-123".to_string(),
@@ -662,7 +649,7 @@ mod tests {
             engine_type: EngineType::Ffmpeg,
             cdn_host: "cdn.example.com".to_string(),
             download_url: "https://cdn.example.com/stream".to_string(),
-        };
+        });
 
         let msg = map_event_to_protobuf(&event, &None).unwrap();
 

--- a/rust-srec/src/downloader/manager.rs
+++ b/rust-srec/src/downloader/manager.rs
@@ -315,8 +315,32 @@ impl DownloadStopCause {
 }
 
 /// Events emitted by the Download Manager.
+///
+/// Events are grouped into two categories:
+///
+/// - [`DownloadProgressEvent`]: in-flight notifications about an ongoing
+///   download (start, progress, segment lifecycle, config changes). These do
+///   not mark a session as finished.
+/// - [`DownloadTerminalEvent`]: the download has stopped and no further events
+///   for the same `(download_id, session_id)` pair will be emitted. Consumers
+///   that need to react to "session ended" should match on this variant and
+///   use [`DownloadTerminalEvent::should_run_session_complete_pipeline`] to
+///   decide whether to fire the post-recording pipeline.
+///
+/// The split exists to make session-termination a first-class, non-droppable
+/// signal: Rust's exhaustive pattern matching forces every consumer to make
+/// an explicit decision for every terminal variant. A silent `_ => {}` on the
+/// previous flat enum is how #520 (pipeline not running on `DownloadFailed`)
+/// went unnoticed since the feature landed in PR #187.
 #[derive(Debug, Clone)]
 pub enum DownloadManagerEvent {
+    Progress(DownloadProgressEvent),
+    Terminal(DownloadTerminalEvent),
+}
+
+/// Non-terminal download notifications.
+#[derive(Debug, Clone)]
+pub enum DownloadProgressEvent {
     /// Download started.
     DownloadStarted {
         download_id: String,
@@ -361,35 +385,6 @@ pub enum DownloadManagerEvent {
         split_reason_code: Option<String>,
         split_reason_details_json: Option<String>,
     },
-    /// Download completed.
-    DownloadCompleted {
-        download_id: String,
-        streamer_id: String,
-        streamer_name: String,
-        session_id: String,
-        total_bytes: u64,
-        total_duration_secs: f64,
-        total_segments: u32,
-        file_path: Option<String>,
-    },
-    /// Download failed.
-    DownloadFailed {
-        download_id: String,
-        streamer_id: String,
-        streamer_name: String,
-        session_id: String,
-        kind: DownloadFailureKind,
-        error: String,
-        recoverable: bool,
-    },
-    /// Download cancelled.
-    DownloadCancelled {
-        download_id: String,
-        streamer_id: String,
-        streamer_name: String,
-        session_id: String,
-        cause: DownloadStopCause,
-    },
     /// Configuration was updated for a download.
     ConfigUpdated {
         download_id: String,
@@ -404,12 +399,56 @@ pub enum DownloadManagerEvent {
         streamer_name: String,
         error: String,
     },
+}
+
+/// Terminal download notifications: the download has stopped, no further
+/// events for the same `(download_id, session_id)` pair will be emitted.
+///
+/// Consumers that need to react to "session ended" (notifications, pipeline
+/// scheduling, DB status updates, …) should centralise on this enum and call
+/// [`Self::should_run_session_complete_pipeline`] rather than re-deriving
+/// the policy per site.
+#[derive(Debug, Clone)]
+pub enum DownloadTerminalEvent {
+    /// Download completed normally — all segments flushed, outputs finalised.
+    Completed {
+        download_id: String,
+        streamer_id: String,
+        streamer_name: String,
+        session_id: String,
+        total_bytes: u64,
+        total_duration_secs: f64,
+        total_segments: u32,
+        file_path: Option<String>,
+    },
+    /// Download failed — the engine gave up. Whatever output is on disk is
+    /// final; no more segments will arrive.
+    Failed {
+        download_id: String,
+        streamer_id: String,
+        streamer_name: String,
+        session_id: String,
+        kind: DownloadFailureKind,
+        error: String,
+        recoverable: bool,
+    },
+    /// Download cancelled — stop requested externally (e.g. user, streamer
+    /// disabled, shutdown). A final `Completed` may still arrive once the
+    /// engine flushes the in-flight segment, so this variant is not treated
+    /// as "session complete" by default.
+    Cancelled {
+        download_id: String,
+        streamer_id: String,
+        streamer_name: String,
+        session_id: String,
+        cause: DownloadStopCause,
+    },
     /// Download was rejected before starting (e.g., circuit breaker open,
     /// output-root filesystem unwritable).
     ///
-    /// Unlike DownloadFailed, this indicates the download never started.
-    /// No download_id is available because the download was never created.
-    DownloadRejected {
+    /// Unlike [`Self::Failed`], this indicates the download never started.
+    /// No `download_id` is available because the download was never created.
+    Rejected {
         streamer_id: String,
         streamer_name: String,
         session_id: String,
@@ -422,6 +461,127 @@ pub enum DownloadManagerEvent {
         /// and, ultimately, the correct [`crate::monitor::InfraBlockReason`].
         kind: DownloadRejectedKind,
     },
+}
+
+impl DownloadManagerEvent {
+    /// Streamer id shared across both progress and terminal event shapes.
+    pub fn streamer_id(&self) -> &str {
+        match self {
+            Self::Progress(p) => p.streamer_id(),
+            Self::Terminal(t) => t.streamer_id(),
+        }
+    }
+
+    /// Streamer display name shared across both shapes.
+    pub fn streamer_name(&self) -> &str {
+        match self {
+            Self::Progress(p) => p.streamer_name(),
+            Self::Terminal(t) => t.streamer_name(),
+        }
+    }
+
+    /// Recording session id. Present on every variant.
+    pub fn session_id(&self) -> &str {
+        match self {
+            Self::Progress(p) => p.session_id(),
+            Self::Terminal(t) => t.session_id(),
+        }
+    }
+}
+
+impl DownloadProgressEvent {
+    pub fn streamer_id(&self) -> &str {
+        match self {
+            Self::DownloadStarted { streamer_id, .. }
+            | Self::Progress { streamer_id, .. }
+            | Self::SegmentStarted { streamer_id, .. }
+            | Self::SegmentCompleted { streamer_id, .. }
+            | Self::ConfigUpdated { streamer_id, .. }
+            | Self::ConfigUpdateFailed { streamer_id, .. } => streamer_id,
+        }
+    }
+
+    pub fn streamer_name(&self) -> &str {
+        match self {
+            Self::DownloadStarted { streamer_name, .. }
+            | Self::Progress { streamer_name, .. }
+            | Self::SegmentStarted { streamer_name, .. }
+            | Self::SegmentCompleted { streamer_name, .. }
+            | Self::ConfigUpdated { streamer_name, .. }
+            | Self::ConfigUpdateFailed { streamer_name, .. } => streamer_name,
+        }
+    }
+
+    /// `session_id` is always present on live download events, but `ConfigUpdated`
+    /// and `ConfigUpdateFailed` carry none today (they're scoped to a
+    /// `download_id`). Returns an empty string for those variants — callers
+    /// that need a real session id should only call this on variants that
+    /// have one.
+    pub fn session_id(&self) -> &str {
+        match self {
+            Self::DownloadStarted { session_id, .. }
+            | Self::Progress { session_id, .. }
+            | Self::SegmentStarted { session_id, .. }
+            | Self::SegmentCompleted { session_id, .. } => session_id,
+            Self::ConfigUpdated { .. } | Self::ConfigUpdateFailed { .. } => "",
+        }
+    }
+}
+
+impl DownloadTerminalEvent {
+    pub fn streamer_id(&self) -> &str {
+        match self {
+            Self::Completed { streamer_id, .. }
+            | Self::Failed { streamer_id, .. }
+            | Self::Cancelled { streamer_id, .. }
+            | Self::Rejected { streamer_id, .. } => streamer_id,
+        }
+    }
+
+    pub fn streamer_name(&self) -> &str {
+        match self {
+            Self::Completed { streamer_name, .. }
+            | Self::Failed { streamer_name, .. }
+            | Self::Cancelled { streamer_name, .. }
+            | Self::Rejected { streamer_name, .. } => streamer_name,
+        }
+    }
+
+    pub fn session_id(&self) -> &str {
+        match self {
+            Self::Completed { session_id, .. }
+            | Self::Failed { session_id, .. }
+            | Self::Cancelled { session_id, .. }
+            | Self::Rejected { session_id, .. } => session_id,
+        }
+    }
+
+    /// `download_id` is present for every terminal variant except
+    /// [`Self::Rejected`] (rejection happens before the download is created).
+    pub fn download_id(&self) -> Option<&str> {
+        match self {
+            Self::Completed { download_id, .. }
+            | Self::Failed { download_id, .. }
+            | Self::Cancelled { download_id, .. } => Some(download_id),
+            Self::Rejected { .. } => None,
+        }
+    }
+
+    /// Whether this termination represents the recording session reaching a
+    /// final state with outputs on disk that are ready for post-processing.
+    ///
+    /// - [`Self::Completed`]: `true` — normal end, outputs finalised.
+    /// - [`Self::Failed`]: `true` — the engine gave up; whatever's on disk
+    ///   is final. Prior to this method existing, sessions that ended this
+    ///   way silently skipped the session-complete pipeline.
+    /// - [`Self::Cancelled`]: `false` — cancellation is a stop *request*; a
+    ///   `Completed` may still arrive once the engine flushes the final
+    ///   segment. Firing the pipeline early would cause missing inputs.
+    /// - [`Self::Rejected`]: `false` — the download never started, no
+    ///   outputs exist.
+    pub fn should_run_session_complete_pipeline(&self) -> bool {
+        matches!(self, Self::Completed { .. } | Self::Failed { .. })
+    }
 }
 
 /// Reason a [`DownloadManagerEvent::DownloadRejected`] event was emitted.
@@ -573,14 +733,14 @@ impl DownloadManager {
             );
 
             // Emit rejection event for visibility
-            let _ = self.event_tx.send(DownloadManagerEvent::DownloadRejected {
+            let _ = self.event_tx.send(DownloadManagerEvent::Terminal(DownloadTerminalEvent::Rejected {
                 streamer_id: config.streamer_id.clone(),
                 streamer_name: config.streamer_name.clone(),
                 session_id: config.session_id.clone(),
                 reason: format!("Circuit breaker open for engine {}", engine_key),
                 retry_after_secs: Some(self.config.read().circuit_breaker_cooldown_secs),
                 kind: DownloadRejectedKind::CircuitBreaker,
-            });
+            }));
 
             // Try to find an alternative engine
             // For now, fallback to default ffmpeg if validation fails
@@ -604,7 +764,7 @@ impl DownloadManager {
                 "Output root gate rejected download (Degraded); emitting DownloadRejected"
             );
             let cooldown = super::output_root_gate::DEFAULT_GATE_COOLDOWN_SECS;
-            let _ = self.event_tx.send(DownloadManagerEvent::DownloadRejected {
+            let _ = self.event_tx.send(DownloadManagerEvent::Terminal(DownloadTerminalEvent::Rejected {
                 streamer_id: config.streamer_id.clone(),
                 streamer_name: config.streamer_name.clone(),
                 session_id: config.session_id.clone(),
@@ -614,7 +774,7 @@ impl DownloadManager {
                     path: blocked.root.clone(),
                     io_kind: blocked.kind,
                 },
-            });
+            }));
             return Err(crate::Error::Other(format!(
                 "Output root {} is unwritable ({}); gate has the filesystem in Degraded state",
                 blocked.root.display(),
@@ -951,14 +1111,14 @@ impl DownloadManager {
                     .unwrap_or_else(|| {
                         super::output_root_gate::resolve_root(&config.output_dir, &[])
                     });
-                let _ = self.event_tx.send(DownloadManagerEvent::DownloadRejected {
+                let _ = self.event_tx.send(DownloadManagerEvent::Terminal(DownloadTerminalEvent::Rejected {
                     streamer_id: config.streamer_id.clone(),
                     streamer_name: config.streamer_name.clone(),
                     session_id: config.session_id.clone(),
                     reason: engine_err.message.clone(),
                     retry_after_secs: Some(super::output_root_gate::DEFAULT_GATE_COOLDOWN_SECS),
                     kind: DownloadRejectedKind::OutputRootUnavailable { path, io_kind },
-                });
+                }));
             }
             return Err(crate::Error::Other(engine_err.message));
         }
@@ -1020,7 +1180,7 @@ impl DownloadManager {
         );
 
         // Emit start event (broadcast send is synchronous, ignore if no receivers)
-        let _ = self.event_tx.send(DownloadManagerEvent::DownloadStarted {
+        let _ = self.event_tx.send(DownloadManagerEvent::Progress(DownloadProgressEvent::DownloadStarted {
             download_id: download_id.clone(),
             streamer_id: config.streamer_id.clone(),
             streamer_name: config.streamer_name.clone(),
@@ -1028,7 +1188,7 @@ impl DownloadManager {
             engine_type,
             cdn_host,
             download_url: config.url.clone(),
-        });
+        }));
 
         info!(
             "Starting download {} for streamer {} with engine {}",
@@ -1112,7 +1272,7 @@ impl DownloadManager {
                         });
 
                         // Broadcast send is synchronous, ignore if no receivers
-                        let _ = event_tx.send(DownloadManagerEvent::SegmentCompleted {
+                        let _ = event_tx.send(DownloadManagerEvent::Progress(DownloadProgressEvent::SegmentCompleted {
                             download_id: download_id_clone.clone(),
                             streamer_id: streamer_id.clone(),
                             streamer_name: streamer_name.clone(),
@@ -1125,7 +1285,7 @@ impl DownloadManager {
                             size_bytes,
                             split_reason_code,
                             split_reason_details_json,
-                        });
+                        }));
 
                         if let Some(mut download) = active_downloads.get_mut(&download_id_clone) {
                             download.output_path = Some(segment_path);
@@ -1150,14 +1310,14 @@ impl DownloadManager {
                         // Broadcast progress event to WebSocket subscribers (throttled).
                         if last_progress_emit.elapsed() >= PROGRESS_MIN_INTERVAL {
                             last_progress_emit = Instant::now();
-                            let _ = event_tx.send(DownloadManagerEvent::Progress {
+                            let _ = event_tx.send(DownloadManagerEvent::Progress(DownloadProgressEvent::Progress {
                                 download_id: download_id_clone.clone(),
                                 streamer_id: streamer_id.clone(),
                                 streamer_name: streamer_name.clone(),
                                 session_id: session_id.clone(),
                                 status: DownloadStatus::Downloading,
                                 progress,
-                            });
+                            }));
                         }
                     }
                     SegmentEvent::DownloadCompleted {
@@ -1171,14 +1331,14 @@ impl DownloadManager {
                         // Emit one final progress update before sending the terminal event.
                         if let Some(download) = active_downloads.get(&download_id_clone) {
                             let final_progress = download.progress.clone();
-                            let _ = event_tx.send(DownloadManagerEvent::Progress {
+                            let _ = event_tx.send(DownloadManagerEvent::Progress(DownloadProgressEvent::Progress {
                                 download_id: download_id_clone.clone(),
                                 streamer_id: streamer_id.clone(),
                                 streamer_name: streamer_name.clone(),
                                 session_id: session_id.clone(),
                                 status: DownloadStatus::Downloading,
                                 progress: final_progress,
-                            });
+                            }));
                         }
 
                         // remove download from active_downloads
@@ -1198,7 +1358,7 @@ impl DownloadManager {
                         normal_limit.apply_best_effort();
                         high_priority_limit.apply_best_effort();
 
-                        let _ = event_tx.send(DownloadManagerEvent::DownloadCompleted {
+                        let _ = event_tx.send(DownloadManagerEvent::Terminal(DownloadTerminalEvent::Completed {
                             download_id: download_id_clone.clone(),
                             streamer_id: streamer_id.clone(),
                             streamer_name: streamer_name.clone(),
@@ -1207,7 +1367,7 @@ impl DownloadManager {
                             total_duration_secs,
                             total_segments,
                             file_path: output_path,
-                        });
+                        }));
 
                         debug!(
                             download_id = %download_id_clone,
@@ -1240,14 +1400,14 @@ impl DownloadManager {
                         // Emit one final progress update (best-effort) before the failure event.
                         if let Some(download) = active_downloads.get(&download_id_clone) {
                             let final_progress = download.progress.clone();
-                            let _ = event_tx.send(DownloadManagerEvent::Progress {
+                            let _ = event_tx.send(DownloadManagerEvent::Progress(DownloadProgressEvent::Progress {
                                 download_id: download_id_clone.clone(),
                                 streamer_id: streamer_id.clone(),
                                 streamer_name: streamer_name.clone(),
                                 session_id: session_id.clone(),
                                 status: DownloadStatus::Downloading,
                                 progress: final_progress,
-                            });
+                            }));
                         }
 
                         // remove download from active_downloads
@@ -1258,7 +1418,7 @@ impl DownloadManager {
                         normal_limit.apply_best_effort();
                         high_priority_limit.apply_best_effort();
 
-                        let _ = event_tx.send(DownloadManagerEvent::DownloadFailed {
+                        let _ = event_tx.send(DownloadManagerEvent::Terminal(DownloadTerminalEvent::Failed {
                             download_id: download_id_clone.clone(),
                             streamer_id: streamer_id.clone(),
                             streamer_name: streamer_name.clone(),
@@ -1266,7 +1426,7 @@ impl DownloadManager {
                             kind,
                             error: message,
                             recoverable,
-                        });
+                        }));
 
                         break;
                     }
@@ -1284,7 +1444,7 @@ impl DownloadManager {
                         }
 
                         // Emit segment started event
-                        let _ = event_tx.send(DownloadManagerEvent::SegmentStarted {
+                        let _ = event_tx.send(DownloadManagerEvent::Progress(DownloadProgressEvent::SegmentStarted {
                             download_id: download_id_clone.clone(),
                             streamer_id: streamer_id.clone(),
                             streamer_name: streamer_name.clone(),
@@ -1292,7 +1452,7 @@ impl DownloadManager {
                             segment_path: segment_path.clone(),
                             segment_index: sequence,
                             started_at,
-                        });
+                        }));
 
                         if let Some((_, pending_update)) =
                             pending_updates.remove(&download_id_clone)
@@ -1343,14 +1503,14 @@ impl DownloadManager {
             let session_id = config_snap.session_id;
 
             // Emit one final progress update before cancellation.
-            let _ = self.event_tx.send(DownloadManagerEvent::Progress {
+            let _ = self.event_tx.send(DownloadManagerEvent::Progress(DownloadProgressEvent::Progress {
                 download_id: download_id.to_string(),
                 streamer_id: streamer_id.clone(),
                 streamer_name: streamer_name.clone(),
                 session_id: session_id.clone(),
                 status: DownloadStatus::Cancelled,
                 progress: download.progress.clone(),
-            });
+            }));
 
             if let Some(engine) = self.get_engine(engine_type) {
                 engine.stop(&download.handle).await?;
@@ -1359,13 +1519,13 @@ impl DownloadManager {
             self.pending_updates.remove(download_id);
 
             // Broadcast send is synchronous, ignore if no receivers
-            let _ = self.event_tx.send(DownloadManagerEvent::DownloadCancelled {
+            let _ = self.event_tx.send(DownloadManagerEvent::Terminal(DownloadTerminalEvent::Cancelled {
                 download_id: download_id.to_string(),
                 streamer_id,
                 streamer_name,
                 session_id,
                 cause,
-            });
+            }));
 
             info!("Stopped download {}", download_id);
 
@@ -1631,12 +1791,12 @@ impl DownloadManager {
             .map(|d| d.handle.config.read().streamer_name.clone())
             .unwrap_or_else(|| streamer_id.to_string());
 
-        let event = DownloadManagerEvent::ConfigUpdated {
+        let event = DownloadManagerEvent::Progress(DownloadProgressEvent::ConfigUpdated {
             download_id: download_id.to_string(),
             streamer_id: streamer_id.to_string(),
             streamer_name,
             update_type,
-        };
+        });
 
         // Broadcast send returns Ok if at least one receiver got the message
         // Returns Err if there are no receivers, which is fine
@@ -1681,12 +1841,12 @@ impl DownloadManager {
             .map(|d| d.handle.config.read().streamer_name.clone())
             .unwrap_or_else(|| streamer_id.to_string());
 
-        let event = DownloadManagerEvent::ConfigUpdateFailed {
+        let event = DownloadManagerEvent::Progress(DownloadProgressEvent::ConfigUpdateFailed {
             download_id: download_id.to_string(),
             streamer_id: streamer_id.to_string(),
             streamer_name,
             error: error.to_string(),
-        };
+        });
 
         match self.event_tx.send(event) {
             Ok(_) => {
@@ -1776,12 +1936,12 @@ impl DownloadManager {
         if applied {
             let update_type = Self::determine_config_update_type(&update_clone);
             let streamer_name = download.handle.config.read().streamer_name.clone();
-            let _ = event_tx.send(DownloadManagerEvent::ConfigUpdated {
+            let _ = event_tx.send(DownloadManagerEvent::Progress(DownloadProgressEvent::ConfigUpdated {
                 download_id: download_id.to_string(),
                 streamer_id: streamer_id.to_string(),
                 streamer_name,
                 update_type,
-            });
+            }));
         }
     }
 
@@ -1988,12 +2148,12 @@ mod tests {
         // Verify the event was received
         let event = receiver.try_recv().unwrap();
         match event {
-            DownloadManagerEvent::ConfigUpdated {
+            DownloadManagerEvent::Progress(DownloadProgressEvent::ConfigUpdated {
                 download_id,
                 streamer_id,
                 update_type,
                 ..
-            } => {
+            }) => {
                 assert_eq!(download_id, "download-123");
                 assert_eq!(streamer_id, "streamer-456");
                 assert_eq!(update_type, ConfigUpdateType::Cookies);
@@ -2026,12 +2186,12 @@ mod tests {
         // Verify the event was received
         let event = receiver.try_recv().unwrap();
         match event {
-            DownloadManagerEvent::ConfigUpdateFailed {
+            DownloadManagerEvent::Progress(DownloadProgressEvent::ConfigUpdateFailed {
                 download_id,
                 streamer_id,
                 error,
                 ..
-            } => {
+            }) => {
                 assert_eq!(download_id, "download-123");
                 assert_eq!(streamer_id, "streamer-456");
                 assert_eq!(error, "Connection timeout");

--- a/rust-srec/src/downloader/mod.rs
+++ b/rust-srec/src/downloader/mod.rs
@@ -27,7 +27,7 @@ pub use output_root_gate::{
 
 pub use manager::{
     ConfigUpdateType, DownloadManager, DownloadManagerConfig, DownloadManagerEvent,
-    DownloadRejectedKind, DownloadStopCause,
+    DownloadProgressEvent, DownloadRejectedKind, DownloadStopCause, DownloadTerminalEvent,
 };
 pub use resilience::{CircuitBreaker, EngineKey, RetryConfig};
 pub use stream_selector::{StreamSelectionConfig, StreamSelector};

--- a/rust-srec/src/notification/service.rs
+++ b/rust-srec/src/notification/service.rs
@@ -41,7 +41,7 @@ use crate::database::models::{
     TelegramChannelSettings, WebhookChannelSettings,
 };
 use crate::database::repositories::NotificationRepository;
-use crate::downloader::DownloadManagerEvent;
+use crate::downloader::{DownloadManagerEvent, DownloadProgressEvent, DownloadTerminalEvent};
 use crate::monitor::MonitorEvent;
 use crate::pipeline::PipelineEvent;
 
@@ -1551,25 +1551,25 @@ impl NotificationService {
                                 }
 
                                 let notification = match event {
-                                    DownloadManagerEvent::DownloadStarted {
+                                    DownloadManagerEvent::Progress(DownloadProgressEvent::DownloadStarted {
                                         streamer_id,
                                         streamer_name,
                                         session_id,
                                         ..
-                                    } => Some(NotificationEvent::DownloadStarted {
+                                    }) => Some(NotificationEvent::DownloadStarted {
                                         streamer_id,
                                         streamer_name,
                                         session_id,
                                         timestamp: Utc::now(),
                                     }),
-                                    DownloadManagerEvent::DownloadCompleted {
+                                    DownloadManagerEvent::Terminal(DownloadTerminalEvent::Completed {
                                         streamer_id,
                                         streamer_name,
                                         session_id,
                                         total_bytes,
                                         total_duration_secs,
                                         ..
-                                    } => Some(NotificationEvent::DownloadCompleted {
+                                    }) => Some(NotificationEvent::DownloadCompleted {
                                         streamer_id,
                                         streamer_name,
                                         session_id,
@@ -1577,20 +1577,20 @@ impl NotificationService {
                                         duration_secs: total_duration_secs,
                                         timestamp: Utc::now(),
                                     }),
-                                    DownloadManagerEvent::DownloadFailed {
+                                    DownloadManagerEvent::Terminal(DownloadTerminalEvent::Failed {
                                         streamer_id,
                                         streamer_name,
                                         error,
                                         recoverable,
                                         ..
-                                    } => Some(NotificationEvent::DownloadError {
+                                    }) => Some(NotificationEvent::DownloadError {
                                         streamer_id,
                                         streamer_name,
                                         error_message: error,
                                         recoverable,
                                         timestamp: Utc::now(),
                                     }),
-                                    DownloadManagerEvent::SegmentStarted {
+                                    DownloadManagerEvent::Progress(DownloadProgressEvent::SegmentStarted {
                                         streamer_id,
                                         streamer_name,
                                         session_id,
@@ -1598,7 +1598,7 @@ impl NotificationService {
                                         segment_index,
                                         started_at,
                                         ..
-                                    } => Some(NotificationEvent::SegmentStarted {
+                                    }) => Some(NotificationEvent::SegmentStarted {
                                         streamer_id,
                                         streamer_name,
                                         session_id,
@@ -1606,7 +1606,7 @@ impl NotificationService {
                                         segment_index,
                                         timestamp: started_at,
                                     }),
-                                    DownloadManagerEvent::SegmentCompleted {
+                                    DownloadManagerEvent::Progress(DownloadProgressEvent::SegmentCompleted {
                                         streamer_id,
                                         streamer_name,
                                         session_id,
@@ -1616,7 +1616,7 @@ impl NotificationService {
                                         duration_secs,
                                         size_bytes,
                                         ..
-                                    } => Some(NotificationEvent::SegmentCompleted {
+                                    }) => Some(NotificationEvent::SegmentCompleted {
                                         streamer_id,
                                         streamer_name,
                                         session_id,
@@ -1626,36 +1626,36 @@ impl NotificationService {
                                         duration_secs,
                                         timestamp: completed_at,
                                     }),
-                                    DownloadManagerEvent::DownloadCancelled {
+                                    DownloadManagerEvent::Terminal(DownloadTerminalEvent::Cancelled {
                                         streamer_id,
                                         streamer_name,
                                         session_id,
                                         ..
-                                    } => Some(NotificationEvent::DownloadCancelled {
+                                    }) => Some(NotificationEvent::DownloadCancelled {
                                         streamer_id,
                                         streamer_name,
                                         session_id,
                                         timestamp: Utc::now(),
                                     }),
-                                    DownloadManagerEvent::DownloadRejected {
+                                    DownloadManagerEvent::Terminal(DownloadTerminalEvent::Rejected {
                                         streamer_id,
                                         streamer_name,
                                         session_id,
                                         reason,
                                         ..
-                                    } => Some(NotificationEvent::DownloadRejected {
+                                    }) => Some(NotificationEvent::DownloadRejected {
                                         streamer_id,
                                         streamer_name,
                                         session_id,
                                         reason,
                                         timestamp: Utc::now(),
                                     }),
-                                    DownloadManagerEvent::ConfigUpdated {
+                                    DownloadManagerEvent::Progress(DownloadProgressEvent::ConfigUpdated {
                                         streamer_id,
                                         streamer_name,
                                         update_type,
                                         ..
-                                    } => Some(NotificationEvent::ConfigUpdated {
+                                    }) => Some(NotificationEvent::ConfigUpdated {
                                         streamer_id,
                                         streamer_name,
                                         update_type: format!("{:?}", update_type),
@@ -2067,7 +2067,7 @@ mod tests {
         let started_at = Utc::now();
         let completed_at = started_at + chrono::Duration::seconds(10);
 
-        let started_event = match (DownloadManagerEvent::SegmentStarted {
+        let started_event = match DownloadManagerEvent::Progress(DownloadProgressEvent::SegmentStarted {
             download_id: "dl-1".to_string(),
             streamer_id: "streamer-1".to_string(),
             streamer_name: "Streamer".to_string(),
@@ -2076,7 +2076,7 @@ mod tests {
             segment_index: 1,
             started_at,
         }) {
-            DownloadManagerEvent::SegmentStarted {
+            DownloadManagerEvent::Progress(DownloadProgressEvent::SegmentStarted {
                 streamer_id,
                 streamer_name,
                 session_id,
@@ -2084,7 +2084,7 @@ mod tests {
                 segment_index,
                 started_at,
                 ..
-            } => NotificationEvent::SegmentStarted {
+            }) => NotificationEvent::SegmentStarted {
                 streamer_id,
                 streamer_name,
                 session_id,
@@ -2095,7 +2095,7 @@ mod tests {
             _ => unreachable!(),
         };
 
-        let completed_event = match (DownloadManagerEvent::SegmentCompleted {
+        let completed_event = match DownloadManagerEvent::Progress(DownloadProgressEvent::SegmentCompleted {
             download_id: "dl-1".to_string(),
             streamer_id: "streamer-1".to_string(),
             streamer_name: "Streamer".to_string(),
@@ -2109,7 +2109,7 @@ mod tests {
             split_reason_code: None,
             split_reason_details_json: None,
         }) {
-            DownloadManagerEvent::SegmentCompleted {
+            DownloadManagerEvent::Progress(DownloadProgressEvent::SegmentCompleted {
                 streamer_id,
                 streamer_name,
                 session_id,
@@ -2119,7 +2119,7 @@ mod tests {
                 duration_secs,
                 size_bytes,
                 ..
-            } => NotificationEvent::SegmentCompleted {
+            }) => NotificationEvent::SegmentCompleted {
                 streamer_id,
                 streamer_name,
                 session_id,

--- a/rust-srec/src/pipeline/manager.rs
+++ b/rust-srec/src/pipeline/manager.rs
@@ -39,7 +39,7 @@ use crate::database::repositories::streamer::{SqlxStreamerRepository, StreamerRe
 use crate::database::repositories::{
     DagRepository, JobPresetRepository, JobRepository, PipelinePresetRepository, SessionRepository,
 };
-use crate::downloader::DownloadManagerEvent;
+use crate::downloader::{DownloadManagerEvent, DownloadProgressEvent, DownloadTerminalEvent};
 use crate::utils::filename::sanitize_filename;
 
 type BeforeRootJobsHook = Box<dyn FnOnce(&str) + Send>;
@@ -1949,7 +1949,7 @@ where
     /// Handle download manager events.
     pub async fn handle_download_event(&self, event: DownloadManagerEvent) {
         match event {
-            DownloadManagerEvent::SegmentCompleted {
+            DownloadManagerEvent::Progress(DownloadProgressEvent::SegmentCompleted {
                 streamer_id,
                 session_id,
                 segment_path,
@@ -1961,7 +1961,7 @@ where
                 split_reason_code,
                 split_reason_details_json,
                 ..
-            } => {
+            }) => {
                 debug!(
                     "Segment completed for {} (session: {}): {}",
                     streamer_id, session_id, segment_path
@@ -2162,75 +2162,144 @@ where
                     self.try_trigger_session_complete(&session_id).await;
                 }
             }
-            DownloadManagerEvent::DownloadCompleted {
-                streamer_id,
-                session_id,
+            DownloadManagerEvent::Terminal(terminal) => {
+                self.handle_terminal_download_event(terminal).await;
+            }
+            // All other Progress variants are no-ops here (DownloadStarted,
+            // Progress, SegmentStarted, ConfigUpdated, ConfigUpdateFailed).
+            // The session-scoped pipeline only reacts to SegmentCompleted and
+            // the Terminal variants handled above.
+            DownloadManagerEvent::Progress(
+                DownloadProgressEvent::DownloadStarted { .. }
+                | DownloadProgressEvent::Progress { .. }
+                | DownloadProgressEvent::SegmentStarted { .. }
+                | DownloadProgressEvent::ConfigUpdated { .. }
+                | DownloadProgressEvent::ConfigUpdateFailed { .. },
+            ) => {}
+        }
+    }
+
+    /// Handle a terminal download event. Each variant has a distinct log line
+    /// and bookkeeping step, then the shared session-complete dispatch runs
+    /// iff the variant's termination policy says the pipeline should fire
+    /// (see [`DownloadTerminalEvent::should_run_session_complete_pipeline`]).
+    async fn handle_terminal_download_event(&self, event: DownloadTerminalEvent) {
+        let streamer_id = event.streamer_id().to_owned();
+        let session_id = event.session_id().to_owned();
+
+        // Per-variant logging.
+        match &event {
+            DownloadTerminalEvent::Completed { .. } => {
+                info!(
+                    streamer_id = %streamer_id,
+                    session_id = %session_id,
+                    "Download completed"
+                );
+            }
+            DownloadTerminalEvent::Failed {
+                kind,
+                error,
+                recoverable,
                 ..
             } => {
                 info!(
-                    "Download completed for streamer {} session {}",
-                    streamer_id, session_id
+                    streamer_id = %streamer_id,
+                    session_id = %session_id,
+                    kind = ?kind,
+                    recoverable = %recoverable,
+                    error = %error,
+                    "Download failed"
                 );
-
-                if !self.session_complete_pipelines.contains_key(&session_id)
-                    && let Some(config_service) = &self.config_service
-                    && let Ok(config) = config_service.get_config_for_streamer(&streamer_id).await
-                    && let Some(def) = config.session_complete_pipeline.clone()
-                {
-                    self.session_complete_pipelines.insert(
-                        session_id.clone(),
-                        SessionCompletePipelineEntry {
-                            last_seen: std::time::Instant::now(),
-                            definition: def,
-                        },
-                    );
-                    self.session_complete_coordinator.init_session(
-                        &session_id,
-                        &streamer_id,
-                        config.record_danmu,
-                    );
-                }
-
-                if self.session_complete_pipelines.contains_key(&session_id) {
-                    if let Some(mut entry) = self.session_complete_pipelines.get_mut(&session_id) {
-                        entry.last_seen = std::time::Instant::now();
-                    }
-                    self.session_complete_coordinator
-                        .on_video_complete(&session_id);
-                    self.try_trigger_session_complete(&session_id).await;
-                }
             }
-            DownloadManagerEvent::DownloadCancelled {
-                streamer_id,
-                session_id,
-                cause,
-                ..
-            } => {
+            DownloadTerminalEvent::Cancelled { cause, .. } => {
                 info!(
                     streamer_id = %streamer_id,
                     session_id = %session_id,
                     cause = %cause.as_str(),
                     "Download cancelled"
                 );
-
-                // Do not treat DownloadCancelled as stream completion for session-complete purposes.
-                //
-                // On mesio (and other engines), cancellation is a *stop request*; the final segment
-                // may still be flushing and `SegmentCompleted`/`DownloadCompleted` can arrive later.
-                // Marking video complete here can trigger the session-complete pipeline before the
-                // final video output is recorded, resulting in missing `.flv` inputs/outputs.
-                if let Some(mut entry) = self.session_complete_pipelines.get_mut(&session_id) {
-                    entry.last_seen = std::time::Instant::now();
-                }
-                debug!(
+            }
+            DownloadTerminalEvent::Rejected { reason, kind, .. } => {
+                info!(
                     streamer_id = %streamer_id,
                     session_id = %session_id,
-                    cause = %cause.as_str(),
-                    "Download cancellation observed; waiting for DownloadCompleted before marking video complete"
+                    kind = ?kind,
+                    reason = %reason,
+                    "Download rejected"
                 );
             }
-            _ => {}
         }
+
+        // Refresh the cache entry's last_seen regardless of variant so that
+        // an observed Cancelled/Rejected doesn't let the entry GC while we
+        // wait for a subsequent Completed to arrive.
+        if let Some(mut entry) = self.session_complete_pipelines.get_mut(&session_id) {
+            entry.last_seen = std::time::Instant::now();
+        }
+
+        if !event.should_run_session_complete_pipeline() {
+            // Cancelled is a stop *request* on mesio and other engines; the
+            // final segment may still be flushing and `SegmentCompleted` /
+            // `DownloadCompleted` can arrive later. Firing here would cause
+            // missing `.flv` inputs/outputs.
+            // Rejected means the download never started — nothing on disk.
+            debug!(
+                streamer_id = %streamer_id,
+                session_id = %session_id,
+                variant = ?std::mem::discriminant(&event),
+                "Terminal event does not trigger session-complete pipeline; skipping"
+            );
+            return;
+        }
+
+        // Completed and Failed both indicate a session has reached its
+        // definitive final state with outputs on disk. Run the same
+        // bootstrap + trigger sequence the Completed arm used to run alone —
+        // this is the fix for #520 (session-complete pipeline not running
+        // when the engine ends with DownloadFailed rather than
+        // DownloadCompleted).
+        self.ensure_session_complete_pipeline_initialised(&streamer_id, &session_id)
+            .await;
+
+        if self.session_complete_pipelines.contains_key(&session_id) {
+            self.session_complete_coordinator
+                .on_video_complete(&session_id);
+            self.try_trigger_session_complete(&session_id).await;
+        }
+    }
+
+    /// Load the session-complete pipeline config for the streamer (if any)
+    /// and register it in `session_complete_pipelines`. Idempotent —
+    /// re-calling for the same session is a no-op.
+    async fn ensure_session_complete_pipeline_initialised(
+        &self,
+        streamer_id: &str,
+        session_id: &str,
+    ) {
+        if self.session_complete_pipelines.contains_key(session_id) {
+            return;
+        }
+        let Some(config_service) = &self.config_service else {
+            return;
+        };
+        let Ok(config) = config_service.get_config_for_streamer(streamer_id).await else {
+            return;
+        };
+        let Some(def) = config.session_complete_pipeline.clone() else {
+            return;
+        };
+        self.session_complete_pipelines.insert(
+            session_id.to_owned(),
+            SessionCompletePipelineEntry {
+                last_seen: std::time::Instant::now(),
+                definition: def,
+            },
+        );
+        self.session_complete_coordinator.init_session(
+            session_id,
+            streamer_id,
+            config.record_danmu,
+        );
     }
 
     /// Handle danmu service events.
@@ -2628,11 +2697,11 @@ where
                     }
                     event = rx.recv() => {
                         match event {
-                            Some(DownloadManagerEvent::DownloadCompleted {
+                            Some(DownloadManagerEvent::Terminal(DownloadTerminalEvent::Completed {
                                 streamer_id,
                                 session_id,
                                 ..
-                            }) => {
+                            })) => {
                                 info!(
                                     "Creating post-processing jobs for {} / {}",
                                     streamer_id, session_id
@@ -4691,5 +4760,197 @@ mod tests {
             .await;
         assert_eq!(manager.paired_segment_coordinator.active_pair_count(), 0);
         assert!(manager.paired_segment_pipelines.contains_key(&session_id));
+    }
+
+    // -----------------------------------------------------------------------
+    // Tests for #520 — session-complete pipeline firing on terminal download
+    // events (regression guard: Completed *and* Failed should trigger it;
+    // Cancelled and Rejected should not).
+    // -----------------------------------------------------------------------
+
+    use crate::downloader::{DownloadFailureKind, DownloadRejectedKind, DownloadStopCause};
+
+    fn completed_event(session_id: &str, streamer_id: &str) -> DownloadManagerEvent {
+        DownloadManagerEvent::Terminal(DownloadTerminalEvent::Completed {
+            download_id: "dl-1".to_string(),
+            streamer_id: streamer_id.to_string(),
+            streamer_name: "tester".to_string(),
+            session_id: session_id.to_string(),
+            total_bytes: 0,
+            total_duration_secs: 0.0,
+            total_segments: 0,
+            file_path: None,
+        })
+    }
+
+    fn failed_event(session_id: &str, streamer_id: &str) -> DownloadManagerEvent {
+        DownloadManagerEvent::Terminal(DownloadTerminalEvent::Failed {
+            download_id: "dl-1".to_string(),
+            streamer_id: streamer_id.to_string(),
+            streamer_name: "tester".to_string(),
+            session_id: session_id.to_string(),
+            kind: DownloadFailureKind::Network,
+            error: "stalled".to_string(),
+            recoverable: false,
+        })
+    }
+
+    fn cancelled_event(session_id: &str, streamer_id: &str) -> DownloadManagerEvent {
+        DownloadManagerEvent::Terminal(DownloadTerminalEvent::Cancelled {
+            download_id: "dl-1".to_string(),
+            streamer_id: streamer_id.to_string(),
+            streamer_name: "tester".to_string(),
+            session_id: session_id.to_string(),
+            cause: DownloadStopCause::User,
+        })
+    }
+
+    fn rejected_event(session_id: &str, streamer_id: &str) -> DownloadManagerEvent {
+        DownloadManagerEvent::Terminal(DownloadTerminalEvent::Rejected {
+            streamer_id: streamer_id.to_string(),
+            streamer_name: "tester".to_string(),
+            session_id: session_id.to_string(),
+            reason: "test".to_string(),
+            retry_after_secs: None,
+            kind: DownloadRejectedKind::CircuitBreaker,
+        })
+    }
+
+    /// Pure policy predicate — codifies which terminal variants trigger the
+    /// session-complete pipeline. Matches the web player's own behaviour
+    /// (Completed and Failed finalise; Cancelled may still flush a final
+    /// segment and shouldn't trigger early; Rejected never started).
+    #[test]
+    fn test_terminal_should_run_session_complete_policy() {
+        assert!(
+            matches!(completed_event("s", "r"), DownloadManagerEvent::Terminal(t) if t.should_run_session_complete_pipeline())
+        );
+        assert!(
+            matches!(failed_event("s", "r"), DownloadManagerEvent::Terminal(t) if t.should_run_session_complete_pipeline())
+        );
+        assert!(
+            !matches!(cancelled_event("s", "r"), DownloadManagerEvent::Terminal(t) if t.should_run_session_complete_pipeline())
+        );
+        assert!(
+            !matches!(rejected_event("s", "r"), DownloadManagerEvent::Terminal(t) if t.should_run_session_complete_pipeline())
+        );
+    }
+
+    /// Regression for #520: a recording that ends with `DownloadFailed` (e.g.
+    /// HLS 404, stalled stream) must still fire the session-complete pipeline.
+    /// Before the fix, the pipeline manager's `_ => {}` catch-all swallowed
+    /// `DownloadFailed` and `on_video_complete` was never called.
+    #[tokio::test]
+    async fn test_handle_download_event_failed_triggers_session_complete() {
+        let session_repo = Arc::new(TestSessionRepository::new(Some(
+            chrono::Utc::now().timestamp_millis(),
+        )));
+        let manager: PipelineManager = PipelineManager::new().with_session_repository(session_repo);
+
+        let session_id = "session-failed".to_string();
+        let streamer_id = "streamer-1".to_string();
+
+        // Pre-register the pipeline entry (bypasses the config_service lookup;
+        // the fix still uses the already-cached entry when one exists).
+        manager.session_complete_pipelines.insert(
+            session_id.clone(),
+            SessionCompletePipelineEntry {
+                last_seen: std::time::Instant::now(),
+                definition: DagPipelineDefinition::new("empty", vec![]),
+            },
+        );
+        manager
+            .session_complete_coordinator
+            .init_session(&session_id, &streamer_id, false);
+        manager.session_complete_coordinator.on_raw_segment(
+            &session_id,
+            0,
+            PathBuf::from("/seg0.ts"),
+            SourceType::Video,
+        );
+
+        manager
+            .handle_download_event(failed_event(&session_id, &streamer_id))
+            .await;
+
+        // on_video_complete was called and try_trigger_session_complete ran.
+        assert_eq!(
+            manager.session_complete_coordinator.active_session_count(),
+            0,
+            "session-complete coordinator should have been drained after Failed"
+        );
+        assert!(
+            !manager.session_complete_pipelines.contains_key(&session_id),
+            "session_complete_pipelines entry should be drained after Failed"
+        );
+    }
+
+    /// Cancelled is a stop *request*; a final `Completed` may still arrive.
+    /// Firing the pipeline early would use a missing final segment.
+    #[tokio::test]
+    async fn test_handle_download_event_cancelled_does_not_trigger_session_complete() {
+        let manager: PipelineManager = PipelineManager::new();
+
+        let session_id = "session-cancelled".to_string();
+        let streamer_id = "streamer-1".to_string();
+
+        manager.session_complete_pipelines.insert(
+            session_id.clone(),
+            SessionCompletePipelineEntry {
+                last_seen: std::time::Instant::now(),
+                definition: DagPipelineDefinition::new("empty", vec![]),
+            },
+        );
+        manager
+            .session_complete_coordinator
+            .init_session(&session_id, &streamer_id, false);
+
+        manager
+            .handle_download_event(cancelled_event(&session_id, &streamer_id))
+            .await;
+
+        assert_eq!(
+            manager.session_complete_coordinator.active_session_count(),
+            1,
+            "coordinator must still be active after Cancelled (awaiting Completed)"
+        );
+        assert!(
+            manager.session_complete_pipelines.contains_key(&session_id),
+            "pipeline entry must still be present after Cancelled (awaiting Completed)"
+        );
+    }
+
+    /// Rejected means the download never started — no outputs, nothing to run.
+    #[tokio::test]
+    async fn test_handle_download_event_rejected_does_not_trigger_session_complete() {
+        let manager: PipelineManager = PipelineManager::new();
+
+        let session_id = "session-rejected".to_string();
+        let streamer_id = "streamer-1".to_string();
+
+        manager.session_complete_pipelines.insert(
+            session_id.clone(),
+            SessionCompletePipelineEntry {
+                last_seen: std::time::Instant::now(),
+                definition: DagPipelineDefinition::new("empty", vec![]),
+            },
+        );
+        manager
+            .session_complete_coordinator
+            .init_session(&session_id, &streamer_id, false);
+
+        manager
+            .handle_download_event(rejected_event(&session_id, &streamer_id))
+            .await;
+
+        assert_eq!(
+            manager.session_complete_coordinator.active_session_count(),
+            1,
+            "coordinator must still be active after Rejected"
+        );
+        assert!(
+            manager.session_complete_pipelines.contains_key(&session_id),
+            "pipeline entry must still be present after Rejected"
+        );
     }
 }

--- a/rust-srec/src/scheduler/service.rs
+++ b/rust-srec/src/scheduler/service.rs
@@ -27,7 +27,9 @@ use crate::database::repositories::{
     ConfigRepository, FilterRepository, SessionRepository, StreamerRepository,
 };
 use crate::domain::Priority;
-use crate::downloader::{DownloadManagerEvent, DownloadStopCause};
+use crate::downloader::{
+    DownloadManagerEvent, DownloadProgressEvent, DownloadStopCause, DownloadTerminalEvent,
+};
 use crate::monitor::StreamMonitor;
 use crate::streamer::{StreamerManager, StreamerMetadata};
 
@@ -885,12 +887,12 @@ impl<R: StreamerRepository + Send + Sync + 'static> Scheduler<R> {
 
         let now = Instant::now();
         match event {
-            DownloadManagerEvent::DownloadStarted {
+            DownloadManagerEvent::Progress(DownloadProgressEvent::DownloadStarted {
                 streamer_id,
                 download_id,
                 session_id,
                 ..
-            } => {
+            }) => {
                 send_to_actor(
                     streamer_id,
                     StreamerMessage::DownloadStarted {
@@ -900,11 +902,11 @@ impl<R: StreamerRepository + Send + Sync + 'static> Scheduler<R> {
                 )
                 .await;
             }
-            DownloadManagerEvent::DownloadCompleted {
+            DownloadManagerEvent::Terminal(DownloadTerminalEvent::Completed {
                 streamer_id,
                 download_id,
                 ..
-            } => {
+            }) => {
                 if self.stopped_downloads.remove(&download_id).is_some() {
                     debug!(
                         streamer_id = %streamer_id,
@@ -919,12 +921,12 @@ impl<R: StreamerRepository + Send + Sync + 'static> Scheduler<R> {
                 )
                 .await;
             }
-            DownloadManagerEvent::DownloadFailed {
+            DownloadManagerEvent::Terminal(DownloadTerminalEvent::Failed {
                 streamer_id,
                 download_id,
                 error,
                 ..
-            } => {
+            }) => {
                 if self.stopped_downloads.remove(&download_id).is_some() {
                     debug!(
                         streamer_id = %streamer_id,
@@ -939,12 +941,12 @@ impl<R: StreamerRepository + Send + Sync + 'static> Scheduler<R> {
                 )
                 .await;
             }
-            DownloadManagerEvent::DownloadCancelled {
+            DownloadManagerEvent::Terminal(DownloadTerminalEvent::Cancelled {
                 streamer_id,
                 download_id,
                 cause,
                 ..
-            } => {
+            }) => {
                 let now_ms = crate::database::time::now_ms();
 
                 // Engines can still emit a terminal event after a stop request
@@ -990,14 +992,14 @@ impl<R: StreamerRepository + Send + Sync + 'static> Scheduler<R> {
 
                 send_to_actor(streamer_id, StreamerMessage::DownloadEnded(end_reason)).await;
             }
-            DownloadManagerEvent::DownloadRejected {
+            DownloadManagerEvent::Terminal(DownloadTerminalEvent::Rejected {
                 streamer_id,
                 reason,
                 retry_after_secs,
                 session_id,
                 kind,
                 ..
-            } => {
+            }) => {
                 let retry_secs = retry_after_secs.unwrap_or(60);
                 let policy = match kind {
                     crate::downloader::DownloadRejectedKind::CircuitBreaker => {
@@ -1019,13 +1021,13 @@ impl<R: StreamerRepository + Send + Sync + 'static> Scheduler<R> {
                 };
                 send_to_actor(streamer_id, StreamerMessage::DownloadEnded(policy)).await;
             }
-            DownloadManagerEvent::Progress {
+            DownloadManagerEvent::Progress(DownloadProgressEvent::Progress {
                 download_id,
                 streamer_id,
                 session_id,
                 progress,
                 ..
-            } => {
+            }) => {
                 let should_send = match self.download_heartbeat_last_sent.get(&streamer_id) {
                     Some(last) => now.duration_since(*last.value()) >= HEARTBEAT_THROTTLE,
                     None => true,
@@ -1044,18 +1046,18 @@ impl<R: StreamerRepository + Send + Sync + 'static> Scheduler<R> {
                     .await;
                 }
             }
-            DownloadManagerEvent::SegmentStarted {
+            DownloadManagerEvent::Progress(DownloadProgressEvent::SegmentStarted {
                 download_id,
                 streamer_id,
                 session_id,
                 ..
-            }
-            | DownloadManagerEvent::SegmentCompleted {
+            })
+            | DownloadManagerEvent::Progress(DownloadProgressEvent::SegmentCompleted {
                 download_id,
                 streamer_id,
                 session_id,
                 ..
-            } => {
+            }) => {
                 let should_send = match self.download_heartbeat_last_sent.get(&streamer_id) {
                     Some(last) => now.duration_since(*last.value()) >= HEARTBEAT_THROTTLE,
                     None => true,

--- a/rust-srec/src/services/container.rs
+++ b/rust-srec/src/services/container.rs
@@ -41,7 +41,8 @@ use crate::database::repositories::{
 use crate::domain::{Priority, StreamerState};
 use crate::downloader::{
     DEFAULT_GATE_COOLDOWN_SECS, DownloadConfig, DownloadManager, DownloadManagerConfig,
-    DownloadManagerEvent, LAST_ERROR_GATE_PREFIX, OutputRootGate, RecoveryHook,
+    DownloadManagerEvent, DownloadProgressEvent, DownloadTerminalEvent, LAST_ERROR_GATE_PREFIX,
+    OutputRootGate, RecoveryHook,
     engine::DownloadProgress,
 };
 use crate::logging::LoggingConfig;
@@ -1474,7 +1475,7 @@ impl ServiceContainer {
                     result = receiver.recv() => {
                         match result {
                             Ok(download_event) => {
-                                if let DownloadManagerEvent::Progress { progress, .. } = &download_event
+                                if let DownloadManagerEvent::Progress(DownloadProgressEvent::Progress { progress, .. }) = &download_event
                                     && !should_record_recovery_from_progress(progress)
                                 {
                                     continue;
@@ -1505,12 +1506,12 @@ impl ServiceContainer {
                 }
 
                 // Handle download failure for error tracking
-                if let DownloadManagerEvent::DownloadFailed {
+                if let DownloadManagerEvent::Terminal(DownloadTerminalEvent::Failed {
                     ref streamer_id,
                     ref session_id,
                     ref error,
                     ..
-                } = download_event
+                }) = download_event
                 {
                     // Record error for exponential backoff
                     if let Some(metadata) = streamer_manager.get_streamer(streamer_id) {
@@ -1541,7 +1542,7 @@ impl ServiceContainer {
                 }
 
                 // Handle download cancellation - stop danmu collection
-                if let DownloadManagerEvent::DownloadCancelled { ref session_id, .. } =
+                if let DownloadManagerEvent::Terminal(DownloadTerminalEvent::Cancelled { ref session_id, .. }) =
                     download_event
                     && danmu_service.is_collecting(session_id)
                 {
@@ -1561,11 +1562,11 @@ impl ServiceContainer {
                     }
                 }
 
-                if let DownloadManagerEvent::Progress {
+                if let DownloadManagerEvent::Progress(DownloadProgressEvent::Progress {
                     ref streamer_id,
                     ref progress,
                     ..
-                } = download_event
+                }) = download_event
                     && should_record_recovery_from_progress(progress)
                     && let Some(metadata) = streamer_manager.get_streamer(streamer_id)
                     && metadata.is_active()
@@ -1581,14 +1582,14 @@ impl ServiceContainer {
 
                 // Handle danmu segmentation
                 match &download_event {
-                    DownloadManagerEvent::SegmentStarted {
+                    DownloadManagerEvent::Progress(DownloadProgressEvent::SegmentStarted {
                         session_id,
                         streamer_id,
                         segment_path,
                         segment_index,
                         started_at,
                         ..
-                    } => {
+                    }) => {
                         if let Some(metadata) = streamer_manager.get_streamer(streamer_id)
                             && !metadata.is_disabled()
                             && metadata.last_error.is_some()
@@ -1618,14 +1619,14 @@ impl ServiceContainer {
                             }
                         }
                     }
-                    DownloadManagerEvent::SegmentCompleted {
+                    DownloadManagerEvent::Progress(DownloadProgressEvent::SegmentCompleted {
                         session_id,
                         streamer_id,
                         segment_path,
                         segment_index,
                         size_bytes,
                         ..
-                    } => {
+                    }) => {
                         // Decide discard *before* ending danmu segment so we can suppress the
                         // imminent DanmuEvent::SegmentCompleted (avoids pipeline race with deletion).
                         let mut discard = false;


### PR DESCRIPTION
Cherry-pick of #524 onto `dev` for testing.

See #524 for full description, design notes, and rationale. Same diff, same tests (1099 passed), same clippy clean. Cherry-picked cleanly with no conflicts.

Fixes #523