### PR TITLE
fix(huya): treat rectification notice as offline instead of banned

### DIFF
--- a/crates/platforms/src/extractor/platforms/huya/web.rs
+++ b/crates/platforms/src/extractor/platforms/huya/web.rs
@@ -6,6 +6,7 @@ use crate::extractor::platforms::huya::models::{RoomData, WebProfileInfo, WebStr
 use crate::media::media_info::MediaInfo;
 use regex::Regex;
 use rustc_hash::FxHashMap;
+use tracing::warn;
 
 pub(super) static ROOM_DATA_REGEX: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r#"var TT_ROOM_DATA = (.*?);"#).unwrap());
@@ -117,7 +118,11 @@ impl Huya {
         }
 
         if response_text.contains("该主播涉嫌违规，正在整改中") {
-            return Err(ExtractorError::StreamerBanned);
+            warn!(
+                url = %self.extractor.url,
+                "huya rectification notice detected, treating as offline"
+            );
+            return Err(ExtractorError::NoStreamsFound);
         }
 
         if response_text.is_empty() {


### PR DESCRIPTION
## Summary
- Huya's `该主播涉嫌违规，正在整改中` ("under rectification") is a temporary platform-side review, not a permanent ban — but the extractor returned `StreamerBanned`, which the monitor mapped to `LiveStatus::Banned` → `StreamerState::FatalError`, halting polling until the user manually cleared the streamer.
- Now returns `NoStreamsFound` so the detector routes it to `LiveStatus::Offline` and polling resumes on the normal cadence; recovery is automatic when the streamer comes back.
- Emits a `warn!` at the detection site so the rectification signal is still observable in logs.

## Test plan
- [ ] Trigger a Huya URL that returns the rectification HTML and confirm the streamer stays in `NotLive` rather than `FatalError`.
- [ ] Verify the `huya rectification notice detected, treating as offline` warn line appears with the streamer URL.
- [ ] Confirm subsequent monitor polls continue at the normal interval and transition to `Live` when the streamer returns.