### PR TITLE
chore(frontend): migrate to react-day-picker v10

### DIFF
--- a/rust-srec/frontend/package.json
+++ b/rust-srec/frontend/package.json
@@ -64,7 +64,7 @@
     "nitro": "latest",
     "qrcode.react": "^4.2.0",
     "react": "^19.2.6",
-    "react-day-picker": "^9.14.0",
+    "react-day-picker": "^10.0.1",
     "react-dom": "^19.2.6",
     "react-hook-form": "^7.76.1",
     "recharts": "^3.8.1",

--- a/rust-srec/frontend/pnpm-lock.yaml
+++ b/rust-srec/frontend/pnpm-lock.yaml
@@ -150,8 +150,8 @@ importers:
         specifier: ^19.2.6
         version: 19.2.6
       react-day-picker:
-        specifier: ^9.14.0
-        version: 9.14.0(react@19.2.6)
+        specifier: ^10.0.1
+        version: 10.0.1(@types/react@19.2.15)(react@19.2.6)
       react-dom:
         specifier: ^19.2.6
         version: 19.2.6(react@19.2.6)
@@ -2265,10 +2265,6 @@ packages:
   '@swc/types@0.1.26':
     resolution: {integrity: sha512-lyMwd7WGgG79RS7EERZV3T8wMdmPq3xwyg+1nmAM64kIhx5yl+juO2PYIHb7vTiPgPCj8LYjsNV2T5wiQHUEaw==}
 
-  '@tabby_ai/hijri-converter@1.0.5':
-    resolution: {integrity: sha512-r5bClKrcIusDoo049dSL8CawnHR6mRdDwhlQuIgZRNty68q0x8k3Lf1BtPAMxRf/GgnHBnIO4ujd3+GQdLWzxQ==}
-    engines: {node: '>=16.0.0'}
-
   '@tailwindcss/node@4.3.0':
     resolution: {integrity: sha512-aFb4gUhFOgdh9AXo4IzBEOzBkkAxm9VigwDJnMIYv3lcfXCJVesNfbEaBl4BNgVRyid92AmdviqwBUBRKSeY3g==}
 
@@ -3176,9 +3172,6 @@ packages:
   data-urls@7.0.0:
     resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
-
-  date-fns-jalali@4.1.0-0:
-    resolution: {integrity: sha512-hTIP/z+t+qKwBDcmmsnmjWTduxCg+5KfdqWQvb2X/8C9+knYY6epN/pfxdDuyVlSVeFz0sM5eEfwIUQ70U4ckg==}
 
   date-fns@4.4.0:
     resolution: {integrity: sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==}
@@ -4385,11 +4378,15 @@ packages:
     resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
     engines: {node: '>= 0.10'}
 
-  react-day-picker@9.14.0:
-    resolution: {integrity: sha512-tBaoDWjPwe0M5pGrum4H0SR6Lyk+BO9oHnp9JbKpGKW2mlraNPgP9BMfsg5pWpwrssARmeqk7YBl2oXutZTaHA==}
+  react-day-picker@10.0.1:
+    resolution: {integrity: sha512-eNh6BlwcYInWaJtRv18mXQ06Ys/H6rdTZAnTaSdOYJuTpwP1JMCHNd1FDRadA+gbeinq+psdULN5Xnowy9mV8w==}
     engines: {node: '>=18'}
     peerDependencies:
+      '@types/react': '>=16.8.0'
       react: '>=16.8.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
 
   react-dom@19.2.6:
     resolution: {integrity: sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==}
@@ -6901,8 +6898,6 @@ snapshots:
     dependencies:
       '@swc/counter': 0.1.3
 
-  '@tabby_ai/hijri-converter@1.0.5': {}
-
   '@tailwindcss/node@4.3.0':
     dependencies:
       '@jridgewell/remapping': 2.3.5
@@ -7936,8 +7931,6 @@ snapshots:
       whatwg-url: 16.0.1(@noble/hashes@1.8.0)
     transitivePeerDependencies:
       - '@noble/hashes'
-
-  date-fns-jalali@4.1.0-0: {}
 
   date-fns@4.4.0: {}
 
@@ -9092,13 +9085,13 @@ snapshots:
       iconv-lite: 0.7.2
       unpipe: 1.0.0
 
-  react-day-picker@9.14.0(react@19.2.6):
+  react-day-picker@10.0.1(@types/react@19.2.15)(react@19.2.6):
     dependencies:
       '@date-fns/tz': 1.5.0
-      '@tabby_ai/hijri-converter': 1.0.5
       date-fns: 4.4.0
-      date-fns-jalali: 4.1.0-0
       react: 19.2.6
+    optionalDependencies:
+      '@types/react': 19.2.15
 
   react-dom@19.2.6(react@19.2.6):
     dependencies:

--- a/rust-srec/frontend/src/components/logging/log-file-browser.tsx
+++ b/rust-srec/frontend/src/components/logging/log-file-browser.tsx
@@ -295,7 +295,7 @@ export function LogFileBrowser() {
                       date > new Date() || date < new Date('2020-01-01')
                     }
                     numberOfMonths={2}
-                    initialFocus
+                    autoFocus
                   />
                 </PopoverContent>
               </Popover>

--- a/rust-srec/frontend/src/components/ui/calendar.tsx
+++ b/rust-srec/frontend/src/components/ui/calendar.tsx
@@ -82,7 +82,7 @@ function Calendar({
             : 'rounded-md pl-2 pr-1 flex items-center gap-1 text-sm h-8 [&>svg]:text-muted-foreground [&>svg]:size-3.5',
           defaultClassNames.caption_label,
         ),
-        table: 'w-full border-collapse',
+        month_grid: 'w-full border-collapse',
         weekdays: cn('flex', defaultClassNames.weekdays),
         weekday: cn(
           'text-muted-foreground rounded-md flex-1 font-normal text-[0.8rem] select-none',

--- a/rust-srec/frontend/src/routes/_authed/_dashboard/sessions/index.lazy.tsx
+++ b/rust-srec/frontend/src/routes/_authed/_dashboard/sessions/index.lazy.tsx
@@ -363,7 +363,7 @@ function SessionsPage() {
                       date > new Date() || date < new Date('1900-01-01')
                     }
                     numberOfMonths={2}
-                    initialFocus
+                    autoFocus
                     className="rounded-md border shadow-xs"
                   />
                 </PopoverContent>


### PR DESCRIPTION
react-day-picker 10 removes the v9-deprecated APIs still in use. Rename the Calendar classNames key table to month_grid, and replace the removed initialFocus prop with autoFocus in the log file browser and sessions date-range pickers. The lockfile bump also drops the now-unused jalali transitive deps (@tabby_ai/hijri-converter, date-fns-jalali).

## What changed?

Describe the change and the motivation.

## Scope

- Affected components (backend / frontend / desktop / CLI / crates / docs):
- Breaking change: yes/no

## How to test

Steps reviewers can run to validate locally.

## Checklist

- [ ] I ran formatting (`cargo fmt --all`) if Rust code changed
- [ ] I ran lint (`cargo clippy ...`) if Rust code changed
- [ ] I ran tests (`cargo test` or `cargo nextest run`) if feasible
- [ ] I updated docs/config examples if behavior changed
- [ ] I avoided logging secrets and redacted sensitive info in screenshots/logs

## Related issues

Link issues (e.g. `Fixes #123`).
