### PR TITLE
refactor(danmu): WebSocket danmaku lifecycle without connection locks

### DIFF
--- a/crates/platforms/src/danmaku/websocket.rs
+++ b/crates/platforms/src/danmaku/websocket.rs
@@ -172,21 +172,81 @@ fn connector_for_url(url: &str) -> Connector {
     rustls_connector()
 }
 
-/// Protocol definitions for a specific platform.
-pub trait DanmuProtocol: Send + Sync + 'static {
-    /// Platform name (e.g., "huya", "bilibili")
+/// Creates isolated protocol state for WebSocket danmaku connections.
+///
+/// Factories are shared by the provider and must not reuse connection state. Each call to
+/// [`create_protocol`](Self::create_protocol) must return a fresh protocol instance that can
+/// be moved into one connection task.
+pub trait DanmuProtocolFactory: Send + Sync + 'static {
+    /// Task-owned protocol created by this factory.
+    type Protocol: DanmuProtocol;
+
+    /// Returns the platform identifier used by the provider registry.
     fn platform(&self) -> &str;
 
-    /// Check if the URL is supported
+    /// Returns whether `url` belongs to this platform.
     fn supports_url(&self, url: &str) -> bool;
 
-    /// Extract room ID from URL
+    /// Extracts the platform room identifier from `url`.
     fn extract_room_id(&self, url: &str) -> Option<String>;
 
-    /// Get the WebSocket URL for the room
-    fn websocket_url(&self, room_id: &str) -> impl Future<Output = Result<String>> + Send;
+    /// Creates fresh state for one connection or reconnect attempt.
+    fn create_protocol(&self) -> Self::Protocol;
+}
 
-    /// Get custom headers for the WebSocket connection
+/// Output produced while decoding one WebSocket frame.
+///
+/// Protocol responses are written to the socket before decoded danmaku items are
+/// published, preserving the ordering of acknowledgements and authentication steps.
+#[derive(Debug, Default)]
+#[must_use]
+pub struct DanmuProtocolOutput {
+    items: Vec<DanmuItem>,
+    outbound: Vec<Message>,
+}
+
+impl DanmuProtocolOutput {
+    /// Creates output containing decoded `items` and outbound WebSocket frames.
+    pub fn new(items: Vec<DanmuItem>, outbound: Vec<Message>) -> Self {
+        Self { items, outbound }
+    }
+
+    /// Creates output containing only decoded danmaku items.
+    pub fn items(items: Vec<DanmuItem>) -> Self {
+        Self::new(items, Vec::new())
+    }
+
+    /// Creates output containing only outbound WebSocket frames.
+    pub fn outbound(outbound: Vec<Message>) -> Self {
+        Self::new(Vec::new(), outbound)
+    }
+
+    /// Separates decoded items from outbound WebSocket frames.
+    pub fn into_parts(self) -> (Vec<DanmuItem>, Vec<Message>) {
+        (self.items, self.outbound)
+    }
+}
+
+impl From<Vec<DanmuItem>> for DanmuProtocolOutput {
+    fn from(items: Vec<DanmuItem>) -> Self {
+        Self::items(items)
+    }
+}
+
+/// Task-owned state machine for one WebSocket connection attempt.
+///
+/// The connection runner calls every method serially from one Tokio task. Implementations
+/// can therefore use ordinary mutable fields and do not need locks or atomics for
+/// connection-local state.
+pub trait DanmuProtocol: Send + 'static {
+    /// Resolves the WebSocket URL for `room_id` and updates connection state as needed.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when endpoint discovery or session initialization fails.
+    fn websocket_url(&mut self, room_id: &str) -> impl Future<Output = Result<String>> + Send;
+
+    /// Returns custom headers for the WebSocket upgrade.
     fn headers(&self, _room_id: &str) -> HeaderMap {
         HeaderMap::new()
     }
@@ -226,9 +286,13 @@ pub trait DanmuProtocol: Send + Sync + 'static {
     ) {
     }
 
-    /// Generate handshake messages to send upon connection
+    /// Generates handshake messages to send after the WebSocket upgrade.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when authentication or room-join messages cannot be built.
     fn handshake_messages(
-        &self,
+        &mut self,
         _room_id: &str,
     ) -> impl Future<Output = Result<Vec<Message>>> + Send {
         async { Ok(vec![]) }
@@ -244,14 +308,21 @@ pub trait DanmuProtocol: Send + Sync + 'static {
         Duration::from_secs(30)
     }
 
-    /// Decode a WebSocket message into a list of danmu items (messages or control events).
-    /// `room_id` is provided so protocols can use it for responses that need the room context
+    /// Decodes one WebSocket frame and advances the connection state machine.
+    ///
+    /// The returned [`DanmuProtocolOutput`] may contain danmaku items, protocol responses,
+    /// or both. `room_id` is available for protocols whose responses require room context.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the frame is invalid for the current protocol state or a
+    /// required response cannot be constructed. The connection runner reconnects after
+    /// such an error.
     fn decode_message(
-        &self,
+        &mut self,
         message: &Message,
         room_id: &str,
-        tx: &mpsc::Sender<Message>,
-    ) -> impl Future<Output = Result<Vec<DanmuItem>>> + Send;
+    ) -> impl Future<Output = Result<DanmuProtocolOutput>> + Send;
 }
 
 /// Internal state for a WebSocket connection
@@ -293,10 +364,9 @@ impl Drop for WsConnectionState {
     }
 }
 
-/// A generic WebSocket-based Danmu Provider.
-pub struct WebSocketDanmuProvider<P> {
-    /// Protocol implementation
-    protocol: P,
+/// WebSocket danmaku provider backed by a shared protocol factory.
+pub struct WebSocketDanmuProvider<F: DanmuProtocolFactory> {
+    factory: Arc<F>,
     /// Settings
     config: WebSocketProviderConfig,
     /// Active connections
@@ -321,10 +391,11 @@ impl Default for WebSocketProviderConfig {
     }
 }
 
-impl<P: DanmuProtocol + Clone> WebSocketDanmuProvider<P> {
-    pub fn with_protocol(protocol: P, config: Option<WebSocketProviderConfig>) -> Self {
+impl<F: DanmuProtocolFactory> WebSocketDanmuProvider<F> {
+    /// Creates a provider that uses `factory` for every connection attempt.
+    pub fn with_factory(factory: F, config: Option<WebSocketProviderConfig>) -> Self {
         Self {
-            protocol,
+            factory: Arc::new(factory),
             config: config.unwrap_or_default(),
             connections: RwLock::new(HashMap::new()),
             connection_semaphore: Arc::new(Semaphore::new(MAX_ACTIVE_CONNECTIONS)),
@@ -346,10 +417,9 @@ impl<P: DanmuProtocol + Clone> WebSocketDanmuProvider<P> {
         let reconnect_count = Arc::new(AtomicU32::new(0));
         let (message_tx, message_rx) = mpsc::channel(100);
         let message_rx = Arc::new(Mutex::new(message_rx));
-        let (response_tx, mut response_rx) = mpsc::channel::<Message>(100);
         let (shutdown_tx, mut shutdown_rx) = mpsc::channel(1);
 
-        let mut protocol = self.protocol.clone();
+        let factory = Arc::clone(&self.factory);
         let ws_config = config.websocket.unwrap_or(self.config);
         let room_id_owned = room_id.to_string();
         let cookies = config.cookies;
@@ -359,7 +429,10 @@ impl<P: DanmuProtocol + Clone> WebSocketDanmuProvider<P> {
 
         // Spawn main management task
         let handle = tokio::spawn(async move {
-            let mut current_stream: Option<WebSocketStream<MaybeTlsStream<TcpStream>>> = None;
+            let mut current_connection: Option<(
+                WebSocketStream<MaybeTlsStream<TcpStream>>,
+                F::Protocol,
+            )> = None;
             let mut attempt = 0;
             let mut delay = ws_config.base_reconnect_delay_ms;
 
@@ -370,7 +443,8 @@ impl<P: DanmuProtocol + Clone> WebSocketDanmuProvider<P> {
                 }
 
                 // Connect if not connected
-                if current_stream.is_none() {
+                if current_connection.is_none() {
+                    let mut protocol = factory.create_protocol();
                     // Compute cookies and let the protocol derive per-connection state (e.g. uid)
                     // before resolving the final WebSocket URL.
                     let protocol_cookies = protocol.cookies();
@@ -482,27 +556,29 @@ impl<P: DanmuProtocol + Clone> WebSocketDanmuProvider<P> {
 
                                     // Handshake
                                     let mut handshake_ok = true;
-                                    if let Ok(msgs) =
-                                        protocol.handshake_messages(&room_id_owned).await
-                                    {
-                                        for msg in msgs {
-                                            if let Err(e) = ws_stream.send(msg).await {
-                                                error!("Handshake failed: {}", e);
-                                                handshake_ok = false;
-                                                break;
+                                    match protocol.handshake_messages(&room_id_owned).await {
+                                        Ok(msgs) => {
+                                            for msg in msgs {
+                                                if let Err(e) = ws_stream.send(msg).await {
+                                                    error!("Handshake failed: {}", e);
+                                                    handshake_ok = false;
+                                                    break;
+                                                }
                                             }
+                                        }
+                                        Err(e) => {
+                                            error!("Failed to build handshake: {}", e);
+                                            handshake_ok = false;
                                         }
                                     }
 
-                                    if !handshake_ok {
-                                        continue; // Retry connection
+                                    if handshake_ok {
+                                        is_connected_clone.store(true, Ordering::SeqCst);
+                                        reconnect_count_clone.store(0, Ordering::SeqCst);
+                                        attempt = 0;
+                                        delay = ws_config.base_reconnect_delay_ms;
+                                        current_connection = Some((ws_stream, protocol));
                                     }
-
-                                    is_connected_clone.store(true, Ordering::SeqCst);
-                                    reconnect_count_clone.store(0, Ordering::SeqCst);
-                                    attempt = 0;
-                                    delay = ws_config.base_reconnect_delay_ms;
-                                    current_stream = Some(ws_stream);
                                 }
                                 Err(e) => {
                                     warn!("Connection failed: {}", e);
@@ -514,7 +590,7 @@ impl<P: DanmuProtocol + Clone> WebSocketDanmuProvider<P> {
                         }
                     }
 
-                    if current_stream.is_none() {
+                    if current_connection.is_none() {
                         if attempt >= ws_config.max_reconnect_attempts {
                             error!("Max reconnect attempts reached for {}", room_id_owned);
                             break;
@@ -533,13 +609,11 @@ impl<P: DanmuProtocol + Clone> WebSocketDanmuProvider<P> {
                 }
 
                 // Main loop: read/write/heartbeat
-                if let Some(mut stream) = current_stream.take() {
+                if let Some((mut stream, mut protocol)) = current_connection.take() {
                     let heartbeat_enabled = protocol.heartbeat_message().is_some();
                     let heartbeat_interval = protocol.heartbeat_interval();
                     let mut heartbeat_timer = tokio::time::interval(heartbeat_interval);
                     heartbeat_timer.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
-                    let response_tx_clone = response_tx.clone();
-
                     loop {
                         tokio::select! {
                              // Heartbeat (only if enabled)
@@ -553,28 +627,37 @@ impl<P: DanmuProtocol + Clone> WebSocketDanmuProvider<P> {
                                 }
                             }
 
-                            // Response messages from protocol
-                            Some(msg) = response_rx.recv() => {
-                                if let Err(e) = stream.send(msg).await {
-                                    error!("Failed to send response message: {}", e);
-                                    break; // Reconnect
-                                }
-                            }
-
                             // Read message
                             msg_opt = stream.next() => {
                                 match msg_opt {
                                     Some(Ok(msg)) => {
-                                        match protocol.decode_message(&msg, &room_id_owned, &response_tx_clone).await {
-                                            Ok(messages) => {
-                                                for item in messages {
+                                        match protocol.decode_message(&msg, &room_id_owned).await {
+                                            Ok(output) => {
+                                                let (items, outbound) = output.into_parts();
+                                                let mut response_failed = false;
+                                                for response in outbound {
+                                                    if let Err(e) = stream.send(response).await {
+                                                        error!("Failed to send protocol response: {}", e);
+                                                        response_failed = true;
+                                                        break;
+                                                    }
+                                                }
+                                                if response_failed {
+                                                    break;
+                                                }
+                                                for item in items {
                                                     if message_tx.send(item).await.is_err() {
-                                                        break; // Channel closed
+                                                        return;
                                                     }
                                                 }
                                             }
                                             Err(e) => {
                                                 warn!("Failed to decode message: {}", e);
+                                                tokio::select! {
+                                                    _ = tokio::time::sleep(Duration::from_millis(ws_config.base_reconnect_delay_ms)) => {}
+                                                    _ = shutdown_rx.recv() => return,
+                                                }
+                                                break;
                                             }
                                         }
                                     }
@@ -615,9 +698,9 @@ impl<P: DanmuProtocol + Clone> WebSocketDanmuProvider<P> {
 }
 
 #[async_trait]
-impl<P: DanmuProtocol + Clone> DanmuProvider for WebSocketDanmuProvider<P> {
+impl<F: DanmuProtocolFactory> DanmuProvider for WebSocketDanmuProvider<F> {
     fn platform(&self) -> &str {
-        self.protocol.platform()
+        self.factory.platform()
     }
 
     async fn connect(&self, room_id: &str, config: ConnectionConfig) -> Result<DanmuConnection> {
@@ -705,11 +788,11 @@ impl<P: DanmuProtocol + Clone> DanmuProvider for WebSocketDanmuProvider<P> {
     }
 
     fn supports_url(&self, url: &str) -> bool {
-        self.protocol.supports_url(url)
+        self.factory.supports_url(url)
     }
 
     fn extract_room_id(&self, url: &str) -> Option<String> {
-        self.protocol.extract_room_id(url)
+        self.factory.extract_room_id(url)
     }
 }
 

--- a/crates/platforms/src/extractor/platforms/bigo/builder.rs
+++ b/crates/platforms/src/extractor/platforms/bigo/builder.rs
@@ -127,9 +127,7 @@ impl Bigo {
         let artist_url = data.avatar.clone().filter(|s| !s.is_empty());
 
         if !data.is_online() {
-            // Protected offline-looking response without pwd is still PrivateContent
-            // when the API marks passRoom and we have no password.
-            if data.pass_room.unwrap_or(false) && self.resolve_password().is_none() {
+            if data.pass_room.unwrap_or(false) {
                 return Err(ExtractorError::PrivateContent);
             }
 
@@ -292,6 +290,64 @@ mod tests {
             Some(serde_json::json!({"mint_token": false})),
         );
         assert!(!b.mint_token);
+    }
+
+    #[test]
+    fn locked_offline_response_is_private_with_or_without_password() {
+        let client = crate::extractor::default::default_client();
+        let locked_data = || StudioData {
+            alive: Some(0),
+            pass_room: Some(true),
+            room_id: Some("0".to_string()),
+            hls_src: Some(String::new()),
+            ..StudioData::default()
+        };
+
+        let without_password = Bigo::new(
+            "https://www.bigo.tv/1".to_string(),
+            client.clone(),
+            None,
+            None,
+        );
+        assert!(matches!(
+            without_password.media_from_data(locked_data(), "1"),
+            Err(ExtractorError::PrivateContent)
+        ));
+
+        let with_password = Bigo::new(
+            "https://www.bigo.tv/1".to_string(),
+            client,
+            None,
+            Some(serde_json::json!({"stream_password": "wrong"})),
+        );
+        assert!(matches!(
+            with_password.media_from_data(locked_data(), "1"),
+            Err(ExtractorError::PrivateContent)
+        ));
+    }
+
+    #[test]
+    fn public_offline_response_remains_offline() {
+        let bigo = Bigo::new(
+            "https://www.bigo.tv/1".to_string(),
+            crate::extractor::default::default_client(),
+            None,
+            None,
+        );
+        let media = bigo
+            .media_from_data(
+                StudioData {
+                    alive: Some(0),
+                    pass_room: Some(false),
+                    room_id: Some("0".to_string()),
+                    hls_src: Some(String::new()),
+                    ..StudioData::default()
+                },
+                "1",
+            )
+            .expect("public offline room should remain a normal offline result");
+
+        assert!(!media.is_live);
     }
 
     /// Live integration: mint token + studio API + HLS URL.

--- a/crates/platforms/src/extractor/platforms/bigo/danmu.rs
+++ b/crates/platforms/src/extractor/platforms/bigo/danmu.rs
@@ -8,23 +8,21 @@
 //! 5. Ping 791 every ~10s
 
 use std::collections::HashMap;
-use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use base64::{Engine, engine::general_purpose::STANDARD as B64};
 use md5::{Digest, Md5};
-use parking_lot::RwLock;
 use reqwest::Client;
 use serde_json::{Value, json};
-use tokio::sync::mpsc;
 use tokio_tungstenite::tungstenite::http::HeaderMap;
 use tokio_tungstenite::tungstenite::protocol::Message;
-use tracing::{debug, warn};
+use tracing::debug;
 
 use crate::danmaku::error::{DanmakuError, Result};
 use crate::danmaku::websocket::ws_headers_origin_ua;
-use crate::danmaku::websocket::{DanmuProtocol, WebSocketDanmuProvider};
+use crate::danmaku::websocket::{
+    DanmuProtocol, DanmuProtocolFactory, DanmuProtocolOutput, WebSocketDanmuProvider,
+};
 use crate::danmaku::{DanmuItem, DanmuMessage};
 use crate::digest_to_hex;
 use crate::extractor::default::{DEFAULT_UA, default_client};
@@ -56,24 +54,30 @@ struct GuestSession {
     uid_token: String,
 }
 
-/// Bigo danmu protocol state (guest session + password).
-#[derive(Clone)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+enum BigoConnectionPhase {
+    #[default]
+    AwaitingChallenge,
+    AwaitingLogin,
+    AwaitingEnter,
+    Joined,
+}
+
+/// Task-owned Bigo guest session and handshake state.
 pub struct BigoDanmuProtocol {
     client: Client,
-    session: Arc<RwLock<Option<GuestSession>>>,
-    room_password: Arc<RwLock<Option<String>>>,
-    login_sent: Arc<AtomicBool>,
-    enter_sent: Arc<AtomicBool>,
+    session: Option<GuestSession>,
+    room_password: Option<String>,
+    phase: BigoConnectionPhase,
 }
 
 impl Default for BigoDanmuProtocol {
     fn default() -> Self {
         Self {
             client: default_client(),
-            session: Arc::new(RwLock::new(None)),
-            room_password: Arc::new(RwLock::new(None)),
-            login_sent: Arc::new(AtomicBool::new(false)),
-            enter_sent: Arc::new(AtomicBool::new(false)),
+            session: None,
+            room_password: None,
+            phase: BigoConnectionPhase::default(),
         }
     }
 }
@@ -371,7 +375,9 @@ impl BigoDanmuProtocol {
 // rand::RngExt is used in fetch_guest
 use rand::RngExt;
 
-impl DanmuProtocol for BigoDanmuProtocol {
+impl DanmuProtocolFactory for BigoDanmuProtocol {
+    type Protocol = Self;
+
     fn platform(&self) -> &str {
         "bigo"
     }
@@ -385,6 +391,17 @@ impl DanmuProtocol for BigoDanmuProtocol {
         capture_group_1_owned(&URL_REGEX, url)
     }
 
+    fn create_protocol(&self) -> Self::Protocol {
+        Self {
+            client: self.client.clone(),
+            session: None,
+            room_password: None,
+            phase: BigoConnectionPhase::default(),
+        }
+    }
+}
+
+impl DanmuProtocol for BigoDanmuProtocol {
     fn configure_connection(
         &mut self,
         _cookies: Option<&str>,
@@ -396,22 +413,21 @@ impl DanmuProtocol for BigoDanmuProtocol {
                 .or_else(|| e.get("password"))
                 .cloned()
                 .filter(|s| !s.is_empty());
-            *self.room_password.write() = pwd;
+            self.room_password = pwd;
         }
-        self.login_sent.store(false, Ordering::SeqCst);
-        self.enter_sent.store(false, Ordering::SeqCst);
+        self.session = None;
+        self.phase = BigoConnectionPhase::AwaitingChallenge;
     }
 
-    async fn websocket_url(&self, _room_id: &str) -> Result<String> {
+    async fn websocket_url(&mut self, _room_id: &str) -> Result<String> {
         let guest = self.fetch_guest().await?;
         debug!(
             user_id = %guest.user_id,
             device_id = %guest.device_id,
             "bigo guest session ready"
         );
-        *self.session.write() = Some(guest);
-        self.login_sent.store(false, Ordering::SeqCst);
-        self.enter_sent.store(false, Ordering::SeqCst);
+        self.session = Some(guest);
+        self.phase = BigoConnectionPhase::AwaitingChallenge;
         Ok(WSS_URL.to_string())
     }
 
@@ -423,7 +439,7 @@ impl DanmuProtocol for BigoDanmuProtocol {
         false
     }
 
-    async fn handshake_messages(&self, _room_id: &str) -> Result<Vec<Message>> {
+    async fn handshake_messages(&mut self, _room_id: &str) -> Result<Vec<Message>> {
         // Challenge-driven; optional delayed login if server never challenges.
         // We intentionally return empty here — login is sent on challenge or
         // would need a timer outside the trait. Python waits 2s without challenge;
@@ -440,42 +456,45 @@ impl DanmuProtocol for BigoDanmuProtocol {
     }
 
     async fn decode_message(
-        &self,
+        &mut self,
         message: &Message,
         room_id: &str,
-        tx: &mpsc::Sender<Message>,
-    ) -> Result<Vec<DanmuItem>> {
+    ) -> Result<DanmuProtocolOutput> {
         let text = match message {
             Message::Text(t) => t.as_str(),
             Message::Binary(b) => match std::str::from_utf8(b) {
                 Ok(s) => s,
-                Err(_) => return Ok(vec![]),
+                Err(_) => return Ok(DanmuProtocolOutput::default()),
             },
-            Message::Ping(_) | Message::Pong(_) => return Ok(vec![]),
+            Message::Ping(_) | Message::Pong(_) => {
+                return Ok(DanmuProtocolOutput::default());
+            }
             Message::Close(frame) => {
                 debug!(?frame, "bigo ws close");
                 return Err(DanmakuError::connection("Connection closed by server"));
             }
-            _ => return Ok(vec![]),
+            _ => return Ok(DanmuProtocolOutput::default()),
         };
 
         let Some((eid, data)) = Self::parse_frame(text) else {
             debug!(%text, "bigo unparseable frame");
-            return Ok(vec![]);
+            return Ok(DanmuProtocolOutput::default());
         };
 
         match eid {
             EID_CHALLENGE => {
                 if let Some(challenge) = data.get("challenge").and_then(|c| c.as_str()) {
-                    let _ = tx.send(Self::challenge_response(challenge)).await;
-                    if !self.login_sent.swap(true, Ordering::SeqCst) {
-                        let session = self.session.read().clone();
-                        if let Some(session) = session {
-                            let _ = tx.send(Self::login_message(&session)).await;
-                        }
+                    let mut outbound = vec![Self::challenge_response(challenge)];
+                    if self.phase == BigoConnectionPhase::AwaitingChallenge {
+                        let session = self.session.as_ref().ok_or_else(|| {
+                            DanmakuError::protocol("Bigo challenge received without guest session")
+                        })?;
+                        outbound.push(Self::login_message(session));
+                        self.phase = BigoConnectionPhase::AwaitingLogin;
                     }
+                    return Ok(DanmuProtocolOutput::outbound(outbound));
                 }
-                Ok(vec![])
+                Ok(DanmuProtocolOutput::default())
             }
             EID_LOGIN_RES => {
                 let res = data
@@ -488,24 +507,30 @@ impl DanmuProtocol for BigoDanmuProtocol {
                     .unwrap_or_default();
                 if res == "200" {
                     debug!("bigo login ok");
-                    if !self.enter_sent.swap(true, Ordering::SeqCst) {
-                        let session = self.session.read().clone();
+                    if self.phase == BigoConnectionPhase::AwaitingLogin {
+                        let session = self.session.as_ref().ok_or_else(|| {
+                            DanmakuError::protocol("Bigo login succeeded without guest session")
+                        })?;
                         let secret = self
                             .room_password
-                            .read()
-                            .clone()
+                            .as_deref()
                             .filter(|s| !s.is_empty())
-                            .unwrap_or_else(|| "0".to_string());
-                        if let Some(session) = session {
-                            let _ = tx
-                                .send(Self::enter_message(&session, room_id, &secret))
-                                .await;
-                        }
+                            .unwrap_or("0");
+                        let enter = Self::enter_message(session, room_id, secret);
+                        self.phase = BigoConnectionPhase::AwaitingEnter;
+                        return Ok(DanmuProtocolOutput::outbound(vec![enter]));
+                    }
+                    if self.phase == BigoConnectionPhase::AwaitingChallenge {
+                        return Err(DanmakuError::protocol(
+                            "Bigo login response received before login request",
+                        ));
                     }
                 } else {
-                    warn!(%res, "bigo login failed");
+                    return Err(DanmakuError::connection(format!(
+                        "Bigo login rejected: res={res}"
+                    )));
                 }
-                Ok(vec![])
+                Ok(DanmuProtocolOutput::default())
             }
             EID_ENTER_RES => {
                 let code = data
@@ -517,17 +542,27 @@ impl DanmuProtocol for BigoDanmuProtocol {
                     })
                     .unwrap_or_default();
                 if code == "200" {
+                    if self.phase == BigoConnectionPhase::AwaitingChallenge
+                        || self.phase == BigoConnectionPhase::AwaitingLogin
+                    {
+                        return Err(DanmakuError::protocol(
+                            "Bigo enter response received before enter request",
+                        ));
+                    }
+                    self.phase = BigoConnectionPhase::Joined;
                     debug!(%room_id, "bigo enter room ok");
                 } else {
-                    warn!(%code, %room_id, "bigo enter room failed");
+                    return Err(DanmakuError::connection(format!(
+                        "Bigo enter room rejected: room_id={room_id} resCode={code}"
+                    )));
                 }
-                Ok(vec![])
+                Ok(DanmuProtocolOutput::default())
             }
-            EID_NORMAL_TEXT => Ok(Self::normal_text_to_items(&data)),
-            EID_PING => Ok(vec![]),
+            EID_NORMAL_TEXT => Ok(Self::normal_text_to_items(&data).into()),
+            EID_PING => Ok(DanmuProtocolOutput::default()),
             _ => {
                 debug!(eid, "bigo ignored frame");
-                Ok(vec![])
+                Ok(DanmuProtocolOutput::default())
             }
         }
     }
@@ -538,7 +573,7 @@ pub type BigoDanmuProvider = WebSocketDanmuProvider<BigoDanmuProtocol>;
 
 /// Creates a new Bigo danmu provider.
 pub fn create_bigo_danmu_provider() -> BigoDanmuProvider {
-    WebSocketDanmuProvider::with_protocol(BigoDanmuProtocol::default(), None)
+    WebSocketDanmuProvider::with_factory(BigoDanmuProtocol::default(), None)
 }
 
 #[cfg(test)]
@@ -617,6 +652,106 @@ mod tests {
         } else {
             panic!("expected gift");
         }
+    }
+
+    #[test]
+    fn factory_protocol_state_is_connection_local() {
+        let base = BigoDanmuProtocol::default();
+        let mut first = base.create_protocol();
+        let mut second = base.create_protocol();
+
+        let first_extras = HashMap::from([("stream_password".to_string(), "first".to_string())]);
+        let second_extras = HashMap::from([("stream_password".to_string(), "second".to_string())]);
+        first.configure_connection(None, Some(&first_extras));
+        second.configure_connection(None, Some(&second_extras));
+
+        first.session = Some(GuestSession {
+            device_id: "device-first".to_string(),
+            user_id: "user-first".to_string(),
+            uid_token: "token-first".to_string(),
+        });
+        second.session = Some(GuestSession {
+            device_id: "device-second".to_string(),
+            user_id: "user-second".to_string(),
+            uid_token: "token-second".to_string(),
+        });
+        first.phase = BigoConnectionPhase::Joined;
+
+        assert_eq!(first.room_password.as_deref(), Some("first"));
+        assert_eq!(second.room_password.as_deref(), Some("second"));
+        assert_eq!(
+            first.session.as_ref().map(|s| s.user_id.as_str()),
+            Some("user-first")
+        );
+        assert_eq!(
+            second.session.as_ref().map(|s| s.user_id.as_str()),
+            Some("user-second")
+        );
+        assert_eq!(first.phase, BigoConnectionPhase::Joined);
+        assert_eq!(second.phase, BigoConnectionPhase::AwaitingChallenge);
+        assert!(base.session.is_none());
+        assert!(base.room_password.is_none());
+    }
+
+    #[tokio::test]
+    async fn handshake_advances_state_and_returns_outbound_frames() {
+        let mut protocol = BigoDanmuProtocol {
+            session: Some(GuestSession {
+                device_id: "device".to_string(),
+                user_id: "user".to_string(),
+                uid_token: "token".to_string(),
+            }),
+            ..BigoDanmuProtocol::default()
+        };
+
+        let challenge = BigoDanmuProtocol::pack(EID_CHALLENGE, &json!({"challenge": "abcdefgh"}));
+        let (_, challenge_outbound) = protocol
+            .decode_message(&challenge, "room-1")
+            .await
+            .expect("challenge decode")
+            .into_parts();
+        assert_eq!(challenge_outbound.len(), 2);
+        assert_eq!(protocol.phase, BigoConnectionPhase::AwaitingLogin);
+
+        let login = BigoDanmuProtocol::pack(EID_LOGIN_RES, &json!({"res": "200"}));
+        let (_, login_outbound) = protocol
+            .decode_message(&login, "room-1")
+            .await
+            .expect("login decode")
+            .into_parts();
+        assert_eq!(login_outbound.len(), 1);
+        assert_eq!(protocol.phase, BigoConnectionPhase::AwaitingEnter);
+
+        let enter = BigoDanmuProtocol::pack(EID_ENTER_RES, &json!({"resCode": "200"}));
+        let output = protocol
+            .decode_message(&enter, "room-1")
+            .await
+            .expect("enter decode");
+        assert!(output.into_parts().0.is_empty());
+        assert_eq!(protocol.phase, BigoConnectionPhase::Joined);
+    }
+
+    #[tokio::test]
+    async fn rejected_login_and_enter_are_connection_errors() {
+        let mut protocol = BigoDanmuProtocol::default();
+
+        let login = BigoDanmuProtocol::pack(EID_LOGIN_RES, &json!({"res": "403"}));
+        let login_error = protocol
+            .decode_message(&login, "room-1")
+            .await
+            .expect_err("rejected login must fail the connection");
+        assert!(
+            matches!(login_error, DanmakuError::Connection(message) if message.contains("login rejected"))
+        );
+
+        let enter = BigoDanmuProtocol::pack(EID_ENTER_RES, &json!({"resCode": "401"}));
+        let enter_error = protocol
+            .decode_message(&enter, "room-1")
+            .await
+            .expect_err("rejected room entry must fail the connection");
+        assert!(
+            matches!(enter_error, DanmakuError::Connection(message) if message.contains("enter room rejected"))
+        );
     }
 
     /// Live integration: guest login → enter studio roomId → receive frames.

--- a/crates/platforms/src/extractor/platforms/bilibili/danmu.rs
+++ b/crates/platforms/src/extractor/platforms/bilibili/danmu.rs
@@ -12,13 +12,14 @@ use serde_json::Value;
 use std::collections::HashMap;
 use std::io::Read;
 use std::time::Duration;
-use tokio::sync::mpsc;
 use tokio_tungstenite::tungstenite::protocol::Message;
 use tracing::debug;
 
 use crate::danmaku::error::{DanmakuError, Result};
 use crate::danmaku::websocket::ws_headers_origin_referer_ua;
-use crate::danmaku::websocket::{DanmuProtocol, WebSocketDanmuProvider};
+use crate::danmaku::websocket::{
+    DanmuProtocol, DanmuProtocolFactory, DanmuProtocolOutput, WebSocketDanmuProvider,
+};
 use crate::danmaku::{DanmuControlEvent, DanmuItem, DanmuMessage};
 use crate::extractor::default::{DEFAULT_UA, default_client};
 use chrono::{TimeZone, Utc};
@@ -592,7 +593,9 @@ impl BilibiliDanmuProtocol {
     }
 }
 
-impl DanmuProtocol for BilibiliDanmuProtocol {
+impl DanmuProtocolFactory for BilibiliDanmuProtocol {
+    type Protocol = Self;
+
     fn platform(&self) -> &str {
         "bilibili"
     }
@@ -605,7 +608,18 @@ impl DanmuProtocol for BilibiliDanmuProtocol {
         capture_group_1_owned(&URL_REGEX, url)
     }
 
-    async fn websocket_url(&self, room_id: &str) -> Result<String> {
+    fn create_protocol(&self) -> Self::Protocol {
+        Self {
+            client: self.client.clone(),
+            cookies: self.cookies.clone(),
+            uid: None,
+            connection_cookies: None,
+        }
+    }
+}
+
+impl DanmuProtocol for BilibiliDanmuProtocol {
+    async fn websocket_url(&mut self, room_id: &str) -> Result<String> {
         // First get real room ID
         let real_room_id = self.get_real_room_id(room_id).await?;
 
@@ -651,7 +665,7 @@ impl DanmuProtocol for BilibiliDanmuProtocol {
         self.connection_cookies = cookies.map(ToString::to_string);
     }
 
-    async fn handshake_messages(&self, room_id: &str) -> Result<Vec<Message>> {
+    async fn handshake_messages(&mut self, room_id: &str) -> Result<Vec<Message>> {
         // Get real room ID and danmu info
         let real_room_id = self.get_real_room_id(room_id).await?;
         let (_ws_url, token) = self.get_danmu_info(real_room_id).await?;
@@ -671,11 +685,10 @@ impl DanmuProtocol for BilibiliDanmuProtocol {
     }
 
     async fn decode_message(
-        &self,
+        &mut self,
         message: &Message,
         _room_id: &str,
-        _tx: &mpsc::Sender<Message>,
-    ) -> Result<Vec<DanmuItem>> {
+    ) -> Result<DanmuProtocolOutput> {
         match message {
             Message::Binary(data) => {
                 let packets = Self::decode_packets(data);
@@ -700,9 +713,9 @@ impl DanmuProtocol for BilibiliDanmuProtocol {
                     }
                 }
 
-                Ok(items)
+                Ok(items.into())
             }
-            _ => Ok(vec![]),
+            _ => Ok(DanmuProtocolOutput::default()),
         }
     }
 }
@@ -748,7 +761,7 @@ pub type BilibiliDanmuProvider = WebSocketDanmuProvider<BilibiliDanmuProtocol>;
 
 /// Create a new Bilibili danmu provider.
 pub fn create_bilibili_danmu_provider() -> BilibiliDanmuProvider {
-    WebSocketDanmuProvider::with_protocol(BilibiliDanmuProtocol::default(), None)
+    WebSocketDanmuProvider::with_factory(BilibiliDanmuProtocol::default(), None)
 }
 
 #[cfg(test)]

--- a/crates/platforms/src/extractor/platforms/douyin/danmu.rs
+++ b/crates/platforms/src/extractor/platforms/douyin/danmu.rs
@@ -10,13 +10,14 @@ use rustc_hash::FxHashMap;
 use std::io::Read;
 use std::time::Duration;
 
-use tokio::sync::mpsc;
 use tokio_tungstenite::tungstenite::protocol::Message;
 use tracing::debug;
 
 use crate::danmaku::error::{DanmakuError, Result};
 use crate::danmaku::websocket::ws_headers_origin_ua;
-use crate::danmaku::websocket::{DanmuProtocol, WebSocketDanmuProvider};
+use crate::danmaku::websocket::{
+    DanmuProtocol, DanmuProtocolFactory, DanmuProtocolOutput, WebSocketDanmuProvider,
+};
 use crate::danmaku::{DanmuControlEvent, DanmuItem, DanmuMessage};
 use crate::extractor::default::DEFAULT_UA;
 use crate::extractor::platforms::douyin::apis::LIVE_DOUYIN_URL;
@@ -273,7 +274,9 @@ impl DouyinDanmuProtocol {
     }
 }
 
-impl DanmuProtocol for DouyinDanmuProtocol {
+impl DanmuProtocolFactory for DouyinDanmuProtocol {
+    type Protocol = Self;
+
     fn platform(&self) -> &str {
         "douyin"
     }
@@ -286,7 +289,13 @@ impl DanmuProtocol for DouyinDanmuProtocol {
         capture_group_1_owned(&URL_REGEX, url)
     }
 
-    async fn websocket_url(&self, room_id: &str) -> Result<String> {
+    fn create_protocol(&self) -> Self::Protocol {
+        self.clone()
+    }
+}
+
+impl DanmuProtocol for DouyinDanmuProtocol {
+    async fn websocket_url(&mut self, room_id: &str) -> Result<String> {
         // Generate a unique user ID for this session
         let user_id = Self::generate_user_unique_id();
         Self::build_websocket_url(room_id, &user_id)
@@ -307,7 +316,7 @@ impl DanmuProtocol for DouyinDanmuProtocol {
         }
     }
 
-    async fn handshake_messages(&self, _room_id: &str) -> Result<Vec<Message>> {
+    async fn handshake_messages(&mut self, _room_id: &str) -> Result<Vec<Message>> {
         // Douyin doesn't require explicit handshake messages after connection
         // The connection parameters in the URL handle authentication
         Ok(vec![])
@@ -322,30 +331,32 @@ impl DanmuProtocol for DouyinDanmuProtocol {
     }
 
     async fn decode_message(
-        &self,
+        &mut self,
         message: &Message,
         _room_id: &str,
-        tx: &mpsc::Sender<Message>,
-    ) -> Result<Vec<DanmuItem>> {
+    ) -> Result<DanmuProtocolOutput> {
         match message {
             Message::Binary(data) => {
                 let (response, log_id) = Self::decode_push_frame(data)?;
 
-                if response.need_ack {
+                let outbound = if response.need_ack {
                     let ack_packet =
                         Self::create_ack_packet(log_id, response.internal_ext.encode_to_vec())?;
-                    tx.send(Message::Binary(ack_packet)).await.map_err(|e| {
-                        DanmakuError::connection(format!("Failed to send ack packet: {}", e))
-                    })?;
-                }
+                    vec![Message::Binary(ack_packet)]
+                } else {
+                    Vec::new()
+                };
 
-                Ok(Self::parse_response_messages(&response.messages))
+                Ok(DanmuProtocolOutput::new(
+                    Self::parse_response_messages(&response.messages),
+                    outbound,
+                ))
             }
             Message::Text(text) => {
                 debug!("Received text message: {}", text);
-                Ok(vec![])
+                Ok(DanmuProtocolOutput::default())
             }
-            _ => Ok(vec![]),
+            _ => Ok(DanmuProtocolOutput::default()),
         }
     }
 }
@@ -355,7 +366,7 @@ pub type DouyinDanmuProvider = WebSocketDanmuProvider<DouyinDanmuProtocol>;
 
 /// Creates a new Douyin danmu provider.
 pub fn create_douyin_danmu_provider() -> DouyinDanmuProvider {
-    WebSocketDanmuProvider::with_protocol(DouyinDanmuProtocol::default(), None)
+    WebSocketDanmuProvider::with_factory(DouyinDanmuProtocol::default(), None)
 }
 
 #[cfg(test)]
@@ -424,7 +435,7 @@ mod tests {
     #[tokio::test]
     #[ignore] // Ignore by default as it requires JS engine which is slow
     async fn test_websocket_url_generation() {
-        let protocol = DouyinDanmuProtocol::default();
+        let mut protocol = DouyinDanmuProtocol::default();
         let room_id = "123456789";
 
         let result = protocol.websocket_url(room_id).await;
@@ -450,7 +461,7 @@ mod tests {
             .try_init()
             .unwrap();
 
-        let protocol = DouyinDanmuProtocol::default();
+        let mut protocol = DouyinDanmuProtocol::default();
         let room_id = "7592278867031231283";
         // Generate WebSocket URL
         let ws_url = protocol

--- a/crates/platforms/src/extractor/platforms/douyu/danmu.rs
+++ b/crates/platforms/src/extractor/platforms/douyu/danmu.rs
@@ -6,13 +6,14 @@
 use bytes::Bytes;
 use chrono::Utc;
 use std::time::Duration;
-use tokio::sync::mpsc;
 use tokio_tungstenite::tungstenite::protocol::Message;
 use tracing::debug;
 
 use crate::danmaku::error::{DanmakuError, Result};
 use crate::danmaku::websocket::ws_headers_origin_referer_ua;
-use crate::danmaku::websocket::{DanmuProtocol, WebSocketDanmuProvider};
+use crate::danmaku::websocket::{
+    DanmuProtocol, DanmuProtocolFactory, DanmuProtocolOutput, WebSocketDanmuProvider,
+};
 use crate::danmaku::{DanmuItem, DanmuMessage};
 use crate::extractor::default::DEFAULT_UA;
 use crate::extractor::platforms::douyu::stt;
@@ -107,7 +108,9 @@ impl DouyuDanmuProtocol {
     }
 }
 
-impl DanmuProtocol for DouyuDanmuProtocol {
+impl DanmuProtocolFactory for DouyuDanmuProtocol {
+    type Protocol = Self;
+
     fn platform(&self) -> &str {
         "douyu"
     }
@@ -120,7 +123,13 @@ impl DanmuProtocol for DouyuDanmuProtocol {
         capture_group_1_owned(&URL_REGEX, url)
     }
 
-    async fn websocket_url(&self, _room_id: &str) -> Result<String> {
+    fn create_protocol(&self) -> Self::Protocol {
+        self.clone()
+    }
+}
+
+impl DanmuProtocol for DouyuDanmuProtocol {
+    async fn websocket_url(&mut self, _room_id: &str) -> Result<String> {
         Ok(DOUYU_WS_URL.to_string())
     }
 
@@ -132,7 +141,7 @@ impl DanmuProtocol for DouyuDanmuProtocol {
         self.cookies.clone()
     }
 
-    async fn handshake_messages(&self, room_id: &str) -> Result<Vec<Message>> {
+    async fn handshake_messages(&mut self, room_id: &str) -> Result<Vec<Message>> {
         // Create login and join group messages
         let login_msg = create_login_message(room_id);
         let join_group_msg = create_join_group_message(room_id, DEFAULT_GROUP_ID);
@@ -159,11 +168,10 @@ impl DanmuProtocol for DouyuDanmuProtocol {
     }
 
     async fn decode_message(
-        &self,
+        &mut self,
         message: &Message,
         _room_id: &str,
-        _tx: &mpsc::Sender<Message>,
-    ) -> Result<Vec<DanmuItem>> {
+    ) -> Result<DanmuProtocolOutput> {
         match message {
             Message::Binary(data) => {
                 let packets = parse_packets(data);
@@ -199,25 +207,25 @@ impl DanmuProtocol for DouyuDanmuProtocol {
                     }
                 }
 
-                Ok(items)
+                Ok(items.into())
             }
             Message::Text(text) => {
                 debug!("Received text message: {}", text);
-                Ok(vec![])
+                Ok(DanmuProtocolOutput::default())
             }
             Message::Ping(_) => {
                 debug!("Received ping");
-                Ok(vec![])
+                Ok(DanmuProtocolOutput::default())
             }
             Message::Pong(_) => {
                 debug!("Received pong");
-                Ok(vec![])
+                Ok(DanmuProtocolOutput::default())
             }
             Message::Close(frame) => {
                 debug!("Received close frame: {:?}", frame);
                 Err(DanmakuError::connection("Connection closed by server"))
             }
-            _ => Ok(vec![]),
+            _ => Ok(DanmuProtocolOutput::default()),
         }
     }
 }
@@ -227,7 +235,7 @@ pub type DouyuDanmuProvider = WebSocketDanmuProvider<DouyuDanmuProtocol>;
 
 /// Creates a new Douyu danmu provider.
 pub fn create_douyu_danmu_provider() -> DouyuDanmuProvider {
-    WebSocketDanmuProvider::with_protocol(DouyuDanmuProtocol::default(), None)
+    WebSocketDanmuProvider::with_factory(DouyuDanmuProtocol::default(), None)
 }
 
 #[cfg(test)]
@@ -291,7 +299,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_handshake_messages() {
-        let protocol = DouyuDanmuProtocol::default();
+        let mut protocol = DouyuDanmuProtocol::default();
         let messages = protocol.handshake_messages("123456").await.unwrap();
 
         assert_eq!(messages.len(), 2); // Login + JoinGroup
@@ -308,7 +316,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_websocket_url() {
-        let protocol = DouyuDanmuProtocol::default();
+        let mut protocol = DouyuDanmuProtocol::default();
         let url = protocol.websocket_url("123456").await.unwrap();
 
         assert!(url.starts_with("wss://"));

--- a/crates/platforms/src/extractor/platforms/huya/danmu.rs
+++ b/crates/platforms/src/extractor/platforms/huya/danmu.rs
@@ -15,7 +15,9 @@ use tokio_tungstenite::tungstenite::protocol::Message;
 use tracing::debug;
 
 use crate::danmaku::error::{DanmakuError, Result};
-use crate::danmaku::websocket::{DanmuProtocol, WebSocketDanmuProvider};
+use crate::danmaku::websocket::{
+    DanmuProtocol, DanmuProtocolFactory, DanmuProtocolOutput, WebSocketDanmuProvider,
+};
 use crate::danmaku::{DanmuItem, DanmuMessage};
 use crate::extractor::platforms::huya::huya_uri;
 use crate::extractor::platforms::huya::{HuyaSourceType, HuyaWsCmd};
@@ -65,7 +67,9 @@ impl HuyaDanmuProtocol {
     }
 }
 
-impl DanmuProtocol for HuyaDanmuProtocol {
+impl DanmuProtocolFactory for HuyaDanmuProtocol {
+    type Protocol = Self;
+
     fn platform(&self) -> &str {
         "huya"
     }
@@ -78,7 +82,13 @@ impl DanmuProtocol for HuyaDanmuProtocol {
         capture_group_1_owned(&URL_REGEX, url)
     }
 
-    async fn websocket_url(&self, _room_id: &str) -> Result<String> {
+    fn create_protocol(&self) -> Self::Protocol {
+        self.clone()
+    }
+}
+
+impl DanmuProtocol for HuyaDanmuProtocol {
+    async fn websocket_url(&mut self, _room_id: &str) -> Result<String> {
         Ok(HUYA_WS_URL.to_string())
     }
 
@@ -86,7 +96,7 @@ impl DanmuProtocol for HuyaDanmuProtocol {
         self.cookies.clone()
     }
 
-    async fn handshake_messages(&self, room_id: &str) -> Result<Vec<Message>> {
+    async fn handshake_messages(&mut self, room_id: &str) -> Result<Vec<Message>> {
         let room_id_num: i64 = room_id
             .parse()
             .map_err(|_| DanmakuError::connection("Invalid room ID".to_string()))?;
@@ -119,14 +129,13 @@ impl DanmuProtocol for HuyaDanmuProtocol {
     }
 
     async fn decode_message(
-        &self,
+        &mut self,
         message: &Message,
         room_id: &str,
-        tx: &tokio::sync::mpsc::Sender<Message>,
-    ) -> Result<Vec<DanmuItem>> {
+    ) -> Result<DanmuProtocolOutput> {
         match message {
-            Message::Binary(data) => self.parse_socket_command(data, room_id, tx).await,
-            _ => Ok(vec![]),
+            Message::Binary(data) => self.parse_socket_command(data, room_id),
+            _ => Ok(DanmuProtocolOutput::default()),
         }
     }
 }
@@ -135,7 +144,7 @@ impl DanmuProtocol for HuyaDanmuProtocol {
 pub type HuyaDanmuProvider = WebSocketDanmuProvider<HuyaDanmuProtocol>;
 
 pub fn create_huya_danmu_provider() -> HuyaDanmuProvider {
-    HuyaDanmuProvider::with_protocol(HuyaDanmuProtocol::default(), None)
+    HuyaDanmuProvider::with_factory(HuyaDanmuProtocol::default(), None)
 }
 
 // Static helper methods for TARS encoding/decoding
@@ -237,14 +246,9 @@ impl HuyaDanmuProtocol {
     }
 
     /// Parse incoming WebSocket command and handle protocol-level responses
-    async fn parse_socket_command(
-        &self,
-        data: &[u8],
-        room_id: &str,
-        tx: &tokio::sync::mpsc::Sender<Message>,
-    ) -> Result<Vec<DanmuItem>> {
+    fn parse_socket_command(&self, data: &[u8], room_id: &str) -> Result<DanmuProtocolOutput> {
         if data.len() < 4 {
-            return Ok(vec![]);
+            return Ok(DanmuProtocolOutput::default());
         }
 
         // First, decode the WebSocketCommand wrapper (naked struct)
@@ -252,7 +256,7 @@ impl HuyaDanmuProtocol {
             Ok(v) => v,
             Err(e) => {
                 debug!("Failed to decode TARS value from socket command: {}", e);
-                return Ok(vec![]);
+                return Ok(DanmuProtocolOutput::default());
             }
         };
 
@@ -260,7 +264,7 @@ impl HuyaDanmuProtocol {
             Ok(cmd) => cmd,
             Err(e) => {
                 debug!("Failed to convert TARS value to WebSocketCommand: {}", e);
-                return Ok(vec![]);
+                return Ok(DanmuProtocolOutput::default());
             }
         };
 
@@ -270,14 +274,14 @@ impl HuyaDanmuProtocol {
             // HeartbeatRsp (2) - just acknowledge
             2 => {
                 debug!("Received heartbeat response");
-                Ok(vec![])
+                Ok(DanmuProtocolOutput::default())
             }
             // RegisterRsp (4) - check if it's doLaunch response, then send join group packet
             4 => {
                 let inner_data = socket_cmd.data();
                 if inner_data.is_empty() {
                     debug!("Received empty RegisterRsp");
-                    return Ok(vec![]);
+                    return Ok(DanmuProtocolOutput::default());
                 }
 
                 // Decode the inner TARS message to check func_name
@@ -286,56 +290,56 @@ impl HuyaDanmuProtocol {
                     Ok(Some(msg)) => msg,
                     Ok(None) => {
                         debug!("No TARS message in RegisterRsp");
-                        return Ok(vec![]);
+                        return Ok(DanmuProtocolOutput::default());
                     }
                     Err(e) => {
                         debug!("Failed to decode RegisterRsp inner message: {}", e);
-                        return Ok(vec![]);
+                        return Ok(DanmuProtocolOutput::default());
                     }
                 };
 
                 // Only send join group packet for doLaunch response
                 if message.header.func_name == "doLaunch" {
                     debug!("Received doLaunch response, sending join group packet");
-                    if let Ok(presenter_uid) = room_id.parse::<i64>() {
+                    let outbound = if let Ok(presenter_uid) = room_id.parse::<i64>() {
                         match Self::create_create_join_group_packet(presenter_uid) {
                             Ok(packet) => {
-                                if let Err(e) = tx.send(Message::Binary(packet)).await {
-                                    debug!("Failed to send join group packet: {}", e);
-                                } else {
-                                    debug!(
-                                        "Sent join group packet for presenter_uid: {}",
-                                        presenter_uid
-                                    );
-                                }
+                                debug!(
+                                    "Queued join group packet for presenter_uid: {}",
+                                    presenter_uid
+                                );
+                                vec![Message::Binary(packet)]
                             }
                             Err(e) => {
                                 debug!("Failed to create join group packet: {}", e);
+                                Vec::new()
                             }
                         }
                     } else {
                         debug!("Invalid room_id for join group: {}", room_id);
-                    }
+                        Vec::new()
+                    };
+                    return Ok(DanmuProtocolOutput::outbound(outbound));
                 } else {
                     debug!(
                         "Received RegisterRsp with func_name: {}",
                         message.header.func_name
                     );
                 }
-                Ok(vec![])
+                Ok(DanmuProtocolOutput::default())
             }
             // WupRsp (7) - Push messages in WsPushMessage format
             7 => {
                 let inner_data = socket_cmd.data();
                 if inner_data.is_empty() {
-                    return Ok(vec![]);
+                    return Ok(DanmuProtocolOutput::default());
                 }
 
                 let push_msg_val = match decode_tars_struct(Bytes::copy_from_slice(inner_data)) {
                     Ok(v) => v,
                     Err(e) => {
                         debug!("Failed to decode WsPushMessage TARS: {}", e);
-                        return Ok(vec![]);
+                        return Ok(DanmuProtocolOutput::default());
                     }
                 };
 
@@ -343,7 +347,7 @@ impl HuyaDanmuProtocol {
                     Ok(push_msg) => {
                         // we only want 1400 uri (danmu messages)
                         if push_msg.i_uri != huya_uri::MESSAGE_NOTICE as i64 {
-                            return Ok(vec![]);
+                            return Ok(DanmuProtocolOutput::default());
                         }
 
                         // Parse the inner s_msg data as MessageNotice
@@ -353,7 +357,7 @@ impl HuyaDanmuProtocol {
                                     Ok(v) => v,
                                     Err(e) => {
                                         debug!("Failed to decode MessageNotice TARS: {}", e);
-                                        return Ok(vec![]);
+                                        return Ok(DanmuProtocolOutput::default());
                                     }
                                 };
 
@@ -373,7 +377,7 @@ impl HuyaDanmuProtocol {
                                         if color != -1 && color != 0 {
                                             danmu = danmu.with_color(format!("#{:06X}", color));
                                         }
-                                        return Ok(vec![DanmuItem::Message(danmu)]);
+                                        return Ok(vec![DanmuItem::Message(danmu)].into());
                                     }
                                 }
                                 Err(e) => {
@@ -381,21 +385,21 @@ impl HuyaDanmuProtocol {
                                 }
                             }
                         }
-                        Ok(vec![])
+                        Ok(DanmuProtocolOutput::default())
                     }
                     Err(e) => {
                         debug!("Failed to convert to WsPushMessage: {}", e);
-                        Ok(vec![])
+                        Ok(DanmuProtocolOutput::default())
                     }
                 }
             }
             // RegisterGroupRsp (17) - acknowledgment of group registration
             17 => {
                 debug!("Successfully registered to group");
-                Ok(vec![])
+                Ok(DanmuProtocolOutput::default())
             }
             // Other types
-            _ => Ok(vec![]),
+            _ => Ok(DanmuProtocolOutput::default()),
         }
     }
 }
@@ -518,7 +522,7 @@ mod tests {
         use tokio_tungstenite::connect_async;
 
         let room_id = "660000";
-        let protocol = HuyaDanmuProtocol::default();
+        let mut protocol = HuyaDanmuProtocol::default();
 
         // Connect directly to verify the flow
         let ws_url = protocol.websocket_url(room_id).await.unwrap();
@@ -536,21 +540,12 @@ mod tests {
         }
         println!("Sent handshake messages");
 
-        // Create a channel for responses
-        let (tx, mut rx) = tokio::sync::mpsc::channel(10);
-
         // Receive a few messages and verify WebSocketCommand decoding
         let mut response_count = 0;
         let start = std::time::Instant::now();
 
         while start.elapsed() < Duration::from_secs(10) && response_count < 20 {
             tokio::select! {
-                Some(response_msg) = rx.recv() => {
-                    // Send any response messages back
-                    if let Err(e) = ws_stream.send(response_msg).await {
-                        println!("Failed to send response: {}", e);
-                    }
-                }
                 msg_result = ws_stream.next() => {
                     match msg_result {
                         Some(Ok(Message::Binary(data))) => {
@@ -560,8 +555,12 @@ mod tests {
                                     response_count += 1;
 
                                     // Parse through our protocol
-                                    match protocol.parse_socket_command(&data, room_id, &tx).await {
-                                        Ok(items) => {
+                                    match protocol.parse_socket_command(&data, room_id) {
+                                        Ok(output) => {
+                                            let (items, outbound) = output.into_parts();
+                                            for response in outbound {
+                                                ws_stream.send(response).await.expect("Failed to send response");
+                                            }
                                             for item in items {
                                                 match item {
                                                     crate::danmaku::DanmuItem::Message(danmu) => {

--- a/crates/platforms/src/extractor/platforms/soop/danmu.rs
+++ b/crates/platforms/src/extractor/platforms/soop/danmu.rs
@@ -9,14 +9,15 @@ use std::time::Duration;
 
 use bytes::Bytes;
 use chrono::Utc;
-use tokio::sync::mpsc;
 use tokio_tungstenite::tungstenite::http::{HeaderMap, HeaderValue, header};
 use tokio_tungstenite::tungstenite::protocol::Message;
-use tracing::{debug, warn};
+use tracing::debug;
 
 use crate::danmaku::error::{DanmakuError, Result};
 use crate::danmaku::websocket::ws_headers_origin_ua;
-use crate::danmaku::websocket::{DanmuProtocol, WebSocketDanmuProvider};
+use crate::danmaku::websocket::{
+    DanmuProtocol, DanmuProtocolFactory, DanmuProtocolOutput, WebSocketDanmuProvider,
+};
 use crate::danmaku::{DanmuItem, DanmuMessage};
 use crate::extractor::default::DEFAULT_UA;
 use crate::extractor::platforms::soop::URL_REGEX;
@@ -249,7 +250,9 @@ impl SoopDanmuProtocol {
     }
 }
 
-impl DanmuProtocol for SoopDanmuProtocol {
+impl DanmuProtocolFactory for SoopDanmuProtocol {
+    type Protocol = Self;
+
     fn platform(&self) -> &str {
         "soop"
     }
@@ -262,7 +265,16 @@ impl DanmuProtocol for SoopDanmuProtocol {
         capture_group_1_owned(&URL_REGEX, url)
     }
 
-    async fn websocket_url(&self, room_id: &str) -> Result<String> {
+    fn create_protocol(&self) -> Self::Protocol {
+        Self {
+            session: ChatSession::default(),
+            cookies: self.cookies.clone(),
+        }
+    }
+}
+
+impl DanmuProtocol for SoopDanmuProtocol {
+    async fn websocket_url(&mut self, room_id: &str) -> Result<String> {
         let session = self.session.clone();
         let bjid = if session.bjid.is_empty() {
             room_id.to_string()
@@ -348,7 +360,7 @@ impl DanmuProtocol for SoopDanmuProtocol {
         }
     }
 
-    async fn handshake_messages(&self, _room_id: &str) -> Result<Vec<Message>> {
+    async fn handshake_messages(&mut self, _room_id: &str) -> Result<Vec<Message>> {
         // Guest login: empty ticket, empty password, flag 16.
         let login = Self::make_packet(SVC_LOGIN, &["", "", "16"]);
         Ok(vec![Message::Binary(login)])
@@ -363,15 +375,15 @@ impl DanmuProtocol for SoopDanmuProtocol {
     }
 
     async fn decode_message(
-        &self,
+        &mut self,
         message: &Message,
         room_id: &str,
-        tx: &mpsc::Sender<Message>,
-    ) -> Result<Vec<DanmuItem>> {
+    ) -> Result<DanmuProtocolOutput> {
         match message {
             Message::Binary(data) => {
                 let packets = Self::parse_packets(data);
                 let mut items = Vec::new();
+                let mut outbound = Vec::new();
 
                 for (svc, fields) in packets {
                     match svc {
@@ -400,15 +412,12 @@ impl DanmuProtocol for SoopDanmuProtocol {
                                     mode.as_str(),
                                 ],
                             );
-                            if let Err(e) = tx.send(Message::Binary(join)).await {
-                                warn!(error = %e, "failed to send SOOP JOINCH");
-                            } else {
-                                debug!(
-                                    chatno = %session.chatno,
-                                    room_id,
-                                    "SOOP JOINCH sent after LOGIN"
-                                );
-                            }
+                            outbound.push(Message::Binary(join));
+                            debug!(
+                                chatno = %session.chatno,
+                                room_id,
+                                "SOOP JOINCH queued after LOGIN"
+                            );
                         }
                         SVC_JOINCH => {
                             if Self::is_join_failure(&fields) {
@@ -436,23 +445,23 @@ impl DanmuProtocol for SoopDanmuProtocol {
                     }
                 }
 
-                Ok(items)
+                Ok(DanmuProtocolOutput::new(items, outbound))
             }
             Message::Text(text) => {
                 debug!(%text, "SOOP unexpected text frame");
-                Ok(vec![])
+                Ok(DanmuProtocolOutput::default())
             }
             Message::Close(frame) => Err(DanmakuError::connection(format!(
                 "SOOP chat closed: {frame:?}"
             ))),
-            _ => Ok(vec![]),
+            _ => Ok(DanmuProtocolOutput::default()),
         }
     }
 }
 
 /// Create a SOOP guest danmu provider.
 pub fn create_soop_danmu_provider() -> WebSocketDanmuProvider<SoopDanmuProtocol> {
-    WebSocketDanmuProvider::with_protocol(SoopDanmuProtocol::new(), None)
+    WebSocketDanmuProvider::with_factory(SoopDanmuProtocol::new(), None)
 }
 
 #[cfg(test)]
@@ -514,10 +523,10 @@ mod tests {
     }
 
     #[test]
-    fn cloned_protocols_keep_connection_state_isolated() {
+    fn factory_protocols_keep_connection_state_isolated() {
         let base = SoopDanmuProtocol::new();
-        let mut first = base.clone();
-        let mut second = base.clone();
+        let mut first = base.create_protocol();
+        let mut second = base.create_protocol();
 
         let mut first_extras = HashMap::new();
         first_extras.insert("chatno".into(), "1001".into());
@@ -537,11 +546,10 @@ mod tests {
 
     #[tokio::test]
     async fn login_without_chatno_errors() {
-        let p = SoopDanmuProtocol::new();
+        let mut p = SoopDanmuProtocol::new();
         let login = SoopDanmuProtocol::make_packet(SVC_LOGIN, &["", "", "16"]);
-        let (tx, _rx) = mpsc::channel(4);
         let err = p
-            .decode_message(&Message::Binary(login), "bjid", &tx)
+            .decode_message(&Message::Binary(login), "bjid")
             .await
             .expect_err("must require chatno");
         assert!(err.to_string().contains("chatno"));
@@ -559,13 +567,13 @@ mod tests {
         p.configure_connection(None, Some(&extras));
 
         let login = SoopDanmuProtocol::make_packet(SVC_LOGIN, &["", "", "16"]);
-        let (tx, mut rx) = mpsc::channel(4);
-        let items = p
-            .decode_message(&Message::Binary(login), "example", &tx)
+        let output = p
+            .decode_message(&Message::Binary(login), "example")
             .await
             .expect("decode");
+        let (items, mut outbound) = output.into_parts();
         assert!(items.is_empty());
-        let join = rx.try_recv().expect("JOIN packet");
+        let join = outbound.pop().expect("JOIN packet");
         let Message::Binary(data) = join else {
             panic!("expected binary JOIN");
         };

--- a/crates/platforms/src/extractor/platforms/twitcasting/danmu.rs
+++ b/crates/platforms/src/extractor/platforms/twitcasting/danmu.rs
@@ -11,13 +11,14 @@ use md5::{Digest, Md5};
 use reqwest::Client;
 use serde::Deserialize;
 use std::time::Duration;
-use tokio::sync::mpsc;
 use tokio_tungstenite::tungstenite::protocol::Message;
 use tracing::{debug, warn};
 
 use crate::danmaku::error::{DanmakuError, Result};
 use crate::danmaku::websocket::ws_headers_origin_referer;
-use crate::danmaku::websocket::{DanmuProtocol, WebSocketDanmuProvider};
+use crate::danmaku::websocket::{
+    DanmuProtocol, DanmuProtocolFactory, DanmuProtocolOutput, WebSocketDanmuProvider,
+};
 use crate::danmaku::{DanmuItem, DanmuMessage};
 use crate::extractor::default::default_client;
 use tokio_tungstenite::tungstenite::http::HeaderMap;
@@ -102,8 +103,6 @@ pub struct TwitcastingDanmuProtocol {
     cookies: Option<String>,
     /// Optional password for password-protected streams
     password: Option<String>,
-    /// Cached WebSocket URL (set after websocket_url is called)
-    cached_ws_url: std::sync::Arc<parking_lot::RwLock<Option<String>>>,
 }
 
 impl Default for TwitcastingDanmuProtocol {
@@ -112,7 +111,6 @@ impl Default for TwitcastingDanmuProtocol {
             client: default_client(),
             cookies: None,
             password: None,
-            cached_ws_url: std::sync::Arc::new(parking_lot::RwLock::new(None)),
         }
     }
 }
@@ -129,7 +127,6 @@ impl TwitcastingDanmuProtocol {
             client: default_client(),
             cookies: Some(cookies.into()),
             password: None,
-            cached_ws_url: std::sync::Arc::new(parking_lot::RwLock::new(None)),
         }
     }
 
@@ -139,7 +136,6 @@ impl TwitcastingDanmuProtocol {
             client: default_client(),
             cookies: None,
             password: Some(password.into()),
-            cached_ws_url: std::sync::Arc::new(parking_lot::RwLock::new(None)),
         }
     }
 
@@ -149,7 +145,6 @@ impl TwitcastingDanmuProtocol {
             client: default_client(),
             cookies: Some(cookies.into()),
             password: Some(password.into()),
-            cached_ws_url: std::sync::Arc::new(parking_lot::RwLock::new(None)),
         }
     }
 
@@ -345,7 +340,9 @@ impl TwitcastingDanmuProtocol {
     }
 }
 
-impl DanmuProtocol for TwitcastingDanmuProtocol {
+impl DanmuProtocolFactory for TwitcastingDanmuProtocol {
+    type Protocol = Self;
+
     fn platform(&self) -> &str {
         "twitcasting"
     }
@@ -358,7 +355,13 @@ impl DanmuProtocol for TwitcastingDanmuProtocol {
         capture_group_1_owned(&URL_REGEX, url)
     }
 
-    async fn websocket_url(&self, room_id: &str) -> Result<String> {
+    fn create_protocol(&self) -> Self::Protocol {
+        self.clone()
+    }
+}
+
+impl DanmuProtocol for TwitcastingDanmuProtocol {
+    async fn websocket_url(&mut self, room_id: &str) -> Result<String> {
         // First get the movie ID from streamserver.php
         let movie_id = self.get_movie_id(room_id).await?;
         debug!("TwitCasting movie ID: {}", movie_id);
@@ -366,9 +369,6 @@ impl DanmuProtocol for TwitcastingDanmuProtocol {
         // Then get the WebSocket URL
         let ws_url = self.get_event_pubsub_url(&movie_id).await?;
         debug!("TwitCasting WebSocket URL: {}", ws_url);
-
-        // Cache the URL
-        *self.cached_ws_url.write() = Some(ws_url.clone());
 
         Ok(ws_url)
     }
@@ -381,7 +381,7 @@ impl DanmuProtocol for TwitcastingDanmuProtocol {
         ws_headers_origin_referer("https://twitcasting.tv", "https://twitcasting.tv")
     }
 
-    async fn handshake_messages(&self, _room_id: &str) -> Result<Vec<Message>> {
+    async fn handshake_messages(&mut self, _room_id: &str) -> Result<Vec<Message>> {
         // TwitCasting doesn't require explicit handshake - connection is sufficient
         Ok(vec![])
     }
@@ -396,11 +396,10 @@ impl DanmuProtocol for TwitcastingDanmuProtocol {
     }
 
     async fn decode_message(
-        &self,
+        &mut self,
         message: &Message,
         _room_id: &str,
-        tx: &mpsc::Sender<Message>,
-    ) -> Result<Vec<DanmuItem>> {
+    ) -> Result<DanmuProtocolOutput> {
         match message {
             Message::Text(text) => {
                 let mut items = Vec::new();
@@ -419,24 +418,24 @@ impl DanmuProtocol for TwitcastingDanmuProtocol {
                     items.extend(parsed.into_iter().map(DanmuItem::Message));
                 }
 
-                Ok(items)
+                Ok(items.into())
             }
             Message::Binary(data) => {
                 // Try to parse binary as text
                 if let Ok(text) = String::from_utf8(data.to_vec()) {
-                    return Ok(Self::parse_comments(&text)
-                        .into_iter()
-                        .map(DanmuItem::Message)
-                        .collect());
+                    return Ok(DanmuProtocolOutput::items(
+                        Self::parse_comments(&text)
+                            .into_iter()
+                            .map(DanmuItem::Message)
+                            .collect(),
+                    ));
                 }
-                Ok(vec![])
+                Ok(DanmuProtocolOutput::default())
             }
-            Message::Ping(data) => {
-                // Respond to WebSocket-level PING
-                let _ = tx.send(Message::Pong(data.clone())).await;
-                Ok(vec![])
-            }
-            _ => Ok(vec![]),
+            Message::Ping(data) => Ok(DanmuProtocolOutput::outbound(vec![Message::Pong(
+                data.clone(),
+            )])),
+            _ => Ok(DanmuProtocolOutput::default()),
         }
     }
 }
@@ -446,7 +445,7 @@ pub type TwitcastingDanmuProvider = WebSocketDanmuProvider<TwitcastingDanmuProto
 
 /// Creates a new TwitCasting danmu provider.
 pub fn create_twitcasting_danmu_provider() -> TwitcastingDanmuProvider {
-    WebSocketDanmuProvider::with_protocol(TwitcastingDanmuProtocol::default(), None)
+    WebSocketDanmuProvider::with_factory(TwitcastingDanmuProtocol::default(), None)
 }
 
 #[cfg(test)]
@@ -526,6 +525,20 @@ mod tests {
 
         let result = TwitcastingDanmuProtocol::parse_comments(json);
         assert!(result.is_empty());
+    }
+
+    #[tokio::test]
+    async fn websocket_ping_returns_pong_as_outbound_protocol_frame() {
+        let mut protocol = TwitcastingDanmuProtocol::default();
+        let payload = bytes::Bytes::from_static(b"ping");
+        let output = protocol
+            .decode_message(&Message::Ping(payload.clone()), "user")
+            .await
+            .expect("decode ping");
+        let (items, outbound) = output.into_parts();
+
+        assert!(items.is_empty());
+        assert_eq!(outbound, vec![Message::Pong(payload)]);
     }
 
     /// Real integration test - connects to an actual TwitCasting stream

--- a/crates/platforms/src/extractor/platforms/twitch/danmu.rs
+++ b/crates/platforms/src/extractor/platforms/twitch/danmu.rs
@@ -3,12 +3,13 @@
 //! Implements danmu collection for the Twitch streaming platform using IRC over WebSocket.
 
 use std::time::Duration;
-use tokio::sync::mpsc;
 use tokio_tungstenite::tungstenite::protocol::Message;
 use tracing::debug;
 
 use crate::danmaku::error::Result;
-use crate::danmaku::websocket::{DanmuProtocol, WebSocketDanmuProvider};
+use crate::danmaku::websocket::{
+    DanmuProtocol, DanmuProtocolFactory, DanmuProtocolOutput, WebSocketDanmuProvider,
+};
 use crate::danmaku::{DanmuItem, DanmuMessage, DanmuType};
 
 use super::URL_REGEX;
@@ -131,7 +132,9 @@ impl TwitchDanmuProtocol {
     }
 }
 
-impl DanmuProtocol for TwitchDanmuProtocol {
+impl DanmuProtocolFactory for TwitchDanmuProtocol {
+    type Protocol = Self;
+
     fn platform(&self) -> &str {
         "twitch"
     }
@@ -144,7 +147,13 @@ impl DanmuProtocol for TwitchDanmuProtocol {
         capture_group_1(&URL_REGEX, url).map(str::to_lowercase)
     }
 
-    async fn websocket_url(&self, _room_id: &str) -> Result<String> {
+    fn create_protocol(&self) -> Self::Protocol {
+        self.clone()
+    }
+}
+
+impl DanmuProtocol for TwitchDanmuProtocol {
+    async fn websocket_url(&mut self, _room_id: &str) -> Result<String> {
         Ok(TWITCH_WS_URL.to_string())
     }
 
@@ -153,7 +162,7 @@ impl DanmuProtocol for TwitchDanmuProtocol {
         None
     }
 
-    async fn handshake_messages(&self, room_id: &str) -> Result<Vec<Message>> {
+    async fn handshake_messages(&mut self, room_id: &str) -> Result<Vec<Message>> {
         let mut messages = Vec::new();
 
         // Request Twitch capabilities for tags and commands
@@ -205,34 +214,32 @@ impl DanmuProtocol for TwitchDanmuProtocol {
     }
 
     async fn decode_message(
-        &self,
+        &mut self,
         message: &Message,
         _room_id: &str,
-        tx: &mpsc::Sender<Message>,
-    ) -> Result<Vec<DanmuItem>> {
+    ) -> Result<DanmuProtocolOutput> {
         match message {
-            Message::Text(text) => Self::decode_text(text, tx).await,
+            Message::Text(text) => Ok(Self::decode_text(text)),
             Message::Binary(data) => {
                 // Twitch IRC uses text, but handle binary just in case
                 if let Ok(text) = std::str::from_utf8(data) {
-                    Self::decode_text(text, tx).await
+                    Ok(Self::decode_text(text))
                 } else {
-                    Ok(vec![])
+                    Ok(DanmuProtocolOutput::default())
                 }
             }
-            Message::Ping(data) => {
-                // Respond to WebSocket-level PING
-                let _ = tx.send(Message::Pong(data.clone())).await;
-                Ok(vec![])
-            }
-            _ => Ok(vec![]),
+            Message::Ping(data) => Ok(DanmuProtocolOutput::outbound(vec![Message::Pong(
+                data.clone(),
+            )])),
+            _ => Ok(DanmuProtocolOutput::default()),
         }
     }
 }
 
 impl TwitchDanmuProtocol {
-    async fn decode_text(text: &str, tx: &mpsc::Sender<Message>) -> Result<Vec<DanmuItem>> {
+    fn decode_text(text: &str) -> DanmuProtocolOutput {
         let mut items = Vec::new();
+        let mut outbound = Vec::new();
 
         // Handle each line (Twitch may send multiple messages in one frame)
         for line in text.lines() {
@@ -246,7 +253,7 @@ impl TwitchDanmuProtocol {
                 let pong_data = trimmed.strip_prefix("PING ").unwrap_or(":tmi.twitch.tv");
                 let pong = format!("PONG {}", pong_data);
                 debug!("Sending PONG: {}", pong);
-                let _ = tx.send(Message::Text(pong.into())).await;
+                outbound.push(Message::Text(pong.into()));
                 continue;
             }
 
@@ -256,7 +263,7 @@ impl TwitchDanmuProtocol {
             }
         }
 
-        Ok(items)
+        DanmuProtocolOutput::new(items, outbound)
     }
 }
 
@@ -265,7 +272,7 @@ pub type TwitchDanmuProvider = WebSocketDanmuProvider<TwitchDanmuProtocol>;
 
 /// Creates a new Twitch danmu provider (anonymous).
 pub fn create_twitch_danmu_provider() -> TwitchDanmuProvider {
-    WebSocketDanmuProvider::with_protocol(TwitchDanmuProtocol::default(), None)
+    WebSocketDanmuProvider::with_factory(TwitchDanmuProtocol::default(), None)
 }
 
 #[cfg(test)]
@@ -293,6 +300,20 @@ mod tests {
         let line = "PING :tmi.twitch.tv";
         let result = TwitchDanmuProtocol::parse_irc_message(line);
         assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn ping_returns_pong_as_outbound_protocol_frame() {
+        let mut protocol = TwitchDanmuProtocol::default();
+        let output = protocol
+            .decode_message(&Message::Text("PING :tmi.twitch.tv".into()), "channel")
+            .await
+            .expect("decode ping");
+        let (items, outbound) = output.into_parts();
+
+        assert!(items.is_empty());
+        assert_eq!(outbound.len(), 1);
+        assert_eq!(outbound[0], Message::Text("PONG :tmi.twitch.tv".into()));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- split shared danmaku provider configuration from task-owned mutable protocol state
- create a fresh protocol state machine for every connection and reconnect attempt
- return outbound protocol frames directly from decoding and write them before publishing decoded items
- migrate Bigo, Bilibili, Douyin, Douyu, Huya, SOOP, Twitch, and TwitCasting to the factory lifecycle
- preserve Bigo private-room classification and propagate login and room-entry failures

## Why

The WebSocket provider previously cloned protocol implementations that shared connection-local state through locks and atomics. Concurrent rooms and reconnect attempts could therefore observe or mutate the same session state. Protocol-generated responses also traveled through a separate channel, obscuring ordering and allowing response-send failures to be detached from frame processing.

Each connection task now owns its mutable protocol instance exclusively. This removes connection-local locking, isolates reconnect state, and makes protocol response ordering explicit.

## Impact

Providers can keep ordinary mutable fields for per-connection state without synchronization. Bigo guest sessions and SOOP chat sessions are rebuilt on reconnect, while immutable configuration such as clients, cookies, and passwords remains on the shared factory.

## Validation

- `cargo clippy --locked -p platforms-parser --all-targets --jobs 2 -- -D warnings`
- `cargo test --locked -p platforms-parser --lib --jobs 2 -- --test-threads=2`
- `cargo test --locked -p platforms-parser --doc --jobs 2 -- --test-threads=2`
- `cargo test --locked -p platforms-parser --lib bigo::danmu::tests::test_live_connection --jobs 2 -- --ignored --nocapture --test-threads=2`
- `cargo fmt --all`
- `git diff --check`
