### PR TITLE
fix(player): prevent fullscreen seek stalls

### DIFF
--- a/rust-srec/frontend/src/components/player/__tests__/mpegts-playback.test.ts
+++ b/rust-srec/frontend/src/components/player/__tests__/mpegts-playback.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { hasSeekSettled, MpegtsPlaybackController } from '../mpegts-playback';
+
+function bufferedRanges(...ranges: Array<[number, number]>): TimeRanges {
+  return {
+    length: ranges.length,
+    start: (index: number) => ranges[index][0],
+    end: (index: number) => ranges[index][1],
+  };
+}
+
+describe('hasSeekSettled', () => {
+  it('rejects seeked events without readable media data', () => {
+    expect(
+      hasSeekSettled(
+        {
+          currentTime: 223,
+          readyState: 1,
+          buffered: bufferedRanges(),
+        },
+        223,
+        false,
+        false,
+      ),
+    ).toBe(false);
+  });
+
+  it('rejects a readable frame outside the requested buffered range', () => {
+    expect(
+      hasSeekSettled(
+        {
+          currentTime: 223,
+          readyState: 4,
+          buffered: bufferedRanges([0, 150]),
+        },
+        223,
+        true,
+        false,
+      ),
+    ).toBe(false);
+  });
+
+  it('accepts a readable frame at the requested buffered range', () => {
+    expect(
+      hasSeekSettled(
+        {
+          currentTime: 223.2,
+          readyState: 4,
+          buffered: bufferedRanges([222.05, 369.8]),
+        },
+        223,
+        true,
+        false,
+      ),
+    ).toBe(true);
+  });
+
+  it('rejects buffered media until a target frame is rendered', () => {
+    expect(
+      hasSeekSettled(
+        {
+          currentTime: 223,
+          readyState: 4,
+          buffered: bufferedRanges([222.05, 369.8]),
+        },
+        223,
+        false,
+        false,
+      ),
+    ).toBe(false);
+  });
+});
+
+describe('MpegtsPlaybackController', () => {
+  it('uses the public currentTime setter only when rebuilding a stalled seek', () => {
+    vi.useFakeTimers();
+    let requestedTime = 0;
+    const player = {
+      on: vi.fn(),
+      attachMediaElement: vi.fn(),
+      load: vi.fn(),
+      unload: vi.fn(),
+      detachMediaElement: vi.fn(),
+      destroy: vi.fn(),
+      play: vi.fn(),
+      get currentTime() {
+        return requestedTime;
+      },
+      set currentTime(value: number) {
+        requestedTime = value;
+      },
+    };
+    const createPlayer = vi.fn(() => player);
+    const mpegts = {
+      createPlayer,
+      Events: { ERROR: 'error' },
+    } as unknown as ConstructorParameters<typeof MpegtsPlaybackController>[0];
+    const controller = new MpegtsPlaybackController(mpegts, {
+      mediaType: 'flv',
+      isLive: false,
+      onLoadingChange: vi.fn(),
+      onError: vi.fn(),
+      onStalled: vi.fn(),
+      onWarning: vi.fn(),
+    });
+
+    controller.attach(
+      {
+        paused: false,
+        currentTime: 0,
+        readyState: 1,
+        buffered: bufferedRanges(),
+      } as HTMLVideoElement,
+      '/recording.flv',
+    );
+    expect(createPlayer).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ accurateSeek: false }),
+    );
+
+    expect(controller.seek(223)).toBe(true);
+    expect(requestedTime).toBe(0);
+
+    vi.advanceTimersByTime(3_000);
+
+    expect(requestedTime).toBe(223);
+
+    controller.destroy();
+    vi.useRealTimers();
+  });
+});

--- a/rust-srec/frontend/src/components/player/__tests__/use-player-playback.test.tsx
+++ b/rust-srec/frontend/src/components/player/__tests__/use-player-playback.test.tsx
@@ -1,0 +1,217 @@
+import { act, render, waitFor } from '@testing-library/react';
+import {
+  buildPlaybackUrl,
+  usePlayerPlayback,
+  type UsePlayerPlaybackOptions,
+} from '../use-player-playback';
+
+const artplayerMock = vi.hoisted(() => {
+  type EventHandler = (...args: unknown[]) => void;
+
+  class MockArtplayer {
+    static FULLSCREEN_WEB_IN_BODY = true;
+    readonly events = new Map<string, EventHandler[]>();
+    readonly video = { pause: vi.fn() };
+    readonly destroy = vi.fn();
+    volume: number;
+    muted: boolean;
+    fullscreenWeb = false;
+    isReady = false;
+
+    constructor(readonly options: Record<string, unknown>) {
+      this.volume = typeof options.volume === 'number' ? options.volume : 0.5;
+      this.muted = typeof options.muted === 'boolean' ? options.muted : false;
+      instances.push(this);
+    }
+
+    on(event: string, handler: EventHandler) {
+      const handlers = this.events.get(event) ?? [];
+      handlers.push(handler);
+      this.events.set(event, handlers);
+    }
+
+    emit(event: string, ...args: unknown[]) {
+      for (const handler of this.events.get(event) ?? []) handler(...args);
+    }
+  }
+
+  const instances: MockArtplayer[] = [];
+  return { MockArtplayer, instances };
+});
+
+const resolveUrlMock = vi.hoisted(() => vi.fn());
+const toastErrorMock = vi.hoisted(() => vi.fn());
+
+vi.mock('artplayer', () => ({ default: artplayerMock.MockArtplayer }));
+vi.mock('@/server/functions/parse', () => ({ resolveUrl: resolveUrlMock }));
+vi.mock('sonner', () => ({ toast: { error: toastErrorMock } }));
+vi.mock('@/utils/desktop', () => ({ isDesktopBuild: () => false }));
+vi.mock('@/utils/env', () => ({ BASE_URL: '/api' }));
+vi.mock('@/utils/session', () => ({ getDesktopAccessToken: () => null }));
+
+const defaultOptions: UsePlayerPlaybackOptions = {
+  url: 'https://media.example/recording.mp4',
+  title: 'recording.mp4',
+  muted: false,
+  volume: 0.5,
+  defaultWebFullscreen: false,
+  mediaType: 'mp4',
+  isLive: false,
+};
+
+function PlaybackHarness(options: UsePlayerPlaybackOptions) {
+  const playback = usePlayerPlayback(options);
+  return (
+    <div
+      ref={playback.containerRef}
+      data-error={playback.error ?? ''}
+      data-loading={String(playback.loading)}
+    />
+  );
+}
+
+describe('buildPlaybackUrl', () => {
+  it('only proxies sources that need request headers', () => {
+    const directUrl = buildPlaybackUrl({
+      url: 'https://media.example/video.mp4',
+      desktopBuild: false,
+      desktopToken: null,
+      baseUrl: '/api',
+    });
+    const proxiedUrl = buildPlaybackUrl({
+      url: 'https://media.example/video.mp4',
+      headers: { Referer: 'https://source.example/' },
+      desktopBuild: false,
+      desktopToken: null,
+      baseUrl: '/api',
+    });
+
+    expect(directUrl).toBe('https://media.example/video.mp4');
+    expect(proxiedUrl).toContain('/stream-proxy?url=');
+    expect(decodeURIComponent(proxiedUrl)).toContain(
+      '"Referer":"https://source.example/"',
+    );
+  });
+
+  it('requires a desktop token before proxying authenticated sources', () => {
+    const options = {
+      url: 'https://media.example/video.mp4',
+      headers: { Authorization: 'upstream' },
+      desktopBuild: true,
+      baseUrl: 'http://localhost:12555/api/',
+    };
+
+    expect(buildPlaybackUrl({ ...options, desktopToken: null })).toBe(
+      options.url,
+    );
+    expect(
+      buildPlaybackUrl({ ...options, desktopToken: 'desktop-token' }),
+    ).toContain(
+      'http://localhost:12555/api/stream-proxy?url=https%3A%2F%2Fmedia.example',
+    );
+  });
+});
+
+describe('usePlayerPlayback', () => {
+  beforeEach(() => {
+    artplayerMock.instances.length = 0;
+    artplayerMock.MockArtplayer.FULLSCREEN_WEB_IN_BODY = true;
+    resolveUrlMock.mockReset();
+    toastErrorMock.mockReset();
+  });
+
+  it('updates mutable player state and callbacks without rebuilding', async () => {
+    const firstVolumeCallback = vi.fn();
+    const latestVolumeCallback = vi.fn();
+    const muteCallback = vi.fn();
+    const view = render(
+      <PlaybackHarness
+        {...defaultOptions}
+        defaultWebFullscreen
+        onVolumeChange={firstVolumeCallback}
+      />,
+    );
+
+    await waitFor(() => expect(artplayerMock.instances).toHaveLength(1));
+    const player = artplayerMock.instances[0];
+    expect(player).toBeDefined();
+    expect(artplayerMock.MockArtplayer.FULLSCREEN_WEB_IN_BODY).toBe(false);
+
+    player!.isReady = true;
+    act(() => player!.emit('ready'));
+    expect(player!.fullscreenWeb).toBe(true);
+
+    view.rerender(
+      <PlaybackHarness
+        {...defaultOptions}
+        muted
+        volume={0.8}
+        onVolumeChange={latestVolumeCallback}
+        onMuteChange={muteCallback}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(player!.volume).toBe(0.8);
+      expect(player!.muted).toBe(true);
+    });
+    expect(artplayerMock.instances).toHaveLength(1);
+
+    act(() => player!.emit('video:volumechange'));
+    expect(firstVolumeCallback).not.toHaveBeenCalled();
+    expect(latestVolumeCallback).toHaveBeenCalledWith(0.8);
+    expect(muteCallback).toHaveBeenCalledWith(true);
+
+    view.unmount();
+    expect(player!.video.pause).toHaveBeenCalledOnce();
+    expect(player!.destroy).toHaveBeenCalledWith(false);
+  });
+
+  it('tears down the old player while source resolution is pending', async () => {
+    let finishResolution: ((response: unknown) => void) | undefined;
+    resolveUrlMock.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          finishResolution = resolve;
+        }),
+    );
+    const view = render(<PlaybackHarness {...defaultOptions} />);
+
+    await waitFor(() => expect(artplayerMock.instances).toHaveLength(1));
+    const initialPlayer = artplayerMock.instances[0];
+    const streamData = { platform: 'example' };
+    const headers = { Referer: 'https://source.example/' };
+    view.rerender(
+      <PlaybackHarness
+        {...defaultOptions}
+        url="https://media.example/fallback.mp4"
+        title="resolved.mp4"
+        headers={headers}
+        streamData={streamData}
+      />,
+    );
+
+    await waitFor(() => expect(resolveUrlMock).toHaveBeenCalledOnce());
+    await waitFor(() => expect(initialPlayer!.destroy).toHaveBeenCalled());
+    expect(artplayerMock.instances).toHaveLength(1);
+
+    await act(async () => {
+      finishResolution?.({
+        success: true,
+        stream_info: { url: 'https://media.example/resolved.mp4' },
+      });
+      await Promise.resolve();
+    });
+
+    await waitFor(() => expect(artplayerMock.instances).toHaveLength(2));
+    const resolvedPlayer = artplayerMock.instances[1];
+    const playbackUrl = resolvedPlayer!.options.url;
+    expect(typeof playbackUrl).toBe('string');
+    expect(decodeURIComponent(playbackUrl as string)).toContain(
+      'https://media.example/resolved.mp4',
+    );
+    expect(decodeURIComponent(playbackUrl as string)).toContain(
+      '"Referer":"https://source.example/"',
+    );
+  });
+});

--- a/rust-srec/frontend/src/components/player/mpegts-playback.ts
+++ b/rust-srec/frontend/src/components/player/mpegts-playback.ts
@@ -1,0 +1,318 @@
+type MpegtsModule = (typeof import('mpegts.js'))['default'];
+type MpegtsPlayer = ReturnType<MpegtsModule['createPlayer']>;
+
+const HAVE_CURRENT_DATA = 2;
+const SEEK_RECOVERY_DELAY_MS = 3_000;
+const SEEK_REBUILD_TIMEOUT_MS = 8_000;
+const SEEK_TARGET_TOLERANCE_SECS = 5;
+
+interface PendingSeek {
+  targetTime: number;
+  resumePlayback: boolean;
+  pipelineRebuilt: boolean;
+  targetFrameRendered: boolean;
+}
+
+export interface MpegtsPlaybackError {
+  type: string;
+  details: string;
+  data: unknown;
+}
+
+export interface MpegtsPlaybackOptions {
+  mediaType: 'flv' | 'mpegts';
+  isLive: boolean;
+  durationSecs?: number | null;
+  fileSizeBytes?: number;
+  onLoadingChange: (loading: boolean) => void;
+  onError: (error: MpegtsPlaybackError) => void;
+  onStalled: () => void;
+  onWarning: (message: string, error: unknown) => void;
+}
+
+type SeekState = Pick<
+  HTMLVideoElement,
+  'buffered' | 'currentTime' | 'readyState'
+>;
+
+function positiveFinite(value: number | null | undefined): number | undefined {
+  return value != null && Number.isFinite(value) && value > 0
+    ? value
+    : undefined;
+}
+
+export function hasSeekSettled(
+  video: SeekState,
+  targetTime: number,
+  targetFrameRendered: boolean,
+  playbackAdvanced: boolean,
+): boolean {
+  if (
+    video.readyState < HAVE_CURRENT_DATA ||
+    Math.abs(video.currentTime - targetTime) > SEEK_TARGET_TOLERANCE_SECS ||
+    (!targetFrameRendered && !playbackAdvanced)
+  ) {
+    return false;
+  }
+
+  for (let index = 0; index < video.buffered.length; index += 1) {
+    if (
+      targetTime >= video.buffered.start(index) - SEEK_TARGET_TOLERANCE_SECS &&
+      targetTime <= video.buffered.end(index) + SEEK_TARGET_TOLERANCE_SECS
+    ) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+export class MpegtsPlaybackController {
+  private player: MpegtsPlayer | null = null;
+  private video: HTMLVideoElement | null = null;
+  private sourceUrl: string | null = null;
+  private pendingSeek: PendingSeek | null = null;
+  private recoveryTimer: ReturnType<typeof setTimeout> | undefined;
+  private videoFrameCallbackId: number | undefined;
+  private destroyed = false;
+
+  constructor(
+    private readonly mpegts: MpegtsModule,
+    private readonly options: MpegtsPlaybackOptions,
+  ) {}
+
+  attach(video: HTMLVideoElement, sourceUrl: string): void {
+    if (this.destroyed) {
+      throw new Error('Cannot attach a destroyed MPEG-TS playback controller');
+    }
+
+    this.video = video;
+    this.sourceUrl = sourceUrl;
+    this.replacePlayer();
+  }
+
+  seek(targetTime: number): boolean {
+    if (
+      this.options.isLive ||
+      !Number.isFinite(targetTime) ||
+      !this.player ||
+      !this.video
+    ) {
+      return false;
+    }
+
+    this.clearSeekRecovery();
+    this.pendingSeek = {
+      targetTime,
+      resumePlayback: !this.video.paused,
+      pipelineRebuilt: false,
+      targetFrameRendered: false,
+    };
+    this.options.onLoadingChange(true);
+
+    this.watchForTargetFrame();
+    this.scheduleRecovery(SEEK_RECOVERY_DELAY_MS);
+    return true;
+  }
+
+  notifyMediaProgress(): boolean {
+    if (!this.pendingSeek || !this.video) {
+      return false;
+    }
+
+    const supportsVideoFrameCallbacks =
+      typeof this.video.requestVideoFrameCallback === 'function';
+    const playbackAdvanced =
+      !supportsVideoFrameCallbacks &&
+      this.pendingSeek.resumePlayback &&
+      this.video.currentTime >= this.pendingSeek.targetTime + 0.25;
+    if (
+      !hasSeekSettled(
+        this.video,
+        this.pendingSeek.targetTime,
+        this.pendingSeek.targetFrameRendered,
+        playbackAdvanced,
+      )
+    ) {
+      return false;
+    }
+
+    this.clearSeekRecovery();
+    this.options.onLoadingChange(false);
+    return true;
+  }
+
+  cancelSeekRecovery(): void {
+    this.clearSeekRecovery();
+  }
+
+  destroy(): void {
+    this.destroyed = true;
+    this.clearSeekRecovery();
+    this.destroyPlayer();
+    this.video = null;
+    this.sourceUrl = null;
+  }
+
+  private replacePlayer(seekTime?: number): MpegtsPlayer {
+    if (!this.video || !this.sourceUrl) {
+      throw new Error('MPEG-TS playback controller is not attached');
+    }
+
+    this.destroyPlayer();
+
+    const durationSecs = positiveFinite(this.options.durationSecs);
+    const player = this.mpegts.createPlayer(
+      {
+        type: this.options.mediaType,
+        url: this.sourceUrl,
+        isLive: this.options.isLive,
+        cors: true,
+        duration:
+          !this.options.isLive && durationSecs != null
+            ? durationSecs * 1_000
+            : undefined,
+        filesize: !this.options.isLive
+          ? positiveFinite(this.options.fileSizeBytes)
+          : undefined,
+      },
+      {
+        isLive: this.options.isLive,
+        // Starting from the preceding IDR frame avoids Chromium showing the
+        // requested timestamp before its decoder can produce a picture.
+        accurateSeek: false,
+        rangeLoadZeroStart: !this.options.isLive,
+      },
+    );
+    this.player = player;
+
+    player.on(
+      this.mpegts.Events.ERROR,
+      (type: string, details: string, data: unknown) => {
+        if (this.destroyed || player !== this.player) return;
+
+        this.clearSeekRecovery();
+        this.options.onLoadingChange(false);
+        this.options.onError({ type, details, data });
+      },
+    );
+    player.attachMediaElement(this.video);
+    player.load();
+
+    if (seekTime !== undefined) {
+      player.currentTime = seekTime;
+    }
+
+    return player;
+  }
+
+  private rebuildPlayer(targetTime: number, resumePlayback: boolean): boolean {
+    try {
+      const player = this.replacePlayer(targetTime);
+      if (resumePlayback) {
+        void player.play().catch((error: unknown) => {
+          if (!this.destroyed && player === this.player) {
+            this.options.onWarning(
+              'Unable to resume playback after seek recovery',
+              error,
+            );
+          }
+        });
+      }
+      if (this.pendingSeek) {
+        this.pendingSeek.targetFrameRendered = false;
+        this.watchForTargetFrame();
+      }
+      return true;
+    } catch (error) {
+      this.options.onWarning(
+        'Unable to rebuild MPEG-TS player after a stalled seek',
+        error,
+      );
+      return false;
+    }
+  }
+
+  private scheduleRecovery(delay: number): void {
+    this.clearRecoveryTimer();
+    this.recoveryTimer = setTimeout(() => {
+      this.recoveryTimer = undefined;
+      if (this.destroyed || !this.pendingSeek || this.notifyMediaProgress()) {
+        return;
+      }
+
+      if (!this.pendingSeek.pipelineRebuilt) {
+        this.pendingSeek.pipelineRebuilt = true;
+        this.options.onWarning('Recovering a stalled MPEG-TS seek', {
+          targetTime: this.pendingSeek.targetTime,
+        });
+        const rebuilt = this.rebuildPlayer(
+          this.pendingSeek.targetTime,
+          this.pendingSeek.resumePlayback,
+        );
+        if (rebuilt) {
+          this.scheduleRecovery(SEEK_REBUILD_TIMEOUT_MS);
+          return;
+        }
+      }
+
+      this.clearSeekRecovery();
+      this.options.onLoadingChange(false);
+      this.options.onStalled();
+    }, delay);
+  }
+
+  private clearRecoveryTimer(): void {
+    if (this.recoveryTimer !== undefined) {
+      clearTimeout(this.recoveryTimer);
+      this.recoveryTimer = undefined;
+    }
+  }
+
+  private clearSeekRecovery(): void {
+    this.clearRecoveryTimer();
+    this.cancelVideoFrameCallback();
+    this.pendingSeek = null;
+  }
+
+  private watchForTargetFrame(): void {
+    const video = this.video;
+    const pendingSeek = this.pendingSeek;
+    if (!video?.requestVideoFrameCallback || !pendingSeek) return;
+
+    this.cancelVideoFrameCallback();
+    this.videoFrameCallbackId = video.requestVideoFrameCallback(
+      (_now, metadata) => {
+        this.videoFrameCallbackId = undefined;
+        if (this.destroyed || this.pendingSeek !== pendingSeek) return;
+
+        if (
+          Math.abs(metadata.mediaTime - pendingSeek.targetTime) <=
+          SEEK_TARGET_TOLERANCE_SECS
+        ) {
+          pendingSeek.targetFrameRendered = true;
+          this.notifyMediaProgress();
+        } else {
+          this.watchForTargetFrame();
+        }
+      },
+    );
+  }
+
+  private cancelVideoFrameCallback(): void {
+    if (this.videoFrameCallbackId === undefined) return;
+
+    this.video?.cancelVideoFrameCallback?.(this.videoFrameCallbackId);
+    this.videoFrameCallbackId = undefined;
+  }
+
+  private destroyPlayer(): void {
+    const player = this.player;
+    if (!player) return;
+
+    this.player = null;
+    player.unload();
+    player.detachMediaElement();
+    player.destroy();
+  }
+}

--- a/rust-srec/frontend/src/components/player/player-card.tsx
+++ b/rust-srec/frontend/src/components/player/player-card.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import type { ReactNode } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -9,27 +9,26 @@ import {
 } from '@/components/ui/popover';
 import { AlertCircle, Loader2, RefreshCcw, Settings2, X } from 'lucide-react';
 import { cn } from '@/lib/utils';
-import { resolveUrl } from '@/server/functions/parse';
-import { toast } from 'sonner';
-
-import { BASE_URL } from '@/utils/env';
-import { getDesktopAccessToken } from '@/utils/session';
-import { isDesktopBuild } from '@/utils/desktop';
+import { usePlayerPlayback } from './use-player-playback';
 
 export interface PlayerCardProps {
   url: string;
   title?: string;
   headers?: Record<string, string>;
-  streamData?: any; // The original stream object for resolution
+  streamData?: unknown;
   onRemove?: () => void;
   className?: string;
   contentClassName?: string;
-  settingsContent?: React.ReactNode;
+  settingsContent?: ReactNode;
   muted?: boolean;
   volume?: number;
   onVolumeChange?: (volume: number) => void;
   onMuteChange?: (muted: boolean) => void;
   defaultWebFullscreen?: boolean;
+  mediaType?: string;
+  isLive?: boolean;
+  mediaDurationSecs?: number | null;
+  mediaFileSizeBytes?: number;
 }
 
 export function PlayerCard({
@@ -46,323 +45,26 @@ export function PlayerCard({
   onVolumeChange,
   onMuteChange,
   defaultWebFullscreen = false,
+  mediaType,
+  isLive = false,
+  mediaDurationSecs,
+  mediaFileSizeBytes,
 }: PlayerCardProps) {
-  const artRef = useRef<HTMLDivElement>(null);
-  const playerRef = useRef<any>(null); // Type loose for dynamic import
-  const hlsRef = useRef<any>(null);
-  const flvRef = useRef<any>(null);
-  const [error, setError] = useState<string | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [resolving, setResolving] = useState(false);
-  const [currentUrl, setCurrentUrl] = useState(url);
-  const [currentHeaders, setCurrentHeaders] = useState(headers);
-
-  const [refreshKey, setRefreshKey] = useState(0);
-
-  const handleRefresh = () => {
-    setRefreshKey((prev) => prev + 1);
-    setLoading(true);
-  };
-
-  // Auto-resolve URL on mount or refresh if streamData is present
-  useEffect(() => {
-    let disposed = false;
-    const resolve = async () => {
-      if (!streamData || !title) {
-        setCurrentUrl(url);
-        setCurrentHeaders(headers);
-
-        return;
-      }
-
-      const baseStreamInfo = streamData;
-
-      setResolving(true);
-      try {
-        const response = await resolveUrl({
-          data: {
-            url: title,
-            stream_info: baseStreamInfo,
-          },
-        });
-        if (disposed) return;
-        console.log('[PlayerCard] Headers:', headers);
-        console.log('[PlayerCard] Resolve Response:', response);
-
-        if (response.success && response.stream_info) {
-          console.log('[PlayerCard] Resolved URL:', response.stream_info.url);
-          setCurrentUrl(response.stream_info.url || url);
-          // Ensure use headers from resolved stream info if available
-          // setCurrentHeaders(response.stream_info.headers || headers);
-        } else {
-          console.warn(
-            '[PlayerCard] URL resolution failed, using original:',
-            response.error,
-          );
-          toast.error(
-            `Resolution failed: ${response.error || 'Unknown error'}`,
-          );
-          setCurrentUrl(url);
-          setCurrentHeaders(headers);
-        }
-      } catch (err) {
-        console.error('[PlayerCard] Resolution error:', err);
-        if (disposed) return;
-        setCurrentUrl(url);
-        setCurrentHeaders(headers);
-      } finally {
-        if (!disposed) setResolving(false);
-      }
-    };
-
-    void resolve();
-
-    return () => {
-      disposed = true;
-    };
-  }, [url, headers, streamData, title, refreshKey]);
-
-  useEffect(() => {
-    if (!artRef.current || resolving) return;
-
-    let disposed = false;
-
-    if (playerRef.current) {
-      const video: HTMLMediaElement | undefined = playerRef.current?.video;
-      if (video) {
-        try {
-          video.pause();
-          video.removeAttribute('src');
-          video.load();
-        } catch {
-          // ignore
-        }
-      }
-      playerRef.current.destroy(false);
-      playerRef.current = null;
-    }
-
-    // Clear only if we are about to create a new one, ensuring clean slate
-    if (artRef.current) {
-      artRef.current.innerHTML = '';
-    }
-
-    const checkString = (currentUrl + (title || '')).toLowerCase();
-    const isHLS = checkString.includes('.m3u8') || checkString.includes('m3u8');
-    const isMPEGTS =
-      checkString.includes('.flv') || checkString.includes('.ts');
-    const isMP4 = checkString.includes('.mp4');
-    const isMKV = checkString.includes('.mkv');
-    const isAudio =
-      checkString.includes('.mp3') ||
-      checkString.includes('.wav') ||
-      checkString.includes('.ogg');
-
-    // Build proxy URL if headers are needed
-    const shouldProxy =
-      !!currentHeaders && Object.keys(currentHeaders).length > 0;
-
-    const desktopBuild = isDesktopBuild();
-    const desktopToken = desktopBuild ? getDesktopAccessToken() : null;
-    const baseUrl = BASE_URL.endsWith('/') ? BASE_URL.slice(0, -1) : BASE_URL;
-
-    const playUrl = shouldProxy
-      ? desktopBuild
-        ? desktopToken
-          ? `${baseUrl}/stream-proxy?url=${encodeURIComponent(currentUrl)}&headers=${encodeURIComponent(JSON.stringify(currentHeaders))}&token=${encodeURIComponent(desktopToken)}`
-          : currentUrl
-        : `/stream-proxy?url=${encodeURIComponent(currentUrl)}&headers=${encodeURIComponent(JSON.stringify(currentHeaders))}`
-      : currentUrl;
-
-    console.log('[PlayerCard] Init:', {
-      originalUrl: url,
-      currentUrl,
-      headers: currentHeaders,
-      shouldProxy,
-      playUrl,
-      isHLS,
-      isMPEGTS,
-      isMP4,
-      isMKV,
-      isAudio,
-    });
-
-    const initPlayer = async () => {
-      try {
-        const { default: Artplayer } = await import('artplayer');
-        if (disposed || !artRef.current) return;
-
-        const options: any = {
-          container: artRef.current,
-          url: playUrl,
-          autoplay: true,
-          volume: volume,
-          muted: muted,
-          autoSize: false,
-          pip: true,
-          mutex: false,
-          setting: true,
-          playbackRate: true,
-          aspectRatio: true,
-          fullscreen: true,
-          fullscreenWeb: true,
-          miniProgressBar: true,
-          theme: '#3b82f6',
-          type: isHLS
-            ? 'm3u8'
-            : isMPEGTS
-              ? 'flv'
-              : isMP4
-                ? 'mp4'
-                : isMKV
-                  ? 'mkv'
-                  : isAudio
-                    ? 'mp3'
-                    : 'auto',
-        };
-
-        // Custom type for HLS
-        if (isHLS) {
-          try {
-            // Dynamically import Hls.js
-            const { default: Hls } = await import('hls.js');
-            if (Hls.isSupported()) {
-              console.log('[PlayerCard] Using custom type for HLS');
-              options.customType = {
-                m3u8: (video: HTMLMediaElement, url: string) => {
-                  const hls = new Hls({
-                    enableWorker: true,
-                    lowLatencyMode: true,
-                  });
-                  hlsRef.current = hls;
-                  hls.loadSource(url);
-                  hls.attachMedia(video);
-                  hls.on(Hls.Events.ERROR, (_event: any, data: any) => {
-                    if (data.fatal) {
-                      setError(`HLS Error: ${data.type} - ${data.details}`);
-                      setLoading(false);
-                    }
-                  });
-                },
-              };
-            }
-          } catch (e) {
-            console.error('Failed to load hls.js', e);
-          }
-        }
-
-        // Custom type for MPEG-TS
-        if (isMPEGTS) {
-          try {
-            // Dynamically import mpegts.js
-            const { default: mpegts } = await import('mpegts.js');
-            if (mpegts.isSupported()) {
-              console.log('[PlayerCard] Using custom type for MPEG-TS');
-              options.customType = {
-                flv: (video: HTMLMediaElement, url: string) => {
-                  const player = mpegts.createPlayer({
-                    type: 'flv',
-                    url: url,
-                    isLive: true,
-                    cors: true,
-                  });
-                  flvRef.current = player;
-                  player.attachMediaElement(video);
-                  player.load();
-                  player.on(
-                    mpegts.Events.ERROR,
-                    (type: any, details: any, data: any) => {
-                      console.error('MPEG-TS Error:', { type, details, data });
-                      setError(`MPEG-TS Error: ${type} - ${details}`);
-                      setLoading(false);
-                    },
-                  );
-                },
-              };
-            }
-          } catch (e) {
-            console.error('Failed to load mpegts.js', e);
-          }
-        }
-
-        const art = new Artplayer(options);
-        if (disposed) {
-          art.destroy(false);
-          return;
-        }
-        playerRef.current = art;
-
-        art.on('ready', () => {
-          if (defaultWebFullscreen) {
-            art.fullscreenWeb = true;
-          }
-          setLoading(false);
-          setError(null);
-        });
-
-        art.on('error', (err: any) => {
-          console.log('Player Error: ', err);
-          setError(`Player Error: ${err?.message || 'Unknown error'}`);
-          setLoading(false);
-        });
-
-        art.on('video:volumechange', () => {
-          onVolumeChange?.(art.volume);
-          onMuteChange?.(art.muted);
-        });
-      } catch (err) {
-        setError(
-          `Failed to initialize player: ${err instanceof Error ? err.message : 'Unknown error'}`,
-        );
-        setLoading(false);
-      }
-    };
-
-    void initPlayer();
-
-    return () => {
-      disposed = true;
-      if (hlsRef.current) {
-        const hls = hlsRef.current;
-        hls.stopLoad?.();
-        hls.detachMedia?.();
-        hls.destroy?.();
-        hlsRef.current = null;
-      }
-      if (flvRef.current) {
-        const flv = flvRef.current;
-        flv.unload?.();
-        flv.detachMediaElement?.();
-        flv.destroy?.();
-        flvRef.current = null;
-      }
-      if (playerRef.current) {
-        const video: HTMLMediaElement | undefined = playerRef.current?.video;
-        if (video) {
-          try {
-            video.pause();
-            video.removeAttribute('src');
-            video.load();
-          } catch {
-            // ignore
-          }
-        }
-        playerRef.current.destroy(false);
-        playerRef.current = null;
-      }
-      // Aggressive cleanup for strict mode
-      if (artRef.current) {
-        artRef.current.innerHTML = '';
-      }
-    };
-  }, [
-    currentUrl,
-    currentHeaders,
-    resolving,
+  const { containerRef, error, loading, reload } = usePlayerPlayback({
+    url,
+    headers,
     title,
-    refreshKey,
+    streamData,
+    muted,
+    volume,
+    onVolumeChange,
+    onMuteChange,
     defaultWebFullscreen,
-  ]);
+    mediaType,
+    isLive,
+    mediaDurationSecs,
+    mediaFileSizeBytes,
+  });
 
   return (
     <Card
@@ -402,7 +104,7 @@ export function PlayerCard({
             variant="ghost"
             size="icon"
             className="h-8 w-8 text-muted-foreground/60 hover:text-primary hover:bg-primary/10 transition-colors rounded-full"
-            onClick={handleRefresh}
+            onClick={reload}
             title="Reload Player"
           >
             <RefreshCcw className="h-4 w-4" />
@@ -445,8 +147,14 @@ export function PlayerCard({
           contentClassName,
         )}
       >
-        {error ? (
-          <div className="flex flex-col items-center justify-center h-full text-center space-y-3 p-8">
+        <div ref={containerRef} className="w-full h-full absolute inset-0" />
+        {loading && !error && (
+          <div className="pointer-events-none absolute inset-0 z-[5] flex items-center justify-center bg-black/20">
+            <Loader2 className="h-8 w-8 animate-spin text-white/80 drop-shadow" />
+          </div>
+        )}
+        {error && (
+          <div className="absolute inset-0 z-10 flex flex-col items-center justify-center h-full text-center space-y-3 p-8 bg-black/90">
             <div className="p-3 rounded-full bg-destructive/10 text-destructive mb-2">
               <AlertCircle className="h-8 w-8" />
             </div>
@@ -457,8 +165,6 @@ export function PlayerCard({
               {error}
             </p>
           </div>
-        ) : (
-          <div ref={artRef} className="w-full h-full absolute inset-0" />
         )}
       </CardContent>
     </Card>

--- a/rust-srec/frontend/src/components/player/stream-info-card.tsx
+++ b/rust-srec/frontend/src/components/player/stream-info-card.tsx
@@ -12,6 +12,7 @@ import { Separator } from '@/components/ui/separator';
 import { CheckCircle2, Radio, Server, Video } from 'lucide-react';
 import { Trans } from '@lingui/react/macro';
 import { cn } from '@/lib/utils';
+import { resolvePlayerMediaType } from '@/lib/media';
 
 export interface StreamOption {
   url: string;
@@ -263,7 +264,10 @@ function extractStreams(mediaInfo: any): StreamOption[] {
         url: stream.url || stream.src || '',
         quality: stream.quality || stream.resolution || 'unknown',
         cdn: stream.cdn || stream.server || extras.cdn,
-        format: stream.format || detectFormat(stream.url),
+        format:
+          stream.format ||
+          stream.stream_format ||
+          resolvePlayerMediaType(undefined, stream.url),
         bitrate: stream.bitrate || stream.bandwidth,
         headers: { ...mediaInfo.headers, ...stream.headers },
         extras,
@@ -276,7 +280,10 @@ function extractStreams(mediaInfo: any): StreamOption[] {
       url: mediaInfo.url,
       quality: mediaInfo.quality || 'default',
       cdn: mediaInfo.cdn || extras.cdn,
-      format: mediaInfo.format || detectFormat(mediaInfo.url),
+      format:
+        mediaInfo.format ||
+        mediaInfo.stream_format ||
+        resolvePlayerMediaType(undefined, mediaInfo.url),
       bitrate: mediaInfo.bitrate,
       headers: mediaInfo.headers || {},
       extras,
@@ -284,16 +291,6 @@ function extractStreams(mediaInfo: any): StreamOption[] {
   }
 
   return streams.filter((s) => s.url);
-}
-
-// Detect format from URL
-function detectFormat(url: string): string {
-  if (!url) return 'unknown';
-  if (url.includes('.m3u8')) return 'hls';
-  if (url.includes('.flv')) return 'flv';
-  if (url.includes('.ts')) return 'mpegts';
-  if (url.includes('.mp4')) return 'mp4';
-  return 'unknown';
 }
 
 function stringifyValues(obj: Record<string, any>): Record<string, string> {

--- a/rust-srec/frontend/src/components/player/use-player-playback.ts
+++ b/rust-srec/frontend/src/components/player/use-player-playback.ts
@@ -1,0 +1,456 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { toast } from 'sonner';
+import { resolvePlayerMediaType, type PlayerMediaType } from '@/lib/media';
+import { resolveUrl } from '@/server/functions/parse';
+import { isDesktopBuild } from '@/utils/desktop';
+import { BASE_URL } from '@/utils/env';
+import { getDesktopAccessToken } from '@/utils/session';
+import { MpegtsPlaybackController } from './mpegts-playback';
+
+type ArtplayerInstance = InstanceType<(typeof import('artplayer'))['default']>;
+type ArtplayerOptions = ConstructorParameters<
+  (typeof import('artplayer'))['default']
+>[0];
+type ArtplayerMediaType = NonNullable<ArtplayerOptions['type']>;
+type HlsInstance = InstanceType<(typeof import('hls.js'))['default']>;
+
+interface PlaybackSource {
+  url: string;
+  headers?: Record<string, string>;
+}
+
+interface SourceRequest {
+  url: string;
+  headers?: Record<string, string>;
+  title: string;
+  streamData: unknown;
+  reloadKey: number;
+}
+
+interface ResolvedSource {
+  request: SourceRequest;
+  source: PlaybackSource;
+}
+
+interface UseResolvedSourceOptions {
+  url: string;
+  headers?: Record<string, string>;
+  title?: string;
+  streamData?: unknown;
+  reloadKey: number;
+}
+
+export interface UsePlayerPlaybackOptions {
+  url: string;
+  headers?: Record<string, string>;
+  title?: string;
+  streamData?: unknown;
+  muted: boolean;
+  volume: number;
+  onVolumeChange?: (volume: number) => void;
+  onMuteChange?: (muted: boolean) => void;
+  defaultWebFullscreen: boolean;
+  mediaType?: string;
+  isLive: boolean;
+  mediaDurationSecs?: number | null;
+  mediaFileSizeBytes?: number;
+}
+
+export interface BuildPlaybackUrlOptions extends PlaybackSource {
+  desktopBuild: boolean;
+  desktopToken: string | null;
+  baseUrl: string;
+}
+
+function getArtplayerType(mediaType: PlayerMediaType): ArtplayerMediaType {
+  switch (mediaType) {
+    case 'hls':
+      return 'm3u8';
+    case 'flv':
+      return 'flv';
+    case 'mpegts':
+      return 'mpegts';
+    case 'mp4':
+      return 'mp4';
+    case 'mkv':
+      return 'mkv';
+    case 'audio':
+      return 'mp3';
+    case 'native':
+    case 'auto':
+      return 'auto';
+  }
+}
+
+export function buildPlaybackUrl({
+  url,
+  headers,
+  desktopBuild,
+  desktopToken,
+  baseUrl,
+}: BuildPlaybackUrlOptions): string {
+  if (!headers || Object.keys(headers).length === 0) return url;
+
+  const query = `url=${encodeURIComponent(url)}&headers=${encodeURIComponent(JSON.stringify(headers))}`;
+  if (!desktopBuild) return `/stream-proxy?${query}`;
+  if (!desktopToken) return url;
+
+  return `${baseUrl.replace(/\/$/, '')}/stream-proxy?${query}&token=${encodeURIComponent(desktopToken)}`;
+}
+
+function matchesRequest(
+  resolved: ResolvedSource | null,
+  options: UseResolvedSourceOptions,
+): boolean {
+  if (!resolved || !options.title || !options.streamData) return false;
+
+  const { request } = resolved;
+  return (
+    request.url === options.url &&
+    request.headers === options.headers &&
+    request.title === options.title &&
+    request.streamData === options.streamData &&
+    request.reloadKey === options.reloadKey
+  );
+}
+
+function useResolvedSource(options: UseResolvedSourceOptions): {
+  source: PlaybackSource | null;
+  resolving: boolean;
+} {
+  const { url, headers, title, streamData, reloadKey } = options;
+  const [resolved, setResolved] = useState<ResolvedSource | null>(null);
+  const needsResolution = Boolean(streamData && title);
+
+  useEffect(() => {
+    if (!streamData || !title) return;
+
+    let disposed = false;
+    const request: SourceRequest = {
+      url,
+      headers,
+      title,
+      streamData,
+      reloadKey,
+    };
+
+    const resolve = async () => {
+      let sourceUrl = url;
+      try {
+        const response = await resolveUrl({
+          data: {
+            url: title,
+            stream_info: streamData,
+          },
+        });
+        if (disposed) return;
+
+        if (response.success && response.stream_info) {
+          sourceUrl = response.stream_info.url || url;
+        } else {
+          console.warn(
+            '[PlayerCard] URL resolution failed, using original:',
+            response.error,
+          );
+          toast.error(
+            `Resolution failed: ${response.error || 'Unknown error'}`,
+          );
+        }
+      } catch (error) {
+        if (disposed) return;
+        console.error('[PlayerCard] Resolution error:', error);
+      }
+
+      if (!disposed) {
+        setResolved({ request, source: { url: sourceUrl, headers } });
+      }
+    };
+
+    void resolve();
+    return () => {
+      disposed = true;
+    };
+  }, [url, headers, title, streamData, reloadKey]);
+
+  if (!needsResolution) {
+    return { source: { url, headers }, resolving: false };
+  }
+  if (!matchesRequest(resolved, options)) {
+    return { source: null, resolving: true };
+  }
+  return { source: resolved.source, resolving: false };
+}
+
+export function usePlayerPlayback(options: UsePlayerPlaybackOptions) {
+  const {
+    url,
+    headers,
+    title,
+    streamData,
+    muted,
+    volume,
+    onVolumeChange,
+    onMuteChange,
+    defaultWebFullscreen,
+    mediaType,
+    isLive,
+    mediaDurationSecs,
+    mediaFileSizeBytes,
+  } = options;
+  const containerRef = useRef<HTMLDivElement>(null);
+  const playerRef = useRef<ArtplayerInstance | null>(null);
+  const volumeRef = useRef(volume);
+  const mutedRef = useRef(muted);
+  const defaultWebFullscreenRef = useRef(defaultWebFullscreen);
+  const onVolumeChangeRef = useRef(onVolumeChange);
+  const onMuteChangeRef = useRef(onMuteChange);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [reloadKey, setReloadKey] = useState(0);
+
+  volumeRef.current = volume;
+  mutedRef.current = muted;
+  defaultWebFullscreenRef.current = defaultWebFullscreen;
+  onVolumeChangeRef.current = onVolumeChange;
+  onMuteChangeRef.current = onMuteChange;
+
+  const { source, resolving } = useResolvedSource({
+    url,
+    headers,
+    title,
+    streamData,
+    reloadKey,
+  });
+  const desktopBuild = isDesktopBuild();
+  const desktopToken = desktopBuild ? getDesktopAccessToken() : null;
+  const playUrl = source
+    ? buildPlaybackUrl({
+        ...source,
+        desktopBuild,
+        desktopToken,
+        baseUrl: BASE_URL,
+      })
+    : null;
+  const resolvedMediaType = source
+    ? resolvePlayerMediaType(mediaType, source.url, title)
+    : null;
+
+  const reload = useCallback(() => {
+    setError(null);
+    setLoading(true);
+    setReloadKey((current) => current + 1);
+  }, []);
+
+  useEffect(() => {
+    if (!resolving) return;
+    setError(null);
+    setLoading(true);
+  }, [resolving]);
+
+  useEffect(() => {
+    const player = playerRef.current;
+    if (player && player.volume !== volume) player.volume = volume;
+  }, [volume]);
+
+  useEffect(() => {
+    const player = playerRef.current;
+    if (player && player.muted !== muted) player.muted = muted;
+  }, [muted]);
+
+  useEffect(() => {
+    if (defaultWebFullscreen && playerRef.current?.isReady) {
+      playerRef.current.fullscreenWeb = true;
+    }
+  }, [defaultWebFullscreen]);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container || !playUrl || !resolvedMediaType) return;
+
+    let disposed = false;
+    let art: ArtplayerInstance | null = null;
+    let hls: HlsInstance | null = null;
+    let mpegtsController: MpegtsPlaybackController | null = null;
+
+    const destroySession = () => {
+      hls?.destroy();
+      hls = null;
+      mpegtsController?.destroy();
+      mpegtsController = null;
+
+      const currentArt = art;
+      art = null;
+      if (currentArt) {
+        currentArt.video.pause();
+        currentArt.destroy(false);
+        if (playerRef.current === currentArt) playerRef.current = null;
+      }
+      container.replaceChildren();
+    };
+
+    const initialize = async () => {
+      setError(null);
+      setLoading(true);
+
+      try {
+        const { default: Artplayer } = await import('artplayer');
+        if (disposed) return;
+
+        // Artplayer 5.4 reparents web-fullscreen players into document.body by
+        // default, which can leave Chromium's MediaSource video surface black.
+        Artplayer.FULLSCREEN_WEB_IN_BODY = false;
+
+        const artplayerType = getArtplayerType(resolvedMediaType);
+        const options: ArtplayerOptions = {
+          container,
+          url: playUrl,
+          autoplay: true,
+          volume: volumeRef.current,
+          muted: mutedRef.current,
+          autoSize: false,
+          pip: true,
+          mutex: false,
+          setting: true,
+          playbackRate: true,
+          aspectRatio: true,
+          fullscreen: true,
+          fullscreenWeb: true,
+          isLive,
+          miniProgressBar: !isLive,
+          theme: '#3b82f6',
+          type: artplayerType,
+        };
+
+        if (resolvedMediaType === 'hls') {
+          const { default: Hls } = await import('hls.js');
+          if (disposed) return;
+
+          if (Hls.isSupported()) {
+            options.customType = {
+              m3u8: (video: HTMLVideoElement, sourceUrl: string) => {
+                hls = new Hls({
+                  enableWorker: true,
+                  lowLatencyMode: isLive,
+                });
+                hls.loadSource(sourceUrl);
+                hls.attachMedia(video);
+                hls.on(Hls.Events.ERROR, (_event, data) => {
+                  if (!disposed && data.fatal) {
+                    setError(`HLS Error: ${data.type} - ${data.details}`);
+                    setLoading(false);
+                  }
+                });
+              },
+            };
+          }
+        }
+
+        const mpegtsType =
+          resolvedMediaType === 'flv' || resolvedMediaType === 'mpegts'
+            ? resolvedMediaType
+            : null;
+        if (mpegtsType) {
+          const { default: mpegts } = await import('mpegts.js');
+          if (disposed) return;
+          if (!mpegts.isSupported()) {
+            throw new Error(
+              'MPEG-TS playback is not supported by this browser',
+            );
+          }
+
+          mpegtsController = new MpegtsPlaybackController(mpegts, {
+            mediaType: mpegtsType,
+            isLive,
+            durationSecs: mediaDurationSecs,
+            fileSizeBytes: mediaFileSizeBytes,
+            onLoadingChange: (nextLoading) => {
+              if (!disposed) setLoading(nextLoading);
+            },
+            onError: ({ type, details, data }) => {
+              console.error('MPEG-TS Error:', { type, details, data });
+              if (!disposed) {
+                setError(`MPEG-TS Error: ${type} - ${details}`);
+              }
+            },
+            onStalled: () => {
+              if (!disposed) {
+                setError('Playback stalled while seeking. Reload the player.');
+              }
+            },
+            onWarning: (message, warning) => {
+              console.warn(`${message}:`, warning);
+            },
+          });
+          options.customType = {
+            [artplayerType]: (video: HTMLVideoElement, sourceUrl: string) => {
+              mpegtsController?.attach(video, sourceUrl);
+            },
+          };
+        }
+
+        if (disposed) return;
+        const createdArt = new Artplayer(options);
+        art = createdArt;
+        if (disposed) {
+          destroySession();
+          return;
+        }
+        playerRef.current = createdArt;
+
+        createdArt.on('ready', () => {
+          if (disposed) return;
+          if (defaultWebFullscreenRef.current) {
+            createdArt.fullscreenWeb = true;
+          }
+          setLoading(false);
+          setError(null);
+        });
+        createdArt.on('error', (playerError: Error) => {
+          if (disposed) return;
+          mpegtsController?.cancelSeekRecovery();
+          console.error('Player Error:', playerError);
+          setError(`Player Error: ${playerError.message || 'Unknown error'}`);
+          setLoading(false);
+        });
+        createdArt.on('video:volumechange', () => {
+          onVolumeChangeRef.current?.(createdArt.volume);
+          onMuteChangeRef.current?.(createdArt.muted);
+        });
+        createdArt.on('seek', (currentTime) => {
+          if (!mpegtsController?.seek(currentTime)) return;
+          setError(null);
+        });
+
+        const notifyMpegtsProgress = () => {
+          mpegtsController?.notifyMediaProgress();
+        };
+        createdArt.on('video:seeked', notifyMpegtsProgress);
+        createdArt.on('video:canplay', notifyMpegtsProgress);
+        createdArt.on('video:playing', notifyMpegtsProgress);
+        createdArt.on('video:timeupdate', notifyMpegtsProgress);
+      } catch (initializationError) {
+        destroySession();
+        if (disposed) return;
+        setError(
+          `Failed to initialize player: ${initializationError instanceof Error ? initializationError.message : 'Unknown error'}`,
+        );
+        setLoading(false);
+      }
+    };
+
+    void initialize();
+    return () => {
+      disposed = true;
+      destroySession();
+    };
+  }, [
+    playUrl,
+    resolvedMediaType,
+    isLive,
+    mediaDurationSecs,
+    mediaFileSizeBytes,
+    reloadKey,
+  ]);
+
+  return { containerRef, error, loading, reload };
+}

--- a/rust-srec/frontend/src/lib/__tests__/media.test.ts
+++ b/rust-srec/frontend/src/lib/__tests__/media.test.ts
@@ -1,0 +1,64 @@
+import {
+  isPlayable,
+  normalizePlayerMediaType,
+  resolvePlayerMediaType,
+} from '../media';
+
+describe('player media type resolution', () => {
+  it('normalizes backend format aliases', () => {
+    expect(normalizePlayerMediaType('HLS')).toBe('hls');
+    expect(normalizePlayerMediaType('http-flv')).toBe('flv');
+    expect(normalizePlayerMediaType('mpeg-ts')).toBe('mpegts');
+    expect(normalizePlayerMediaType('fmp4')).toBe('mp4');
+  });
+
+  it('prefers an explicit format over URL and title fallbacks', () => {
+    expect(
+      resolvePlayerMediaType(
+        'hls',
+        'https://example.com/recording.mp4',
+        'recording.flv',
+      ),
+    ).toBe('hls');
+  });
+
+  it('uses the final path extension instead of substring matches', () => {
+    expect(resolvePlayerMediaType(undefined, 'recording.ts.mp4')).toBe('mp4');
+    expect(resolvePlayerMediaType(undefined, 'recording.mp4.ts')).toBe(
+      'mpegts',
+    );
+  });
+
+  it('ignores query strings and fragments during fallback detection', () => {
+    expect(
+      resolvePlayerMediaType(
+        undefined,
+        '/api/media/id/content?token=header.ts.signature',
+        'recording.mp4#chapter.ts',
+      ),
+    ).toBe('mp4');
+  });
+
+  it('returns auto when no supported type is known', () => {
+    expect(resolvePlayerMediaType('unknown', '/api/media/id/content')).toBe(
+      'auto',
+    );
+  });
+});
+
+describe('isPlayable', () => {
+  it('accepts supported extensions and ignores query strings', () => {
+    expect(
+      isPlayable({ format: 'VIDEO', file_path: '/recordings/video.mp4?v=1' }),
+    ).toBe(true);
+  });
+
+  it('rejects non-media outputs and misleading suffixes', () => {
+    expect(
+      isPlayable({ format: 'THUMBNAIL', file_path: '/recordings/image.mp4' }),
+    ).toBe(false);
+    expect(
+      isPlayable({ format: 'VIDEO', file_path: '/recordings/video.mp4.tmp' }),
+    ).toBe(false);
+  });
+});

--- a/rust-srec/frontend/src/lib/media.ts
+++ b/rust-srec/frontend/src/lib/media.ts
@@ -1,3 +1,87 @@
+export type PlayerMediaType =
+  | 'hls'
+  | 'flv'
+  | 'mpegts'
+  | 'mp4'
+  | 'mkv'
+  | 'audio'
+  | 'native'
+  | 'auto';
+
+const PLAYABLE_EXTENSIONS = new Set([
+  'mp4',
+  'webm',
+  'ogg',
+  'mp3',
+  'wav',
+  'mkv',
+  'flv',
+  'ts',
+  'm3u8',
+]);
+
+const MEDIA_TYPE_ALIASES: Readonly<Record<string, PlayerMediaType>> = {
+  hls: 'hls',
+  m3u8: 'hls',
+  flv: 'flv',
+  'http-flv': 'flv',
+  ts: 'mpegts',
+  m2ts: 'mpegts',
+  mpegts: 'mpegts',
+  'mpeg-ts': 'mpegts',
+  mp4: 'mp4',
+  fmp4: 'mp4',
+  m4v: 'mp4',
+  mov: 'mp4',
+  mkv: 'mkv',
+  matroska: 'mkv',
+  mp3: 'audio',
+  wav: 'audio',
+  ogg: 'audio',
+  aac: 'audio',
+  m4a: 'audio',
+  flac: 'audio',
+  webm: 'native',
+  auto: 'auto',
+};
+
+function getMediaExtension(value: string): string | undefined {
+  const path = value.split(/[?#]/, 1)[0]?.replaceAll('\\', '/');
+  const fileName = path?.split('/').pop();
+  if (!fileName) return undefined;
+
+  const extensionIndex = fileName.lastIndexOf('.');
+  if (extensionIndex <= 0 || extensionIndex === fileName.length - 1) {
+    return undefined;
+  }
+
+  return fileName.slice(extensionIndex + 1).toLowerCase();
+}
+
+export function normalizePlayerMediaType(
+  value: string | null | undefined,
+): PlayerMediaType | undefined {
+  if (!value) return undefined;
+  return MEDIA_TYPE_ALIASES[value.trim().toLowerCase().replace(/^\./, '')];
+}
+
+export function resolvePlayerMediaType(
+  explicitType: string | null | undefined,
+  ...sources: Array<string | null | undefined>
+): PlayerMediaType {
+  const normalizedType = normalizePlayerMediaType(explicitType);
+  if (normalizedType) return normalizedType;
+
+  for (const source of sources) {
+    if (!source) continue;
+    const extension = getMediaExtension(source);
+    const detectedType = normalizePlayerMediaType(extension);
+    if (detectedType) return detectedType;
+  }
+
+  return 'auto';
+}
+
 export function isPlayable(output: {
   format: string;
   file_path: string;
@@ -7,18 +91,7 @@ export function isPlayable(output: {
     return false;
 
   // Whitelist supported extensions
-  const validExtensions = [
-    'mp4',
-    'webm',
-    'ogg',
-    'mp3',
-    'wav',
-    'mkv',
-    'flv',
-    'ts',
-    'm3u8',
-  ];
-  const extension = output.file_path.split('.').pop()?.toLowerCase();
+  const extension = getMediaExtension(output.file_path);
 
-  return validExtensions.includes(extension || '');
+  return extension !== undefined && PLAYABLE_EXTENSIONS.has(extension);
 }

--- a/rust-srec/frontend/src/routes/_authed/_dashboard/player/index.lazy.tsx
+++ b/rust-srec/frontend/src/routes/_authed/_dashboard/player/index.lazy.tsx
@@ -33,6 +33,7 @@ import { msg } from '@lingui/core/macro';
 import { toast } from 'sonner';
 import { motion, AnimatePresence } from 'motion/react';
 import { cn } from '@/lib/utils';
+import { resolvePlayerMediaType } from '@/lib/media';
 
 // Lazy loaded PlayerCard
 const PlayerCard = React.lazy(() =>
@@ -508,6 +509,8 @@ const PlayerItem = React.memo(function PlayerItem({
         <PlayerCard
           url={player.currentStream.url}
           title={player.title}
+          mediaType={player.currentStream.format}
+          isLive={player.response.is_live}
           headers={headers}
           streamData={streamData}
           onRemove={onRemove}
@@ -542,7 +545,10 @@ function extractFirstStream(mediaInfo: any): StreamOption | null {
       url: stream.url || stream.src || '',
       quality: stream.quality || stream.resolution || 'default',
       cdn: stream.cdn || stream.server || extras.cdn,
-      format: stream.format || detectFormat(stream.url),
+      format:
+        stream.format ||
+        stream.stream_format ||
+        resolvePlayerMediaType(undefined, stream.url),
       bitrate: stream.bitrate || stream.bandwidth,
       headers: { ...mediaInfo.headers, ...stream.headers },
       extras,
@@ -556,7 +562,10 @@ function extractFirstStream(mediaInfo: any): StreamOption | null {
       url: mediaInfo.url,
       quality: mediaInfo.quality || 'default',
       cdn: mediaInfo.cdn || extras.cdn,
-      format: mediaInfo.format || detectFormat(mediaInfo.url),
+      format:
+        mediaInfo.format ||
+        mediaInfo.stream_format ||
+        resolvePlayerMediaType(undefined, mediaInfo.url),
       bitrate: mediaInfo.bitrate,
       headers: mediaInfo.headers || {},
       extras,
@@ -568,23 +577,12 @@ function extractFirstStream(mediaInfo: any): StreamOption | null {
     return {
       url: mediaInfo,
       quality: 'default',
-      format: detectFormat(mediaInfo),
+      format: resolvePlayerMediaType(undefined, mediaInfo),
       extras: {},
     };
   }
 
-  console.log('Unable to extract stream from media_info:', mediaInfo);
   return null;
-}
-
-// Detect format from URL
-function detectFormat(url: string): string {
-  if (!url) return 'unknown';
-  if (url.includes('.m3u8')) return 'hls';
-  if (url.includes('.flv')) return 'flv';
-  if (url.includes('.ts')) return 'mpegts';
-  if (url.includes('.mp4')) return 'mp4';
-  return 'unknown';
 }
 
 function stringifyValues(obj: Record<string, any>): Record<string, string> {

--- a/rust-srec/frontend/src/routes/_authed/_dashboard/sessions/$sessionId.lazy.tsx
+++ b/rust-srec/frontend/src/routes/_authed/_dashboard/sessions/$sessionId.lazy.tsx
@@ -34,6 +34,7 @@ import { useLingui } from '@lingui/react';
 import { toast } from 'sonner';
 import { ArrowLeft, AlertCircle } from 'lucide-react';
 import { getMediaUrl } from '@/lib/url';
+import { resolvePlayerMediaType } from '@/lib/media';
 import { formatDuration } from '@/lib/format';
 import { BackendApiError } from '@/lib/api-error';
 import type { MediaOutput } from '@/api/schemas/system';
@@ -109,7 +110,7 @@ async function listAllSessionSegments(
 function SessionDetailPage() {
   const { sessionId } = Route.useParams();
   const { user } = Route.useRouteContext();
-  const [playingOutput, setPlayingOutput] = useState<any>(null);
+  const [playingOutput, setPlayingOutput] = useState<MediaOutput | null>(null);
 
   const [now, setNow] = useState<Date | null>(null);
   useEffect(() => {
@@ -424,6 +425,13 @@ function SessionDetailPage() {
                       ) || ''
                     }
                     title={playingOutput.file_path.split('/').pop()}
+                    mediaType={resolvePlayerMediaType(
+                      undefined,
+                      playingOutput.file_path,
+                    )}
+                    isLive={false}
+                    mediaDurationSecs={playingOutput.duration_secs}
+                    mediaFileSizeBytes={playingOutput.file_size_bytes}
                     className="w-full h-full border-0 rounded-none bg-black"
                     contentClassName="min-h-0"
                     defaultWebFullscreen

--- a/rust-srec/src/api/server.rs
+++ b/rust-srec/src/api/server.rs
@@ -2,6 +2,7 @@
 
 use axum::Router;
 use axum::extract::{DefaultBodyLimit, Request};
+use axum::http::header;
 use axum::serve::ListenerExt;
 use dashmap::DashMap;
 use std::net::SocketAddr;
@@ -441,7 +442,12 @@ impl ApiServer {
             let cors = CorsLayer::new()
                 .allow_origin(Any)
                 .allow_methods(Any)
-                .allow_headers(Any);
+                .allow_headers(Any)
+                .expose_headers([
+                    header::ACCEPT_RANGES,
+                    header::CONTENT_LENGTH,
+                    header::CONTENT_RANGE,
+                ]);
             router = router.layer(cors);
         }
 

--- a/rust-srec/src/downloader/engine/ffmpeg.rs
+++ b/rust-srec/src/downloader/engine/ffmpeg.rs
@@ -19,6 +19,47 @@ use super::utils::{
 use crate::Result;
 use crate::database::models::engine::FfmpegEngineConfig;
 
+fn is_mp4_family(format: &str) -> bool {
+    matches!(
+        format
+            .trim()
+            .trim_start_matches('.')
+            .to_ascii_lowercase()
+            .as_str(),
+        "mp4" | "mov" | "m4v"
+    )
+}
+
+fn contains_option(args: &[String], name: &str) -> bool {
+    args.iter().any(|arg| {
+        arg == name
+            || arg
+                .strip_prefix(name)
+                .is_some_and(|suffix| suffix.starts_with('='))
+    })
+}
+
+fn append_faststart_option(
+    args: &mut Vec<String>,
+    output_args: &[String],
+    output_format: &str,
+    segment_mode: bool,
+) {
+    if !is_mp4_family(output_format) {
+        return;
+    }
+
+    let (option, value) = if segment_mode {
+        ("-segment_format_options", "movflags=+faststart")
+    } else {
+        ("-movflags", "+faststart")
+    };
+
+    if !contains_option(output_args, option) {
+        args.extend([option.to_string(), value.to_string()]);
+    }
+}
+
 /// FFmpeg-based download engine.
 pub struct FfmpegEngine {
     /// Engine configuration.
@@ -106,8 +147,10 @@ impl FfmpegEngine {
             args.extend(["-fs".to_string(), config.max_segment_size_bytes.to_string()]);
         }
 
+        let segment_mode = config.max_segment_duration_secs > 0;
+
         // Segment options if splitting is enabled
-        if config.max_segment_duration_secs > 0 {
+        if segment_mode {
             args.extend([
                 "-f".to_string(),
                 "segment".to_string(),
@@ -120,13 +163,20 @@ impl FfmpegEngine {
             ]);
         }
 
+        append_faststart_option(
+            &mut args,
+            &self.config.output_args,
+            &config.output_format,
+            segment_mode,
+        );
+
         // Output path
         let output_path = config.output_dir.join(format!(
             "{}.{}",
             config.filename_template, config.output_format
         ));
 
-        if config.max_segment_duration_secs > 0 {
+        if segment_mode {
             // Use segment pattern with strftime enabled by -strftime 1 flag
             // In strftime mode, %d is the segment counter (not day-of-month)
             // TODO : ENSURE USER PATH IS VALID
@@ -604,6 +654,76 @@ impl DownloadEngine for FfmpegEngine {
 mod tests {
     use super::*;
     use crate::downloader::engine::utils::parse_time;
+
+    fn engine_with_output_args(output_args: &[&str]) -> FfmpegEngine {
+        FfmpegEngine {
+            config: FfmpegEngineConfig {
+                output_args: output_args.iter().map(ToString::to_string).collect(),
+                ..Default::default()
+            },
+            version: None,
+        }
+    }
+
+    fn download_config(format: &str, segment_duration_secs: u64) -> DownloadConfig {
+        DownloadConfig::new(
+            "https://example.com/live",
+            "recordings",
+            "streamer-id",
+            "Streamer",
+            "session-id",
+        )
+        .with_filename_template("recording-%Y%m%d-%H%M%S")
+        .with_output_format(format)
+        .with_max_segment_duration(segment_duration_secs)
+    }
+
+    fn has_arg_pair(args: &[String], option: &str, value: &str) -> bool {
+        args.windows(2)
+            .any(|pair| pair[0] == option && pair[1] == value)
+    }
+
+    #[test]
+    fn mp4_output_uses_faststart() {
+        let args = engine_with_output_args(&[]).build_args(&download_config("mp4", 0));
+
+        assert!(has_arg_pair(&args, "-movflags", "+faststart"));
+        assert!(!contains_option(&args, "-segment_format_options"));
+    }
+
+    #[test]
+    fn segmented_mp4_output_passes_faststart_to_the_segment_muxer() {
+        let args = engine_with_output_args(&[]).build_args(&download_config("MP4", 60));
+
+        assert!(has_arg_pair(
+            &args,
+            "-segment_format_options",
+            "movflags=+faststart"
+        ));
+        assert!(!contains_option(&args, "-movflags"));
+    }
+
+    #[test]
+    fn non_mp4_output_does_not_use_faststart() {
+        let args = engine_with_output_args(&[]).build_args(&download_config("mkv", 0));
+
+        assert!(!contains_option(&args, "-movflags"));
+        assert!(!contains_option(&args, "-segment_format_options"));
+    }
+
+    #[test]
+    fn custom_faststart_option_is_not_overridden() {
+        let args = engine_with_output_args(&["-movflags=+frag_keyframe"])
+            .build_args(&download_config("mp4", 0));
+
+        assert_eq!(
+            args.iter()
+                .filter(|arg| arg.starts_with("-movflags"))
+                .count(),
+            1
+        );
+        assert!(!args.iter().any(|arg| arg == "+faststart"));
+    }
 
     #[test]
     fn test_parse_time() {


### PR DESCRIPTION
## Summary

- make recorded FLV and MPEG-TS seeking keyframe-aware and recover stalled MediaSource pipelines
- keep Artplayer web fullscreen inside the React-owned container to avoid Chromium black-frame stalls
- centralize source resolution, proxy URL construction, adapter lifecycle, and mutable player state
- propagate explicit media metadata, expose range response headers, and enable MP4 faststart output
- add focused media detection, playback lifecycle, seek recovery, and FFmpeg argument tests

## Root cause

Artplayer 5.4 changed web fullscreen to reparent the player into `document.body` by default. In Chromium, seeking a MediaSource-backed FLV after that move could update the clock and byte range while leaving the video surface black. Recorded streams also need VOD duration and file-size metadata so `mpegts.js` can select and request a preceding keyframe reliably.

## Impact

Recorded playback now seeks without freezing in normal or maximized player views. Stalled seeks rebuild the MPEG-TS pipeline once and report a visible error if recovery fails. Live playback keeps its existing behavior, and the raw FLV recording writer is unchanged.

## Validation

- `pnpm run lint`
- `pnpm test` (66 tests)
- `pnpm run build`
- `cargo fmt --all -- --check`
- `cargo clippy --locked -p rust-srec --lib -- -D warnings`
- `cargo test --locked -p rust-srec --lib downloader::engine::ffmpeg` (9 tests)
- Chrome fullscreen seek smoke test at `04:38`: playback advanced to `04:45`, 2,292 of 2,304 sampled pixels were non-black, and no runtime exceptions occurred
