### PR TITLE
fix(frontend): replace removed lucide-react brand icons with simple-icons

### DIFF
--- a/rust-srec/frontend/package.json
+++ b/rust-srec/frontend/package.json
@@ -20,6 +20,7 @@
     "@bufbuild/protobuf": "^2.12.0",
     "@fontsource/inter": "^5.2.8",
     "@hookform/resolvers": "^5.2.2",
+    "@icons-pack/react-simple-icons": "^13.13.0",
     "@lingui/core": "^6.0.1",
     "@lingui/react": "^6.0.1",
     "@radix-ui/react-accordion": "^1.2.12",

--- a/rust-srec/frontend/pnpm-lock.yaml
+++ b/rust-srec/frontend/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@hookform/resolvers':
         specifier: ^5.2.2
         version: 5.2.2(react-hook-form@7.74.0(react@19.2.5))
+      '@icons-pack/react-simple-icons':
+        specifier: ^13.13.0
+        version: 13.13.0(react@19.2.5)
       '@lingui/core':
         specifier: ^6.0.1
         version: 6.0.1(babel-plugin-macros@3.1.0)
@@ -891,6 +894,12 @@ packages:
     resolution: {integrity: sha512-A/IxlMLShx3KjV/HeTcTfaMxdwy690+L/ZADoeaTltLx+CVuzkeVIPuybK3jrRfw7YZnmdKsVVHAlEPIAEUNlA==}
     peerDependencies:
       react-hook-form: ^7.55.0
+
+  '@icons-pack/react-simple-icons@13.13.0':
+    resolution: {integrity: sha512-B5HhQMIpcSH4z8IZ8HFhD59CboHceKYMpPC9kAwGyKntvPdyJJv26DLu4Z1wAjcCLyrJhf11tMhiQGom9Rxb9g==}
+    engines: {node: '>=24', pnpm: '>=10'}
+    peerDependencies:
+      react: ^16.13 || ^17 || ^18 || ^19
 
   '@inquirer/ansi@2.0.5':
     resolution: {integrity: sha512-doc2sWgJpbFQ64UflSVd17ibMGDuxO1yKgOgLMwavzESnXjFWJqUeG8saYosqKpHp4kWiM5x1nXvEjbpx90gzw==}
@@ -5614,6 +5623,10 @@ snapshots:
     dependencies:
       '@standard-schema/utils': 0.3.0
       react-hook-form: 7.74.0(react@19.2.5)
+
+  '@icons-pack/react-simple-icons@13.13.0(react@19.2.5)':
+    dependencies:
+      react: 19.2.5
 
   '@inquirer/ansi@2.0.5': {}
 

--- a/rust-srec/frontend/src/components/pipeline/constants.tsx
+++ b/rust-srec/frontend/src/components/pipeline/constants.tsx
@@ -11,18 +11,21 @@ import {
   Tag,
   Workflow,
   Globe,
-  Twitch,
-  Youtube,
   Video,
-  Tv,
   Radio,
-  MessageCircle,
-  Music,
   Film,
   Camera,
   Flame,
   Type,
 } from 'lucide-react';
+import {
+  SiBilibili,
+  SiSinaweibo,
+  SiTiktok,
+  SiTwitch,
+  SiXiaohongshu,
+  SiYoutube,
+} from '@icons-pack/react-simple-icons';
 import React from 'react';
 
 export const STEP_ICONS: Record<string, React.ElementType> = {
@@ -85,19 +88,19 @@ export function getStepIcon(processor: string): React.ElementType {
 
 // Platform Constants
 export const PLATFORM_ICONS: Record<string, React.ElementType> = {
-  bilibili: Tv,
-  douyin: Music, // TikTok/Douyin note
-  tiktok: Music,
+  bilibili: SiBilibili,
+  douyin: SiTiktok, // Douyin is the Chinese TikTok; Simple Icons has no separate douyin slug
+  tiktok: SiTiktok,
   douyu: Radio,
   huya: Video,
-  twitch: Twitch,
-  youtube: Youtube,
+  twitch: SiTwitch,
+  youtube: SiYoutube,
   acfun: Film,
   pandatv: Camera,
   picarto: ImageIcon,
-  redbook: MessageCircle, // Xiaohongshu
+  redbook: SiXiaohongshu, // Xiaohongshu
   twitcasting: Radio,
-  weibo: Globe,
+  weibo: SiSinaweibo,
 };
 
 export const PLATFORM_COLORS: Record<string, string> = {

--- a/rust-srec/frontend/src/components/pipeline/workflows/step-library.tsx
+++ b/rust-srec/frontend/src/components/pipeline/workflows/step-library.tsx
@@ -81,7 +81,7 @@ export const StepLibrary = memo(function StepLibrary({
     isLoading: isLoadingPresets,
   } = useInfiniteQuery({
     queryKey: ['job', 'presets', debouncedSearch, selectedCategory],
-    queryFn: ({ pageParam = 0 }) =>
+    queryFn: ({ pageParam }) =>
       listJobPresets({
         data: {
           search: debouncedSearch || undefined,
@@ -107,7 +107,7 @@ export const StepLibrary = memo(function StepLibrary({
     isLoading: isLoadingWorkflows,
   } = useInfiniteQuery({
     queryKey: ['pipeline', 'presets', debouncedSearch],
-    queryFn: ({ pageParam = 0 }) =>
+    queryFn: ({ pageParam }) =>
       listPipelinePresets({
         data: {
           search: debouncedSearch || undefined,

--- a/rust-srec/frontend/src/components/ui/tag-input.tsx
+++ b/rust-srec/frontend/src/components/ui/tag-input.tsx
@@ -14,7 +14,7 @@ interface TagInputProps extends Omit<
 }
 
 export function TagInput({
-  value = [],
+  value,
   onChange,
   placeholder,
   className,


### PR DESCRIPTION
## Summary
- Unblocks #544 (lucide-react 0.577 → 1.14): v1 removed all brand logos, including Twitch and YouTube. This swaps the breaking imports for `@icons-pack/react-simple-icons` and brands four other platforms while we're at it.
- `PLATFORM_ICONS` now uses real brand glyphs for **Bilibili**, **Douyin** (TikTok glyph — Simple Icons has no separate `douyin` slug), **TikTok**, **Twitch**, **YouTube**, **Xiaohongshu** (redbook), and **Sina Weibo**. **Douyu**, **Huya**, **AcFun**, **PandaTV**, **Picarto**, and **TwitCasting** keep their generic Lucide fallbacks since Simple Icons doesn't carry those marks.
- Drops three unreachable destructure defaults that oxlint was flagging (`value = []` in `tag-input.tsx`, `pageParam = 0` twice in `step-library.tsx`).

## Why `@icons-pack/react-simple-icons`
- Same `<Icon className="…" />` ergonomics as Lucide — drop-in replacement.
- `sideEffects: false` plus per-icon export paths → only the 6 imported icons end up in the bundle. The dedicated chunk weighs **13 KB** in `pnpm build` output.
- Simple Icons covers every brand we currently care about; trademark obligations apply regardless of the icon source, so no extra exposure.
- Lucide itself recommends Simple Icons as the replacement in its v1 migration guide.

## Compatibility with #544
The only file both branches touch is `pnpm-lock.yaml`. Trivial textual conflict → resolves to "keep both blocks". This branch works on both lucide-react v0.577 (current `main`) and v1.14 (post #544), so order of merge doesn't matter.

## Test plan
- [x] `pnpm lint` — 0 warnings, 0 errors (was 0 errors / 3 warnings before this PR)
- [x] `pnpm build` — succeeds; `@icons-pack/react-simple-icons` produces a 13 KB chunk containing only the 6 imported brand glyphs
- [ ] Smoke-check the pipeline UI to confirm platform badges render with the new logos (Bilibili / Twitch / YouTube / TikTok / Weibo / Xiaohongshu) and existing fallbacks (Douyu / Huya / AcFun / PandaTV / Picarto / TwitCasting) are unchanged