### PR TITLE
fix(frontend): improve DAG relationship layout

### DIFF
--- a/rust-srec/frontend/src/components/config/shared/pipeline-config-adapter.tsx
+++ b/rust-srec/frontend/src/components/config/shared/pipeline-config-adapter.tsx
@@ -14,13 +14,6 @@ export const PipelineConfigAdapter = memo(
     const currentVal = useWatch({ control: form.control, name });
     const [steps, setSteps] = useState<DagStepDefinition[]>([]);
     useEffect(() => {
-      // Debug log
-      console.log('PipelineConfigAdapter: input changed', {
-        currentVal,
-        type: typeof currentVal,
-        currentStepCount: steps.length,
-      });
-
       if (currentVal) {
         try {
           const parsed =
@@ -39,10 +32,6 @@ export const PipelineConfigAdapter = memo(
             const newJson = JSON.stringify(parsed.steps);
 
             if (currentJson !== newJson) {
-              console.log('PipelineConfigAdapter: updating steps', {
-                from: steps.length,
-                to: parsed.steps.length,
-              });
               setSteps(parsed.steps);
             }
           }

--- a/rust-srec/frontend/src/components/pipeline/workflows/flow-editor/layout.test.ts
+++ b/rust-srec/frontend/src/components/pipeline/workflows/flow-editor/layout.test.ts
@@ -1,0 +1,82 @@
+import type { Edge, Node } from '@xyflow/react';
+import { describe, expect, it } from 'vitest';
+
+import { getLayoutedElements } from './layout';
+
+function node(id: string): Node {
+  return { id, position: { x: 0, y: 0 }, data: {} };
+}
+
+function edge(source: string, target: string): Edge {
+  return { id: `${source}-${target}`, source, target };
+}
+
+function positionsById(nodes: Node[]) {
+  return new Map(nodes.map((item) => [item.id, item.position]));
+}
+
+describe('workflow graph layout', () => {
+  it('keeps a simple chain on one lane', () => {
+    const result = getLayoutedElements(
+      [node('a'), node('b'), node('c')],
+      [edge('a', 'b'), edge('b', 'c')],
+    );
+    const positions = positionsById(result.nodes);
+
+    expect(positions.get('a')?.y).toBe(positions.get('b')?.y);
+    expect(positions.get('b')?.y).toBe(positions.get('c')?.y);
+    expect(positions.get('a')?.x).toBeLessThan(positions.get('b')?.x ?? 0);
+    expect(positions.get('b')?.x).toBeLessThan(positions.get('c')?.x ?? 0);
+  });
+
+  it('separates a bypassed path from its direct edge', () => {
+    const result = getLayoutedElements(
+      [node('remux'), node('thumbnail'), node('upload')],
+      [
+        edge('remux', 'thumbnail'),
+        edge('thumbnail', 'upload'),
+        edge('remux', 'upload'),
+      ],
+    );
+    const positions = positionsById(result.nodes);
+
+    expect(positions.get('remux')?.y).toBe(positions.get('upload')?.y);
+    expect(positions.get('thumbnail')?.y).toBeLessThan(
+      positions.get('remux')?.y ?? 0,
+    );
+  });
+
+  it('places parallel branches on separate lanes around their join', () => {
+    const result = getLayoutedElements(
+      [node('source'), node('video'), node('image'), node('upload')],
+      [
+        edge('source', 'video'),
+        edge('source', 'image'),
+        edge('video', 'upload'),
+        edge('image', 'upload'),
+      ],
+    );
+    const positions = positionsById(result.nodes);
+
+    expect(positions.get('source')?.y).toBe(positions.get('upload')?.y);
+    expect(positions.get('video')?.y).not.toBe(positions.get('image')?.y);
+  });
+
+  it('uses deeper lanes for nested bypass relationships', () => {
+    const result = getLayoutedElements(
+      [node('a'), node('b'), node('c'), node('d')],
+      [
+        edge('a', 'b'),
+        edge('b', 'c'),
+        edge('c', 'd'),
+        edge('a', 'd'),
+        edge('b', 'd'),
+      ],
+    );
+    const positions = positionsById(result.nodes);
+
+    expect(positions.get('a')?.y).toBe(positions.get('d')?.y);
+    expect(positions.get('b')?.y).toBeLessThan(positions.get('a')?.y ?? 0);
+    expect(positions.get('c')?.y).toBeLessThan(positions.get('b')?.y ?? 0);
+  });
+});

--- a/rust-srec/frontend/src/components/pipeline/workflows/flow-editor/layout.test.ts
+++ b/rust-srec/frontend/src/components/pipeline/workflows/flow-editor/layout.test.ts
@@ -1,7 +1,7 @@
 import type { Edge, Node } from '@xyflow/react';
 import { describe, expect, it } from 'vitest';
 
-import { getLayoutedElements } from './layout';
+import { getInitialNodePosition, getLayoutedElements } from './layout';
 
 function node(id: string): Node {
   return { id, position: { x: 0, y: 0 }, data: {} };
@@ -62,6 +62,44 @@ describe('workflow graph layout', () => {
     expect(positions.get('video')?.y).not.toBe(positions.get('image')?.y);
   });
 
+  it('orders connected levels to reduce edge crossings', () => {
+    const result = getLayoutedElements(
+      [node('a'), node('b'), node('x'), node('y')],
+      [edge('a', 'y'), edge('b', 'x')],
+    );
+    const positions = positionsById(result.nodes);
+
+    expect(positions.get('y')?.y).toBeLessThan(positions.get('x')?.y ?? 0);
+  });
+
+  it('balances independent detours above and below their direct paths', () => {
+    const result = getLayoutedElements(
+      [
+        node('a'),
+        node('b'),
+        node('c'),
+        node('d'),
+        node('e'),
+        node('f'),
+        node('g'),
+      ],
+      [
+        edge('a', 'b'),
+        edge('b', 'c'),
+        edge('c', 'd'),
+        edge('a', 'd'),
+        edge('b', 'd'),
+        edge('e', 'f'),
+        edge('f', 'g'),
+        edge('e', 'g'),
+      ],
+    );
+    const positions = positionsById(result.nodes);
+
+    expect(positions.get('b')?.y).toBeLessThan(positions.get('a')?.y ?? 0);
+    expect(positions.get('f')?.y).toBeGreaterThan(positions.get('e')?.y ?? 0);
+  });
+
   it('uses deeper lanes for nested bypass relationships', () => {
     const result = getLayoutedElements(
       [node('a'), node('b'), node('c'), node('d')],
@@ -78,5 +116,42 @@ describe('workflow graph layout', () => {
     expect(positions.get('a')?.y).toBe(positions.get('d')?.y);
     expect(positions.get('b')?.y).toBeLessThan(positions.get('a')?.y ?? 0);
     expect(positions.get('c')?.y).toBeLessThan(positions.get('b')?.y ?? 0);
+  });
+
+  it('places a new child to the right at its dependencies average height', () => {
+    const existingNodes = [
+      { ...node('a'), position: { x: 50, y: 50 } },
+      { ...node('b'), position: { x: 50, y: 250 } },
+    ];
+
+    expect(getInitialNodePosition(existingNodes, ['a', 'b'])).toEqual({
+      x: 400,
+      y: 150,
+    });
+  });
+
+  it('places a new root below existing first-level roots', () => {
+    const existingNodes = [
+      { ...node('a'), position: { x: 50, y: 50 } },
+      { ...node('b'), position: { x: 50, y: 250 } },
+      { ...node('c'), position: { x: 400, y: 50 } },
+    ];
+
+    expect(getInitialNodePosition(existingNodes, [])).toEqual({
+      x: 50,
+      y: 450,
+    });
+  });
+
+  it('avoids an occupied position when adding a sibling', () => {
+    const existingNodes = [
+      { ...node('source'), position: { x: 50, y: 50 } },
+      { ...node('first-child'), position: { x: 400, y: 50 } },
+    ];
+
+    expect(getInitialNodePosition(existingNodes, ['source'])).toEqual({
+      x: 400,
+      y: 250,
+    });
   });
 });

--- a/rust-srec/frontend/src/components/pipeline/workflows/flow-editor/layout.ts
+++ b/rust-srec/frontend/src/components/pipeline/workflows/flow-editor/layout.ts
@@ -1,9 +1,42 @@
-import type { Edge, Node } from '@xyflow/react';
+import type { Edge, Node, XYPosition } from '@xyflow/react';
 
 const LEVEL_SPACING = 350;
 const NODE_SPACING = 200;
 const DETOUR_OFFSET = 180;
 const PADDING = 50;
+
+type Adjacency = {
+  incoming: Map<string, Edge[]>;
+  outgoing: Map<string, Edge[]>;
+};
+
+type DetourLane = {
+  depth: number;
+  direction: -1 | 1;
+};
+
+function buildAdjacency(edges: Edge[]): Adjacency {
+  const outgoing = new Map<string, Edge[]>();
+  const incoming = new Map<string, Edge[]>();
+
+  for (const edge of edges) {
+    const outgoingEdges = outgoing.get(edge.source);
+    if (outgoingEdges) {
+      outgoingEdges.push(edge);
+    } else {
+      outgoing.set(edge.source, [edge]);
+    }
+
+    const incomingEdges = incoming.get(edge.target);
+    if (incomingEdges) {
+      incomingEdges.push(edge);
+    } else {
+      incoming.set(edge.target, [edge]);
+    }
+  }
+
+  return { incoming, outgoing };
+}
 
 function collectReachable(
   startId: string,
@@ -28,23 +61,26 @@ function collectReachable(
   return reachable;
 }
 
-// Separate alternate multi-step paths from direct long edges so neither route is hidden.
-function findDetourDepths(
+function findDetourLanes(
   nodes: Node[],
   edges: Edge[],
   levels: Record<string, number>,
-): Map<string, number> {
-  const outgoing = new Map<string, Edge[]>();
-  const incoming = new Map<string, Edge[]>();
+  { incoming, outgoing }: Adjacency,
+): Map<string, DetourLane> {
+  const detourLanes = new Map<string, DetourLane>();
+  const longEdges = edges
+    .map((edge, index) => ({ edge, index }))
+    .filter(
+      ({ edge }) => (levels[edge.target] ?? 0) - (levels[edge.source] ?? 0) > 1,
+    )
+    .sort((a, b) => {
+      const aSpan = (levels[a.edge.target] ?? 0) - (levels[a.edge.source] ?? 0);
+      const bSpan = (levels[b.edge.target] ?? 0) - (levels[b.edge.source] ?? 0);
+      return bSpan - aSpan || a.index - b.index;
+    });
+  let independentDetourIndex = 0;
 
-  for (const edge of edges) {
-    outgoing.set(edge.source, [...(outgoing.get(edge.source) ?? []), edge]);
-    incoming.set(edge.target, [...(incoming.get(edge.target) ?? []), edge]);
-  }
-
-  const detourDepths = new Map<string, number>();
-
-  for (const edge of edges) {
+  for (const { edge } of longEdges) {
     const sourceLevel = levels[edge.source];
     const targetLevel = levels[edge.target];
     if (
@@ -62,25 +98,176 @@ function findDetourDepths(
     );
     const canReachTarget = collectReachable(edge.target, incoming, edge.id);
 
-    for (const node of nodes) {
-      if (
+    const pathNodes = nodes.filter(
+      (node) =>
         node.id !== edge.source &&
         node.id !== edge.target &&
         reachableFromSource.has(node.id) &&
-        canReachTarget.has(node.id)
-      ) {
-        detourDepths.set(node.id, (detourDepths.get(node.id) ?? 0) + 1);
-      }
+        canReachTarget.has(node.id),
+    );
+    if (pathNodes.length === 0) continue;
+
+    const inheritedLane = pathNodes.reduce<DetourLane | undefined>(
+      (deepestLane, node) => {
+        const lane = detourLanes.get(node.id);
+        if (!lane || (deepestLane && deepestLane.depth >= lane.depth)) {
+          return deepestLane;
+        }
+        return lane;
+      },
+      undefined,
+    );
+    const direction: -1 | 1 =
+      inheritedLane?.direction ?? (independentDetourIndex % 2 === 0 ? -1 : 1);
+    if (!inheritedLane) independentDetourIndex += 1;
+
+    for (const node of pathNodes) {
+      const existing = detourLanes.get(node.id);
+      detourLanes.set(node.id, {
+        depth: (existing?.depth ?? 0) + 1,
+        direction: existing?.direction ?? direction,
+      });
     }
   }
 
-  return detourDepths;
+  return detourLanes;
+}
+
+function verticalOrder(nodesByLevel: Node[][]): Map<string, number> {
+  const order = new Map<string, number>();
+
+  for (const levelNodes of nodesByLevel) {
+    if (!levelNodes) continue;
+
+    const centerIndex = (levelNodes.length - 1) / 2;
+    levelNodes.forEach((node, index) => {
+      order.set(node.id, index - centerIndex);
+    });
+  }
+
+  return order;
+}
+
+function neighborBarycenter(
+  nodeId: string,
+  adjacency: Map<string, Edge[]>,
+  order: Map<string, number>,
+): number | undefined {
+  const positions = (adjacency.get(nodeId) ?? [])
+    .map((edge) =>
+      order.get(edge.source === nodeId ? edge.target : edge.source),
+    )
+    .filter((position): position is number => position !== undefined);
+
+  if (positions.length === 0) return undefined;
+  return (
+    positions.reduce((sum, position) => sum + position, 0) / positions.length
+  );
+}
+
+function orderLevel(
+  levelNodes: Node[],
+  adjacency: Map<string, Edge[]>,
+  order: Map<string, number>,
+  originalOrder: Map<string, number>,
+): Node[] {
+  return [...levelNodes].sort((a, b) => {
+    const aCenter = neighborBarycenter(a.id, adjacency, order);
+    const bCenter = neighborBarycenter(b.id, adjacency, order);
+
+    if (aCenter !== undefined && bCenter !== undefined && aCenter !== bCenter) {
+      return aCenter - bCenter;
+    }
+    if (aCenter !== undefined && bCenter === undefined) return -1;
+    if (aCenter === undefined && bCenter !== undefined) return 1;
+    return (originalOrder.get(a.id) ?? 0) - (originalOrder.get(b.id) ?? 0);
+  });
+}
+
+function minimizeCrossings(
+  nodesByLevel: Node[][],
+  { incoming, outgoing }: Adjacency,
+  originalOrder: Map<string, number>,
+) {
+  for (let pass = 0; pass < 2; pass += 1) {
+    let order = verticalOrder(nodesByLevel);
+    for (let level = 1; level < nodesByLevel.length; level += 1) {
+      const levelNodes = nodesByLevel[level];
+      if (levelNodes) {
+        nodesByLevel[level] = orderLevel(
+          levelNodes,
+          incoming,
+          order,
+          originalOrder,
+        );
+        order = verticalOrder(nodesByLevel);
+      }
+    }
+
+    order = verticalOrder(nodesByLevel);
+    for (let level = nodesByLevel.length - 2; level >= 0; level -= 1) {
+      const levelNodes = nodesByLevel[level];
+      if (levelNodes) {
+        nodesByLevel[level] = orderLevel(
+          levelNodes,
+          outgoing,
+          order,
+          originalOrder,
+        );
+        order = verticalOrder(nodesByLevel);
+      }
+    }
+  }
+}
+
+export function getInitialNodePosition(
+  nodes: Node[],
+  dependencyIds: string[],
+): XYPosition {
+  if (nodes.length === 0) return { x: PADDING, y: PADDING };
+
+  const dependencySet = new Set(dependencyIds);
+  const dependencies = nodes.filter((node) => dependencySet.has(node.id));
+  if (dependencies.length > 0) {
+    const x =
+      Math.max(...dependencies.map((node) => node.position.x)) + LEVEL_SPACING;
+    let y =
+      dependencies.reduce((sum, node) => sum + node.position.y, 0) /
+      dependencies.length;
+
+    const nodesAtLevel = nodes.filter(
+      (node) => Math.abs(node.position.x - x) < LEVEL_SPACING / 2,
+    );
+    while (
+      nodesAtLevel.some((node) => Math.abs(node.position.y - y) < NODE_SPACING)
+    ) {
+      y += NODE_SPACING;
+    }
+
+    return {
+      x,
+      y,
+    };
+  }
+
+  const minX = Math.min(...nodes.map((node) => node.position.x));
+  const firstLevelNodes = nodes.filter((node) => node.position.x === minX);
+  return {
+    x: minX,
+    y:
+      Math.max(...firstLevelNodes.map((node) => node.position.y)) +
+      NODE_SPACING,
+  };
 }
 
 export function getLayoutedElements(nodes: Node[], edges: Edge[]) {
   const levels: Record<string, number> = {};
   const nodeMap: Record<string, Node> = {};
-  nodes.forEach((n) => (nodeMap[n.id] = n));
+  const originalOrder = new Map<string, number>();
+  nodes.forEach((node, index) => {
+    nodeMap[node.id] = node;
+    originalOrder.set(node.id, index);
+  });
 
   const getLevel = (id: string, visiting = new Set<string>()): number => {
     if (levels[id] !== undefined) return levels[id];
@@ -114,7 +301,10 @@ export function getLayoutedElements(nodes: Node[], edges: Edge[]) {
     nodesByLevel[level].push(node);
   });
 
-  const detourDepths = findDetourDepths(nodes, edges, levels);
+  const adjacency = buildAdjacency(edges);
+  minimizeCrossings(nodesByLevel, adjacency, originalOrder);
+
+  const detourLanes = findDetourLanes(nodes, edges, levels, adjacency);
   const yByNodeId = new Map<string, number>();
 
   for (const levelNodes of nodesByLevel) {
@@ -124,8 +314,9 @@ export function getLayoutedElements(nodes: Node[], edges: Edge[]) {
     levelNodes.forEach((node, nodeIndex) => {
       let y = (nodeIndex - centerIndex) * NODE_SPACING;
 
-      if (levelNodes.length === 1) {
-        y -= (detourDepths.get(node.id) ?? 0) * DETOUR_OFFSET;
+      const detourLane = detourLanes.get(node.id);
+      if (detourLane) {
+        y += detourLane.direction * detourLane.depth * DETOUR_OFFSET;
       }
 
       yByNodeId.set(node.id, y);

--- a/rust-srec/frontend/src/components/pipeline/workflows/flow-editor/layout.ts
+++ b/rust-srec/frontend/src/components/pipeline/workflows/flow-editor/layout.ts
@@ -1,26 +1,104 @@
-import { Node, Edge } from '@xyflow/react';
+import type { Edge, Node } from '@xyflow/react';
+
+const LEVEL_SPACING = 350;
+const NODE_SPACING = 200;
+const DETOUR_OFFSET = 180;
+const PADDING = 50;
+
+function collectReachable(
+  startId: string,
+  adjacency: Map<string, Edge[]>,
+  excludedEdgeId: string,
+): Set<string> {
+  const reachable = new Set<string>();
+  const pending = [startId];
+
+  while (pending.length > 0) {
+    const current = pending.pop();
+    if (!current || reachable.has(current)) continue;
+
+    reachable.add(current);
+    for (const edge of adjacency.get(current) ?? []) {
+      if (edge.id !== excludedEdgeId) {
+        pending.push(edge.source === current ? edge.target : edge.source);
+      }
+    }
+  }
+
+  return reachable;
+}
+
+// Separate alternate multi-step paths from direct long edges so neither route is hidden.
+function findDetourDepths(
+  nodes: Node[],
+  edges: Edge[],
+  levels: Record<string, number>,
+): Map<string, number> {
+  const outgoing = new Map<string, Edge[]>();
+  const incoming = new Map<string, Edge[]>();
+
+  for (const edge of edges) {
+    outgoing.set(edge.source, [...(outgoing.get(edge.source) ?? []), edge]);
+    incoming.set(edge.target, [...(incoming.get(edge.target) ?? []), edge]);
+  }
+
+  const detourDepths = new Map<string, number>();
+
+  for (const edge of edges) {
+    const sourceLevel = levels[edge.source];
+    const targetLevel = levels[edge.target];
+    if (
+      sourceLevel === undefined ||
+      targetLevel === undefined ||
+      targetLevel - sourceLevel <= 1
+    ) {
+      continue;
+    }
+
+    const reachableFromSource = collectReachable(
+      edge.source,
+      outgoing,
+      edge.id,
+    );
+    const canReachTarget = collectReachable(edge.target, incoming, edge.id);
+
+    for (const node of nodes) {
+      if (
+        node.id !== edge.source &&
+        node.id !== edge.target &&
+        reachableFromSource.has(node.id) &&
+        canReachTarget.has(node.id)
+      ) {
+        detourDepths.set(node.id, (detourDepths.get(node.id) ?? 0) + 1);
+      }
+    }
+  }
+
+  return detourDepths;
+}
 
 export function getLayoutedElements(nodes: Node[], edges: Edge[]) {
-  const LEVEL_SPACING = 350;
-  const NODE_SPACING = 200;
-
   const levels: Record<string, number> = {};
   const nodeMap: Record<string, Node> = {};
   nodes.forEach((n) => (nodeMap[n.id] = n));
 
-  const getLevel = (id: string, visited = new Set<string>()): number => {
+  const getLevel = (id: string, visiting = new Set<string>()): number => {
     if (levels[id] !== undefined) return levels[id];
-    if (visited.has(id)) return 0; // Cycle safety
-    visited.add(id);
+    if (visiting.has(id)) return 0;
 
-    const incoming = edges.filter((e) => e.target === id);
+    const nextVisiting = new Set(visiting);
+    nextVisiting.add(id);
+
+    const incoming = edges.filter(
+      (edge) => edge.target === id && nodeMap[edge.source],
+    );
     if (incoming.length === 0) {
       levels[id] = 0;
       return 0;
     }
 
     const maxLevel = Math.max(
-      ...incoming.map((e) => getLevel(e.source, visited)),
+      ...incoming.map((edge) => getLevel(edge.source, nextVisiting)),
       -1,
     );
     levels[id] = maxLevel + 1;
@@ -30,27 +108,41 @@ export function getLayoutedElements(nodes: Node[], edges: Edge[]) {
   nodes.forEach((n) => getLevel(n.id));
 
   const nodesByLevel: Node[][] = [];
-  Object.entries(levels).forEach(([id, level]) => {
+  nodes.forEach((node) => {
+    const level = levels[node.id];
     if (!nodesByLevel[level]) nodesByLevel[level] = [];
-    nodesByLevel[level].push(nodeMap[id]);
+    nodesByLevel[level].push(node);
   });
 
-  const maxNodesPerLevel = Math.max(...nodesByLevel.map((l) => l.length), 1);
-  const maxHeight = maxNodesPerLevel * NODE_SPACING;
+  const detourDepths = findDetourDepths(nodes, edges, levels);
+  const yByNodeId = new Map<string, number>();
+
+  for (const levelNodes of nodesByLevel) {
+    if (!levelNodes) continue;
+
+    const centerIndex = (levelNodes.length - 1) / 2;
+    levelNodes.forEach((node, nodeIndex) => {
+      let y = (nodeIndex - centerIndex) * NODE_SPACING;
+
+      if (levelNodes.length === 1) {
+        y -= (detourDepths.get(node.id) ?? 0) * DETOUR_OFFSET;
+      }
+
+      yByNodeId.set(node.id, y);
+    });
+  }
+
+  const minY = Math.min(...yByNodeId.values(), 0);
+  const yShift = PADDING - minY;
 
   const layoutedNodes = nodes.map((node) => {
     const level = levels[node.id];
-    const levelNodes = nodesByLevel[level];
-    const nodeIndex = levelNodes.findIndex((n) => n.id === node.id);
-
-    const levelHeight = (levelNodes.length - 1) * NODE_SPACING;
-    const yOffset = (maxHeight - levelHeight) / 2;
 
     return {
       ...node,
       position: {
-        x: level * LEVEL_SPACING + 50,
-        y: yOffset + nodeIndex * NODE_SPACING + 50,
+        x: level * LEVEL_SPACING + PADDING,
+        y: (yByNodeId.get(node.id) ?? 0) + yShift,
       },
     };
   });

--- a/rust-srec/frontend/src/components/pipeline/workflows/flow-editor/step-node.tsx
+++ b/rust-srec/frontend/src/components/pipeline/workflows/flow-editor/step-node.tsx
@@ -36,8 +36,6 @@ export function StepNode({ data }: NodeProps<StepNode>) {
   const { i18n } = useLingui();
   const { step, id, onEdit, onRemove, onReplace, hasDeleteWarning } = data;
 
-  console.log('StepNode render:', { id, stepType: step.type });
-
   const isPreset = step.type === 'preset';
   const isWorkflow = step.type === 'workflow';
 
@@ -130,16 +128,16 @@ export function StepNode({ data }: NodeProps<StepNode>) {
         <h4 className="text-[14px] font-bold text-foreground truncate tracking-tight uppercase">
           {step.type === 'inline'
             ? (() => {
-                const def = getProcessorDefinition(step.processor);
-                return def ? i18n._(def.label) : step.processor;
-              })()
+              const def = getProcessorDefinition(step.processor);
+              return def ? i18n._(def.label) : step.processor;
+            })()
             : step.type === 'preset'
               ? getJobPresetName({ id: step.name, name: step.name }, i18n)
               : step.type === 'workflow'
                 ? getPipelinePresetName(
-                    { id: step.name, name: step.name },
-                    i18n,
-                  )
+                  { id: step.name, name: step.name },
+                  i18n,
+                )
                 : 'Unknown'}
         </h4>
         <div className="flex items-center justify-between">

--- a/rust-srec/frontend/src/components/pipeline/workflows/flow-editor/workflow-flow-editor.tsx
+++ b/rust-srec/frontend/src/components/pipeline/workflows/flow-editor/workflow-flow-editor.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState, memo, useMemo } from 'react';
+import { useCallback, useEffect, useState, memo, useMemo, useRef } from 'react';
 import {
   ReactFlow,
   Background,
@@ -64,6 +64,19 @@ const WorkflowFlowEditorInner = memo(
     const [hasLaidOut, setHasLaidOut] = useState(false);
     const nodesInitialized = useNodesInitialized();
     const { fitView } = useReactFlow();
+    const lastLayoutTopologyRef = useRef<string | null>(null);
+
+    const topologyKey = useMemo(
+      () =>
+        steps
+          .map(
+            (step) =>
+              `${step.id}:${[...(step.depends_on ?? [])].sort().join(',')}`,
+          )
+          .sort()
+          .join('|'),
+      [steps],
+    );
 
     // Flag delete nodes wired after a transform step: they would delete the converted artifact
     // produced by that step, not the original recording.
@@ -128,17 +141,10 @@ const WorkflowFlowEditorInner = memo(
           return {
             id: s.id,
             type: 'stepNode',
-            position: { x: 0, y: 0 }, // Will be fixed by layout if it's initial load
+            position: { x: 0, y: 0 },
             data: nodeData,
           };
         });
-
-        // If we haven't performed an initial layout yet and we have nodes, do it now.
-        // Note: We check `currentNodes.length === 0` as a proxy for "first load"
-        // combined with the external `hasLaidOut` ref check would be ideal,
-        // but here we can't easily access the updated 'hasLaidOut' state inside this callback
-        // if we wanted to set it.
-        // Instead, we'll handle the "Auto Layout" transformation here and rely on the effect to stabilize.
 
         return nextNodes;
       });
@@ -154,30 +160,33 @@ const WorkflowFlowEditorInner = memo(
       warnedStepIds,
     ]);
 
-    // Separate effect to handle Auto-Layout logic
-    // We want to re-layout when the structure changes (e.g. loading a preset)
-    // We detect this by checking if we have unlayouted nodes (position 0,0) or if the step count changed significantly
     useEffect(() => {
-      // Only run layout if:
-      // 1. We have nodes
-      // 2. Nodes are initialized (measured by React Flow)
-      // 3. We haven't laid out yet OR nodes are all at 0,0 (new load)
+      const expectedEdgeIds = new Set(
+        steps.flatMap((step) =>
+          (step.depends_on ?? []).map(
+            (dependencyId) => `e-${dependencyId}-${step.id}`,
+          ),
+        ),
+      );
+      const graphMatchesTopology =
+        nodes.length === steps.length &&
+        edges.length === expectedEdgeIds.size &&
+        nodes.every((node) => steps.some((step) => step.id === node.id)) &&
+        edges.every((edge) => expectedEdgeIds.has(edge.id));
       const needsLayout =
         nodes.length > 0 &&
         nodesInitialized &&
-        (!hasLaidOut ||
-          nodes.every((n) => n.position.x === 0 && n.position.y === 0));
+        graphMatchesTopology &&
+        lastLayoutTopologyRef.current !== topologyKey;
 
       if (needsLayout) {
-        console.log('WorkflowFlowEditor: Running auto-layout', {
-          nodeCount: nodes.length,
-        });
         const { nodes: layoutedNodes, edges: layoutedEdges } =
           getLayoutedElements(nodes, edges);
 
         setNodes([...layoutedNodes]);
         setEdges([...layoutedEdges]);
         setHasLaidOut(true);
+        lastLayoutTopologyRef.current = topologyKey;
 
         window.requestAnimationFrame(() => {
           void fitView({ padding: 0.2, duration: 200 });
@@ -187,11 +196,11 @@ const WorkflowFlowEditorInner = memo(
       nodes,
       edges,
       nodesInitialized,
-      hasLaidOut,
       setNodes,
       setEdges,
       fitView,
-      nodes.length,
+      steps,
+      topologyKey,
     ]);
 
     const onConnect = useCallback(
@@ -244,7 +253,11 @@ const WorkflowFlowEditorInner = memo(
         getLayoutedElements(nodes, edges);
       setNodes([...layoutedNodes]);
       setEdges([...layoutedEdges]);
-    }, [nodes, edges, setNodes, setEdges]);
+      lastLayoutTopologyRef.current = topologyKey;
+      window.requestAnimationFrame(() => {
+        void fitView({ padding: 0.2, duration: 200 });
+      });
+    }, [nodes, edges, setNodes, setEdges, topologyKey, fitView]);
 
     return (
       <GraphViewport className="h-full min-h-0">

--- a/rust-srec/frontend/src/components/pipeline/workflows/flow-editor/workflow-flow-editor.tsx
+++ b/rust-srec/frontend/src/components/pipeline/workflows/flow-editor/workflow-flow-editor.tsx
@@ -3,17 +3,19 @@ import {
   ReactFlow,
   Background,
   Controls,
-  Connection,
-  Edge,
   useNodesState,
   useEdgesState,
   MarkerType,
   Panel,
   ConnectionMode,
-  Node,
   useReactFlow,
   ReactFlowProvider,
   useNodesInitialized,
+  type Connection,
+  type DefaultEdgeOptions,
+  type Edge,
+  type Node,
+  type NodeChange,
 } from '@xyflow/react';
 import '@xyflow/react/dist/style.css';
 
@@ -22,7 +24,7 @@ import { DagStepDefinition } from '@/api/schemas';
 import { StepNode } from './step-node';
 import { Button } from '@/components/ui/button';
 import { LayoutGrid } from 'lucide-react';
-import { getLayoutedElements } from './layout';
+import { getInitialNodePosition, getLayoutedElements } from './layout';
 import { Trans } from '@lingui/react/macro';
 import {
   usePresetProcessorMap,
@@ -34,12 +36,15 @@ const nodeTypes = {
   stepNode: StepNode,
 };
 
-const defaultEdgeOptions = {
-  style: { strokeWidth: 1.5, stroke: 'rgba(59, 130, 246, 0.4)' },
+const edgeColor = 'rgba(59, 130, 246, 0.68)';
+
+const defaultEdgeOptions: DefaultEdgeOptions = {
+  style: { strokeWidth: 1.8, stroke: edgeColor },
   type: 'smoothstep',
+  pathOptions: { borderRadius: 12, offset: 28 },
   markerEnd: {
     type: MarkerType.ArrowClosed,
-    color: 'rgba(59, 130, 246, 0.4)',
+    color: edgeColor,
   },
 };
 
@@ -65,6 +70,7 @@ const WorkflowFlowEditorInner = memo(
     const nodesInitialized = useNodesInitialized();
     const { fitView } = useReactFlow();
     const lastLayoutTopologyRef = useRef<string | null>(null);
+    const hasManualPositionsRef = useRef(false);
 
     const topologyKey = useMemo(
       () =>
@@ -98,6 +104,20 @@ const WorkflowFlowEditorInner = memo(
       [steps, onUpdateSteps, onRemoveStep],
     );
 
+    const handleNodesChange = useCallback(
+      (changes: NodeChange<Node>[]) => {
+        if (
+          changes.some(
+            (change) => change.type === 'position' && change.dragging,
+          )
+        ) {
+          hasManualPositionsRef.current = true;
+        }
+        onNodesChange(changes);
+      },
+      [onNodesChange],
+    );
+
     // Sync from props
     useEffect(() => {
       // 1. Generate Edges from steps (Always fresh)
@@ -115,6 +135,10 @@ const WorkflowFlowEditorInner = memo(
       // when calculating the merge, preventing stale closures.
       setNodes((currentNodes) => {
         const currentNodeMap = new Map(currentNodes.map((n) => [n.id, n]));
+        const stepIds = new Set(steps.map((step) => step.id));
+        const layoutContext = currentNodes.filter((node) =>
+          stepIds.has(node.id),
+        );
 
         const nextNodes = steps.map((s) => {
           const existing = currentNodeMap.get(s.id);
@@ -138,12 +162,14 @@ const WorkflowFlowEditorInner = memo(
           }
 
           // New node
-          return {
+          const newNode: Node = {
             id: s.id,
             type: 'stepNode',
-            position: { x: 0, y: 0 },
+            position: getInitialNodePosition(layoutContext, s.depends_on ?? []),
             data: nodeData,
           };
+          layoutContext.push(newNode);
+          return newNode;
         });
 
         return nextNodes;
@@ -161,6 +187,7 @@ const WorkflowFlowEditorInner = memo(
     ]);
 
     useEffect(() => {
+      const expectedNodeIds = new Set(steps.map((step) => step.id));
       const expectedEdgeIds = new Set(
         steps.flatMap((step) =>
           (step.depends_on ?? []).map(
@@ -171,12 +198,16 @@ const WorkflowFlowEditorInner = memo(
       const graphMatchesTopology =
         nodes.length === steps.length &&
         edges.length === expectedEdgeIds.size &&
-        nodes.every((node) => steps.some((step) => step.id === node.id)) &&
+        nodes.every((node) => expectedNodeIds.has(node.id)) &&
         edges.every((edge) => expectedEdgeIds.has(edge.id));
+      const canAutomaticallyLayout =
+        lastLayoutTopologyRef.current === null ||
+        !hasManualPositionsRef.current;
       const needsLayout =
         nodes.length > 0 &&
         nodesInitialized &&
         graphMatchesTopology &&
+        canAutomaticallyLayout &&
         lastLayoutTopologyRef.current !== topologyKey;
 
       if (needsLayout) {
@@ -249,6 +280,7 @@ const WorkflowFlowEditorInner = memo(
     );
 
     const handleLayout = useCallback(() => {
+      hasManualPositionsRef.current = false;
       const { nodes: layoutedNodes, edges: layoutedEdges } =
         getLayoutedElements(nodes, edges);
       setNodes([...layoutedNodes]);
@@ -264,7 +296,7 @@ const WorkflowFlowEditorInner = memo(
         <ReactFlow
           nodes={nodes}
           edges={edges}
-          onNodesChange={onNodesChange}
+          onNodesChange={handleNodesChange}
           onEdgesChange={onEdgesChange}
           onConnect={onConnect}
           onEdgesDelete={onEdgeDelete}

--- a/rust-srec/frontend/src/locales/en/messages.po
+++ b/rust-srec/frontend/src/locales/en/messages.po
@@ -700,7 +700,7 @@ msgstr "Auto (Default)"
 msgid "Auto (QR → Phone & Code → Desktop)"
 msgstr "Auto (QR → Phone & Code → Desktop)"
 
-#: src/components/pipeline/workflows/flow-editor/workflow-flow-editor.tsx:297
+#: src/components/pipeline/workflows/flow-editor/workflow-flow-editor.tsx:329
 msgid "Auto Layout"
 msgstr "Auto Layout"
 
@@ -2310,7 +2310,7 @@ msgstr "Downloading {0}"
 msgid "Downloading..."
 msgstr "Downloading..."
 
-#: src/components/pipeline/workflows/flow-editor/workflow-flow-editor.tsx:310
+#: src/components/pipeline/workflows/flow-editor/workflow-flow-editor.tsx:342
 msgid "Drag from edge to link steps"
 msgstr "Drag from edge to link steps"
 

--- a/rust-srec/frontend/src/locales/en/messages.po
+++ b/rust-srec/frontend/src/locales/en/messages.po
@@ -700,7 +700,7 @@ msgstr "Auto (Default)"
 msgid "Auto (QR → Phone & Code → Desktop)"
 msgstr "Auto (QR → Phone & Code → Desktop)"
 
-#: src/components/pipeline/workflows/flow-editor/workflow-flow-editor.tsx:284
+#: src/components/pipeline/workflows/flow-editor/workflow-flow-editor.tsx:297
 msgid "Auto Layout"
 msgstr "Auto Layout"
 
@@ -2310,7 +2310,7 @@ msgstr "Downloading {0}"
 msgid "Downloading..."
 msgstr "Downloading..."
 
-#: src/components/pipeline/workflows/flow-editor/workflow-flow-editor.tsx:297
+#: src/components/pipeline/workflows/flow-editor/workflow-flow-editor.tsx:310
 msgid "Drag from edge to link steps"
 msgstr "Drag from edge to link steps"
 

--- a/rust-srec/frontend/src/locales/en/messages.po
+++ b/rust-srec/frontend/src/locales/en/messages.po
@@ -3937,7 +3937,7 @@ msgstr "Initial Delay (ms)"
 msgid "Initial Fetch Timeout (ms)"
 msgstr "Initial Fetch Timeout (ms)"
 
-#: src/components/pipeline/workflows/flow-editor/step-node.tsx:156
+#: src/components/pipeline/workflows/flow-editor/step-node.tsx:154
 msgid "inline"
 msgstr "inline"
 
@@ -5970,7 +5970,7 @@ msgstr "Preferred Quality (QN)"
 msgid "Preserve Paths"
 msgstr "Preserve Paths"
 
-#: src/components/pipeline/workflows/flow-editor/step-node.tsx:158
+#: src/components/pipeline/workflows/flow-editor/step-node.tsx:156
 msgid "preset"
 msgstr "preset"
 
@@ -6481,7 +6481,7 @@ msgstr "Replace output files if they already exist"
 msgid "Replace Pipeline Step"
 msgstr "Replace Pipeline Step"
 
-#: src/components/pipeline/workflows/flow-editor/step-node.tsx:97
+#: src/components/pipeline/workflows/flow-editor/step-node.tsx:95
 #: src/components/pipeline/workflows/steps-list.tsx:206
 msgid "Replace Step"
 msgstr "Replace Step"
@@ -7850,7 +7850,7 @@ msgstr "These settings only apply to the desktop app. The server will still deli
 msgid "These timeouts are applied when the pipeline worker pools start. Changes require a restart to take effect."
 msgstr "These timeouts are applied when the pipeline worker pools start. Changes require a restart to take effect."
 
-#: src/components/pipeline/workflows/flow-editor/step-node.tsx:79
+#: src/components/pipeline/workflows/flow-editor/step-node.tsx:77
 #: src/components/pipeline/workflows/steps-list.tsx:165
 msgid "This Delete step deletes the converted result, not the original recording. Enable \"Remove Input on Success\" on the transcode step instead."
 msgstr "This Delete step deletes the converted result, not the original recording. Enable \"Remove Input on Success\" on the transcode step instead."
@@ -8701,7 +8701,7 @@ msgstr "Width in pixels (keeps aspect ratio)"
 msgid "Windows Console Error"
 msgstr "Windows Console Error"
 
-#: src/components/pipeline/workflows/flow-editor/step-node.tsx:160
+#: src/components/pipeline/workflows/flow-editor/step-node.tsx:158
 msgid "workflow"
 msgstr "workflow"
 

--- a/rust-srec/frontend/src/locales/zh-CN/messages.po
+++ b/rust-srec/frontend/src/locales/zh-CN/messages.po
@@ -3937,7 +3937,7 @@ msgstr "初始延迟（ms）"
 msgid "Initial Fetch Timeout (ms)"
 msgstr "初始获取超时（ms）"
 
-#: src/components/pipeline/workflows/flow-editor/step-node.tsx:156
+#: src/components/pipeline/workflows/flow-editor/step-node.tsx:154
 msgid "inline"
 msgstr "内联"
 
@@ -5970,7 +5970,7 @@ msgstr "首选画质 (QN)"
 msgid "Preserve Paths"
 msgstr "保留路径"
 
-#: src/components/pipeline/workflows/flow-editor/step-node.tsx:158
+#: src/components/pipeline/workflows/flow-editor/step-node.tsx:156
 msgid "preset"
 msgstr "预设"
 
@@ -6481,7 +6481,7 @@ msgstr "若输出文件已存在则替换"
 msgid "Replace Pipeline Step"
 msgstr "替换管道步骤"
 
-#: src/components/pipeline/workflows/flow-editor/step-node.tsx:97
+#: src/components/pipeline/workflows/flow-editor/step-node.tsx:95
 #: src/components/pipeline/workflows/steps-list.tsx:206
 msgid "Replace Step"
 msgstr "替换步骤"
@@ -7850,7 +7850,7 @@ msgstr "这些设置仅适用于桌面应用。服务器仍将正常发送通道
 msgid "These timeouts are applied when the pipeline worker pools start. Changes require a restart to take effect."
 msgstr "这些超时设置在管道工作线程池启动时应用。更改需要重启才能生效。"
 
-#: src/components/pipeline/workflows/flow-editor/step-node.tsx:79
+#: src/components/pipeline/workflows/flow-editor/step-node.tsx:77
 #: src/components/pipeline/workflows/steps-list.tsx:165
 msgid "This Delete step deletes the converted result, not the original recording. Enable \"Remove Input on Success\" on the transcode step instead."
 msgstr "此删除步骤删除的是转码后的结果文件，而不是原始录制文件。请改为在转码步骤上启用“成功后移除输入”。"
@@ -8701,7 +8701,7 @@ msgstr "宽度（像素，保持宽高比）"
 msgid "Windows Console Error"
 msgstr "Windows 控制台错误"
 
-#: src/components/pipeline/workflows/flow-editor/step-node.tsx:160
+#: src/components/pipeline/workflows/flow-editor/step-node.tsx:158
 msgid "workflow"
 msgstr "工作流"
 

--- a/rust-srec/frontend/src/locales/zh-CN/messages.po
+++ b/rust-srec/frontend/src/locales/zh-CN/messages.po
@@ -700,7 +700,7 @@ msgstr "自动（默认）"
 msgid "Auto (QR → Phone & Code → Desktop)"
 msgstr "自动 (二维码 → 手机号和验证码 → 桌面)"
 
-#: src/components/pipeline/workflows/flow-editor/workflow-flow-editor.tsx:297
+#: src/components/pipeline/workflows/flow-editor/workflow-flow-editor.tsx:329
 msgid "Auto Layout"
 msgstr "自动布局"
 
@@ -2310,7 +2310,7 @@ msgstr "正在下载 {0}"
 msgid "Downloading..."
 msgstr "下载中..."
 
-#: src/components/pipeline/workflows/flow-editor/workflow-flow-editor.tsx:310
+#: src/components/pipeline/workflows/flow-editor/workflow-flow-editor.tsx:342
 msgid "Drag from edge to link steps"
 msgstr "从边缘拖动以连接步骤"
 

--- a/rust-srec/frontend/src/locales/zh-CN/messages.po
+++ b/rust-srec/frontend/src/locales/zh-CN/messages.po
@@ -700,7 +700,7 @@ msgstr "自动（默认）"
 msgid "Auto (QR → Phone & Code → Desktop)"
 msgstr "自动 (二维码 → 手机号和验证码 → 桌面)"
 
-#: src/components/pipeline/workflows/flow-editor/workflow-flow-editor.tsx:284
+#: src/components/pipeline/workflows/flow-editor/workflow-flow-editor.tsx:297
 msgid "Auto Layout"
 msgstr "自动布局"
 
@@ -2310,7 +2310,7 @@ msgstr "正在下载 {0}"
 msgid "Downloading..."
 msgstr "下载中..."
 
-#: src/components/pipeline/workflows/flow-editor/workflow-flow-editor.tsx:297
+#: src/components/pipeline/workflows/flow-editor/workflow-flow-editor.tsx:310
 msgid "Drag from edge to link steps"
 msgstr "从边缘拖动以连接步骤"
 


### PR DESCRIPTION
## Summary

- separate direct long edges from alternate multi-step paths so fan-out and fan-in relationships remain visible
- reduce crossings with deterministic two-way ordering and balance independent detours across upper and lower lanes
- keep nested bypasses on progressively deeper lanes and strengthen edges and arrowheads for clearer direction
- preserve manually dragged positions across topology changes, while Auto Layout restores the computed layout and refits the viewport
- place newly added nodes near their dependencies without overlapping existing nodes
- refresh English and Chinese Lingui catalogs

## Root cause

The level-based layout centered singleton ranks on the same horizontal lane and retained insertion order within each level. Direct edges could overlap alternate paths, crossed connections were not reordered, and every topology update replaced manual node placement.

## Impact

The graph now communicates multiple dependency relationships more clearly without changing DAG execution semantics. Automatic layout runs on initial load and on topology changes until the user manually moves a node; after that, positions remain stable unless Auto Layout is selected.

## Validation

- `pnpm run extract`
- `pnpm run compile`
- `pnpm test -- src/components/pipeline/workflows/flow-editor/layout.test.ts`
- `pnpm run lint`
- `pnpm run build`
- `pnpm exec oxfmt --check src/components/pipeline/workflows/flow-editor/layout.ts src/components/pipeline/workflows/flow-editor/workflow-flow-editor.tsx src/components/pipeline/workflows/flow-editor/layout.test.ts`
- `git diff --cached --check`