### PR TITLE
feat(mesio): add --disable-log-file option

### DIFF
--- a/mesio-cli/README.md
+++ b/mesio-cli/README.md
@@ -149,6 +149,7 @@ HTTP/2 is enabled by default (`--http-version auto`). Use `--http-version http1`
 ```text
   -P, --progress         Show progress bars for download and processing operations
   -v, --verbose          Enable detailed debug logging
+      --disable-log-file Disable writing logs to mesio.log
   -h, --help             Print help
   -V, --version          Print version
 ```

--- a/mesio-cli/src/cli.rs
+++ b/mesio-cli/src/cli.rs
@@ -68,6 +68,14 @@ pub struct CliArgs {
     #[arg(short, long, help = "Enable detailed debug logging")]
     pub verbose: bool,
 
+    /// Disable writing logs to mesio.log
+    #[arg(
+        long = "disable-log-file",
+        alias = "disable_log_file",
+        help = "Disable writing logs to mesio.log"
+    )]
+    pub disable_log_file: bool,
+
     /// Enable keyframe index injection
     #[arg(
         short = 'k',

--- a/mesio-cli/src/main.rs
+++ b/mesio-cli/src/main.rs
@@ -1,4 +1,4 @@
-use std::io;
+use std::io::{self, IsTerminal};
 use std::{path::PathBuf, time::Duration};
 
 use clap::Parser;
@@ -82,6 +82,7 @@ async fn bootstrap() -> Result<(), AppError> {
     };
 
     let filter = tracing_subscriber::filter::LevelFilter::from_level(log_level);
+    let enable_ansi = io::stdout().is_terminal();
 
     // Check if we're in pipe mode (stdout output)
     // In pipe mode, we must:
@@ -99,7 +100,7 @@ async fn bootstrap() -> Result<(), AppError> {
         // Use compact format to reduce verbosity
         let console_layer = tracing_subscriber::fmt::layer()
             .with_writer(indicatif_layer.get_stderr_writer())
-            .with_ansi(true)
+            .with_ansi(enable_ansi)
             .without_time()
             .with_target(true)
             .compact(); // Use compact format without full span paths
@@ -115,7 +116,7 @@ async fn bootstrap() -> Result<(), AppError> {
         // This ensures stdout is reserved exclusively for binary data output
         let console_layer = tracing_subscriber::fmt::layer()
             .with_writer(io::stderr)
-            .with_ansi(true)
+            .with_ansi(enable_ansi)
             .without_time()
             .with_target(true)
             .compact();
@@ -129,7 +130,7 @@ async fn bootstrap() -> Result<(), AppError> {
         // Simple console output without progress bars
         // Use compact format to reduce verbosity
         let console_layer = tracing_subscriber::fmt::layer()
-            .with_ansi(true)
+            .with_ansi(enable_ansi)
             .without_time()
             .with_target(true)
             .compact(); // Use compact format without full span paths

--- a/mesio-cli/src/main.rs
+++ b/mesio-cli/src/main.rs
@@ -68,14 +68,18 @@ async fn bootstrap() -> Result<(), AppError> {
         Level::INFO
     };
 
-    // Create file appender for mesio.log
-    let file_appender = tracing_appender::rolling::daily(".", "mesio.log");
-    let (non_blocking_file, _guard) = tracing_appender::non_blocking(file_appender);
+    let (file_layer, _file_guard) = if args.disable_log_file {
+        (None, None)
+    } else {
+        let file_appender = tracing_appender::rolling::daily(".", "mesio.log");
+        let (non_blocking_file, guard) = tracing_appender::non_blocking(file_appender);
 
-    // Create file logging layer
-    let file_layer = tracing_subscriber::fmt::layer()
-        .with_writer(non_blocking_file)
-        .with_ansi(false);
+        let file_layer = tracing_subscriber::fmt::layer()
+            .with_writer(non_blocking_file)
+            .with_ansi(false);
+
+        (Some(file_layer), Some(guard))
+    };
 
     let filter = tracing_subscriber::filter::LevelFilter::from_level(log_level);
 


### PR DESCRIPTION
## What changed?

 - Mesio cli  add --disable-log-file option
 - Meios cli use terminal check for ANSI support in logging

## Scope

- Affected components (backend / frontend / desktop / CLI / crates / docs): CLI
- Breaking change: no

## How to test

Steps reviewers can run to validate locally.

## Checklist

- [x] I ran formatting (`cargo fmt --all`) if Rust code changed
- [x] I ran lint (`cargo clippy ...`) if Rust code changed
- [x] I ran tests (`cargo test` or `cargo nextest run`) if feasible
- [x] I updated docs/config examples if behavior changed
- [x] I avoided logging secrets and redacted sensitive info in screenshots/logs

## Related issues

Link issues (e.g. `Fixes #123`).
