### PR TITLE
fix(frontend): handle danmu timestamps and events

### DIFF
--- a/crates/platforms/src/danmaku/writer.rs
+++ b/crates/platforms/src/danmaku/writer.rs
@@ -11,7 +11,7 @@
 //!
 //! Each danmu element has the following structure:
 //! ```xml
-//! <d p="{time},{type},{size},{color},{timestamp},{pool},{uid_crc32},{row_id} user={username}">{Text}</d>
+//! <d p="{time},{type},{size},{color},{timestamp},{pool},{uid_crc32},{row_id}" user="{username}">{Text}</d>
 //! ```
 //!
 //! Where:
@@ -138,7 +138,7 @@ impl XmlDanmuWriter {
     /// Write a danmu message to the XML file.
     ///
     /// The format follows Bilibili's danmu XML format:
-    /// `<d p="{time},{type},{size},{color},{timestamp},{pool},{uid_crc32},{row_id},user={username}">{content}</d>`
+    /// `<d p="{time},{type},{size},{color},{timestamp},{pool},{uid_crc32},{row_id}" user="{username}">{content}</d>`
     ///
     /// - `time`: Seconds offset from segment start (3 decimal places)
     /// - `type`: Danmu type (1=scroll right-to-left, 4=bottom, 5=top)

--- a/rust-srec/frontend/package.json
+++ b/rust-srec/frontend/package.json
@@ -68,6 +68,7 @@
     "react-dom": "^19.2.7",
     "react-hook-form": "^7.81.0",
     "recharts": "^3.9.2",
+    "saxes": "^6.0.0",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.6.0",
     "tailwindcss": "^4.3.3",

--- a/rust-srec/frontend/pnpm-lock.yaml
+++ b/rust-srec/frontend/pnpm-lock.yaml
@@ -161,6 +161,9 @@ importers:
       recharts:
         specifier: ^3.9.2
         version: 3.9.2(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1)
+      saxes:
+        specifier: ^6.0.0
+        version: 6.0.0
       sonner:
         specifier: ^2.0.7
         version: 2.0.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)

--- a/rust-srec/frontend/src/components/danmu/danmu-parser.ts
+++ b/rust-srec/frontend/src/components/danmu/danmu-parser.ts
@@ -1,0 +1,186 @@
+import { SaxesParser, type SaxesTagPlain } from 'saxes';
+
+export interface DanmuComment {
+  time: number;
+  mode: number;
+  timestampMs: number | null;
+  userHash: string;
+  rowId: string;
+  username?: string;
+  content: string;
+}
+
+interface ActiveComment {
+  elementName: 'd' | 'gift' | 'sc';
+  comment: DanmuComment;
+  captureText: boolean;
+}
+
+function parseNumber(value: string | null | undefined): number | null {
+  if (value == null || value.trim() === '') return null;
+
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+export function normalizeDanmuTimestamp(
+  value: string | null | undefined,
+): number | null {
+  const timestamp = parseNumber(value);
+  if (timestamp === null) return null;
+
+  return Math.abs(timestamp) < 100_000_000_000 ? timestamp * 1000 : timestamp;
+}
+
+function parseLegacyIdentity(value: string): {
+  rowId: string;
+  username?: string;
+} {
+  const match = value.match(/^(.*?)\s+user=(.*)$/);
+  if (!match) return { rowId: value };
+
+  return { rowId: match[1], username: match[2] };
+}
+
+function parseStandardComment(
+  attributes: Record<string, string>,
+): DanmuComment | null {
+  const parts = attributes.p?.split(',');
+  if (!parts || parts.length < 8) return null;
+
+  const time = parseNumber(parts[0]);
+  const mode = parseNumber(parts[1]);
+  if (time === null || mode === null) return null;
+
+  const legacyIdentity = parseLegacyIdentity(parts[7]);
+  return {
+    time,
+    mode,
+    timestampMs: normalizeDanmuTimestamp(parts[4]),
+    userHash: parts[6],
+    rowId: legacyIdentity.rowId,
+    username: attributes.user || legacyIdentity.username,
+    content: '',
+  };
+}
+
+function parseGift(
+  attributes: Record<string, string>,
+  index: number,
+): DanmuComment | null {
+  const time = parseNumber(attributes.ts);
+  if (time === null) return null;
+
+  const giftName = attributes.giftname || 'Gift';
+  const giftCount = attributes.giftcount;
+  return {
+    time,
+    mode: 1,
+    timestampMs: normalizeDanmuTimestamp(attributes.timestamp),
+    userHash: attributes.uid || '',
+    rowId: `gift-${index}`,
+    username: attributes.user || undefined,
+    content: giftCount ? `${giftName} x${giftCount}` : giftName,
+  };
+}
+
+function parseSuperChat(
+  attributes: Record<string, string>,
+  index: number,
+): DanmuComment | null {
+  const time = parseNumber(attributes.ts);
+  if (time === null) return null;
+
+  return {
+    time,
+    mode: 5,
+    timestampMs: normalizeDanmuTimestamp(attributes.timestamp),
+    userHash: attributes.uid || '',
+    rowId: `sc-${index}`,
+    username: attributes.user || undefined,
+    content: '',
+  };
+}
+
+export class DanmuStreamParser {
+  private readonly parser = new SaxesParser({ xmlns: false, position: false });
+  private readonly comments: DanmuComment[] = [];
+  private activeComment: ActiveComment | null = null;
+  private elementIndex = 0;
+  private isChronological = true;
+  private parseError: Error | null = null;
+
+  constructor() {
+    this.parser.on('opentag', (tag) => this.handleOpenTag(tag));
+    this.parser.on('text', (text) => this.appendText(text));
+    this.parser.on('cdata', (text) => this.appendText(text));
+    this.parser.on('closetag', (tag) => this.handleCloseTag(tag));
+    this.parser.on('error', (error) => {
+      this.parseError ??= error;
+    });
+  }
+
+  write(chunk: string): void {
+    this.parser.write(chunk);
+  }
+
+  finish(): DanmuComment[] {
+    this.parser.close();
+    if (this.parseError) throw new Error('Invalid danmu XML');
+
+    if (!this.isChronological) {
+      this.comments.sort((a, b) => a.time - b.time);
+    }
+    return this.comments;
+  }
+
+  private handleOpenTag(tag: SaxesTagPlain): void {
+    let comment: DanmuComment | null = null;
+    let captureText = false;
+
+    if (tag.name === 'd') {
+      comment = parseStandardComment(tag.attributes);
+      captureText = true;
+    } else if (tag.name === 'gift') {
+      comment = parseGift(tag.attributes, this.elementIndex);
+    } else if (tag.name === 'sc') {
+      comment = parseSuperChat(tag.attributes, this.elementIndex);
+      captureText = true;
+    } else {
+      return;
+    }
+
+    this.elementIndex += 1;
+    if (comment) {
+      this.activeComment = {
+        elementName: tag.name,
+        comment,
+        captureText,
+      };
+    }
+  }
+
+  private appendText(text: string): void {
+    if (this.activeComment?.captureText) {
+      this.activeComment.comment.content += text;
+    }
+  }
+
+  private handleCloseTag(tag: SaxesTagPlain): void {
+    if (tag.name !== this.activeComment?.elementName) return;
+
+    const comment = this.activeComment.comment;
+    const previous = this.comments.at(-1);
+    if (previous && previous.time > comment.time) {
+      this.isChronological = false;
+    }
+    this.comments.push(comment);
+    this.activeComment = null;
+  }
+}
+
+export function parseDanmuXml(text: string): DanmuComment[] {
+  const parser = new DanmuStreamParser();
+  parser.write(text);
+  return parser.finish();
+}

--- a/rust-srec/frontend/src/components/danmu/danmu-parser.worker.ts
+++ b/rust-srec/frontend/src/components/danmu/danmu-parser.worker.ts
@@ -1,0 +1,56 @@
+import { DanmuStreamParser, type DanmuComment } from './danmu-parser';
+
+interface ParseRequest {
+  type: 'parse';
+  url: string;
+}
+
+export type ParseResponse =
+  | { type: 'success'; comments: DanmuComment[] }
+  | { type: 'error'; message: string };
+
+interface WorkerContext {
+  addEventListener(
+    type: 'message',
+    listener: (event: MessageEvent<ParseRequest>) => void,
+  ): void;
+  postMessage(message: ParseResponse): void;
+}
+
+const workerContext = self as unknown as WorkerContext;
+
+workerContext.addEventListener('message', (event) => {
+  if (event.data.type !== 'parse') return;
+
+  void fetchAndParse(event.data.url);
+});
+
+async function fetchAndParse(url: string): Promise<void> {
+  try {
+    const response = await fetch(url);
+    if (!response.ok) {
+      throw new Error(`Failed to fetch danmu file (${response.status})`);
+    }
+
+    const parser = new DanmuStreamParser();
+    if (response.body) {
+      const reader = response.body.getReader();
+      const decoder = new TextDecoder();
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        parser.write(decoder.decode(value, { stream: true }));
+      }
+      parser.write(decoder.decode());
+    } else {
+      parser.write(await response.text());
+    }
+
+    workerContext.postMessage({ type: 'success', comments: parser.finish() });
+  } catch (error) {
+    workerContext.postMessage({
+      type: 'error',
+      message: error instanceof Error ? error.message : 'Unknown error',
+    });
+  }
+}

--- a/rust-srec/frontend/src/components/danmu/danmu-viewer.test.ts
+++ b/rust-srec/frontend/src/components/danmu/danmu-viewer.test.ts
@@ -1,8 +1,9 @@
 import {
-  formatDanmuOffset,
+  DanmuStreamParser,
   normalizeDanmuTimestamp,
   parseDanmuXml,
-} from './danmu-viewer';
+} from './danmu-parser';
+import { formatDanmuOffset } from './danmu-viewer';
 
 describe('parseDanmuXml', () => {
   it('parses rust-srec timestamps and username attributes', () => {
@@ -70,6 +71,17 @@ describe('parseDanmuXml', () => {
   it('rejects malformed XML and skips malformed messages', () => {
     expect(() => parseDanmuXml('<i><d></i>')).toThrow('Invalid danmu XML');
     expect(parseDanmuXml('<i><d p="invalid" /></i>')).toEqual([]);
+  });
+
+  it('parses XML incrementally across chunk boundaries', () => {
+    const parser = new DanmuStreamParser();
+    parser.write('<i><d p="1,1,25,16777215,1700000001,0,u,1" user="A">Hel');
+    parser.write('lo &amp; wel');
+    parser.write('come</d></i>');
+
+    expect(parser.finish()).toMatchObject([
+      { username: 'A', content: 'Hello & welcome' },
+    ]);
   });
 });
 

--- a/rust-srec/frontend/src/components/danmu/danmu-viewer.test.ts
+++ b/rust-srec/frontend/src/components/danmu/danmu-viewer.test.ts
@@ -1,0 +1,85 @@
+import {
+  formatDanmuOffset,
+  normalizeDanmuTimestamp,
+  parseDanmuXml,
+} from './danmu-viewer';
+
+describe('parseDanmuXml', () => {
+  it('parses rust-srec timestamps and username attributes', () => {
+    const [comment] = parseDanmuXml(`
+      <i>
+        <d p="1.500,1,25,16777215,1700000001500,0,1234,1" user="Alice">Hello</d>
+      </i>
+    `);
+
+    expect(comment).toMatchObject({
+      time: 1.5,
+      timestampMs: 1_700_000_001_500,
+      username: 'Alice',
+      rowId: '1',
+      content: 'Hello',
+    });
+  });
+
+  it('normalizes canonical Bilibili timestamps in seconds', () => {
+    const [comment] = parseDanmuXml(`
+      <i>
+        <d p="2,1,25,16777215,1700000001,0,abcd,2">World</d>
+      </i>
+    `);
+
+    expect(comment.timestampMs).toBe(1_700_000_001_000);
+  });
+
+  it('keeps compatibility with usernames embedded in the row ID', () => {
+    const [comment] = parseDanmuXml(`
+      <i>
+        <d p="0,1,25,16777215,1700000001,0,abcd,3 user=Legacy User">Hi</d>
+      </i>
+    `);
+
+    expect(comment.rowId).toBe('3');
+    expect(comment.username).toBe('Legacy User');
+  });
+
+  it('includes gift and super-chat elements in timeline order', () => {
+    const comments = parseDanmuXml(`
+      <i>
+        <sc ts="2.500" user="Carol" uid="u2" price="30" time="60" timestamp="1700000002500">Pinned message</sc>
+        <gift ts="1.500" giftname="Rocket" giftcount="5" price="100" user="Bob" uid="u1" timestamp="1700000001500"></gift>
+      </i>
+    `);
+
+    expect(comments).toHaveLength(2);
+    expect(comments[0]).toMatchObject({
+      time: 1.5,
+      mode: 1,
+      username: 'Bob',
+      userHash: 'u1',
+      content: 'Rocket x5',
+    });
+    expect(comments[1]).toMatchObject({
+      time: 2.5,
+      mode: 5,
+      username: 'Carol',
+      userHash: 'u2',
+      content: 'Pinned message',
+    });
+  });
+
+  it('rejects malformed XML and skips malformed messages', () => {
+    expect(() => parseDanmuXml('<i><d></i>')).toThrow('Invalid danmu XML');
+    expect(parseDanmuXml('<i><d p="invalid" /></i>')).toEqual([]);
+  });
+});
+
+describe('danmu timestamps', () => {
+  it('returns null for missing or invalid timestamps', () => {
+    expect(normalizeDanmuTimestamp(null)).toBeNull();
+    expect(normalizeDanmuTimestamp('not-a-number')).toBeNull();
+  });
+
+  it('renders the segment start explicitly', () => {
+    expect(formatDanmuOffset(0)).toBe('0s');
+  });
+});

--- a/rust-srec/frontend/src/components/danmu/danmu-viewer.tsx
+++ b/rust-srec/frontend/src/components/danmu/danmu-viewer.tsx
@@ -20,6 +20,8 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
+import type { DanmuComment } from './danmu-parser';
+import type { ParseResponse } from './danmu-parser.worker';
 
 interface DanmuViewerProps {
   url: string;
@@ -27,141 +29,7 @@ interface DanmuViewerProps {
   onClose?: () => void;
 }
 
-export interface DanmuComment {
-  time: number; // Seconds from start
-  mode: number;
-  size: number;
-  color: number;
-  timestampMs: number | null;
-  pool: number;
-  userHash: string;
-  rowId: string;
-  username?: string;
-  content: string;
-}
-
 type FilterMode = 'all' | 'scrolling' | 'top' | 'bottom';
-
-const DEFAULT_FONT_SIZE = 25;
-const DEFAULT_COLOR = 16777215;
-
-function parseNumber(value: string | null): number | null {
-  if (value === null || value.trim() === '') return null;
-
-  const parsed = Number(value);
-  return Number.isFinite(parsed) ? parsed : null;
-}
-
-export function normalizeDanmuTimestamp(value: string | null): number | null {
-  const timestamp = parseNumber(value);
-  if (timestamp === null) return null;
-
-  return Math.abs(timestamp) < 100_000_000_000 ? timestamp * 1000 : timestamp;
-}
-
-function parseLegacyIdentity(value: string): {
-  rowId: string;
-  username?: string;
-} {
-  const match = value.match(/^(.*?)\s+user=(.*)$/);
-  if (!match) return { rowId: value };
-
-  return { rowId: match[1], username: match[2] };
-}
-
-function parseStandardComment(element: Element): DanmuComment | null {
-  const parts = element.getAttribute('p')?.split(',');
-  if (!parts || parts.length < 8) return null;
-
-  const time = parseNumber(parts[0]);
-  const mode = parseNumber(parts[1]);
-  const size = parseNumber(parts[2]);
-  const color = parseNumber(parts[3]);
-  const pool = parseNumber(parts[5]);
-  if (
-    time === null ||
-    mode === null ||
-    size === null ||
-    color === null ||
-    pool === null
-  ) {
-    return null;
-  }
-
-  const legacyIdentity = parseLegacyIdentity(parts[7]);
-  return {
-    time,
-    mode,
-    size,
-    color,
-    timestampMs: normalizeDanmuTimestamp(parts[4]),
-    pool,
-    userHash: parts[6],
-    rowId: legacyIdentity.rowId,
-    username: element.getAttribute('user') || legacyIdentity.username,
-    content: element.textContent || '',
-  };
-}
-
-function parseGift(element: Element, index: number): DanmuComment | null {
-  const time = parseNumber(element.getAttribute('ts'));
-  if (time === null) return null;
-
-  const giftName = element.getAttribute('giftname') || 'Gift';
-  const giftCount = element.getAttribute('giftcount');
-  return {
-    time,
-    mode: 1,
-    size: DEFAULT_FONT_SIZE,
-    color: DEFAULT_COLOR,
-    timestampMs: normalizeDanmuTimestamp(element.getAttribute('timestamp')),
-    pool: 0,
-    userHash: element.getAttribute('uid') || '',
-    rowId: `gift-${index}`,
-    username: element.getAttribute('user') || undefined,
-    content: giftCount ? `${giftName} x${giftCount}` : giftName,
-  };
-}
-
-function parseSuperChat(element: Element, index: number): DanmuComment | null {
-  const time = parseNumber(element.getAttribute('ts'));
-  if (time === null) return null;
-
-  return {
-    time,
-    mode: 5,
-    size: DEFAULT_FONT_SIZE,
-    color: DEFAULT_COLOR,
-    timestampMs: normalizeDanmuTimestamp(element.getAttribute('timestamp')),
-    pool: 0,
-    userHash: element.getAttribute('uid') || '',
-    rowId: `sc-${index}`,
-    username: element.getAttribute('user') || undefined,
-    content: element.textContent || '',
-  };
-}
-
-export function parseDanmuXml(text: string): DanmuComment[] {
-  const xmlDoc = new DOMParser().parseFromString(text, 'text/xml');
-  if (xmlDoc.querySelector('parsererror')) {
-    throw new Error('Invalid danmu XML');
-  }
-
-  const comments: DanmuComment[] = [];
-  for (const [index, element] of Array.from(
-    xmlDoc.querySelectorAll('d, gift, sc'),
-  ).entries()) {
-    const comment =
-      element.tagName === 'd'
-        ? parseStandardComment(element)
-        : element.tagName === 'gift'
-          ? parseGift(element, index)
-          : parseSuperChat(element, index);
-    if (comment) comments.push(comment);
-  }
-
-  return comments.sort((a, b) => a.time - b.time);
-}
 
 export function formatDanmuOffset(seconds: number): string {
   return formatDuration(seconds, { nullValue: '0s' });
@@ -175,22 +43,33 @@ export function DanmuViewer({ url, title }: DanmuViewerProps) {
   const [filterMode, setFilterMode] = useState<FilterMode>('all');
 
   useEffect(() => {
-    const fetchAndParseDanmu = async () => {
-      try {
-        setLoading(true);
-        const response = await fetch(url);
-        if (!response.ok) throw new Error('Failed to fetch danmu file');
+    setLoading(true);
+    setError(null);
+    setComments([]);
 
-        const text = await response.text();
-        setComments(parseDanmuXml(text));
-      } catch (err) {
-        setError(err instanceof Error ? err.message : 'Unknown error');
-      } finally {
-        setLoading(false);
+    const worker = new Worker(
+      new URL('./danmu-parser.worker.ts', import.meta.url),
+      { type: 'module' },
+    );
+    worker.addEventListener('message', (event: MessageEvent<ParseResponse>) => {
+      if (event.data.type === 'success') {
+        setComments(event.data.comments);
+      } else {
+        setError(event.data.message);
       }
-    };
+      setLoading(false);
+      worker.terminate();
+    });
+    worker.addEventListener('error', () => {
+      setError('Failed to parse danmu file');
+      setLoading(false);
+      worker.terminate();
+    });
+    worker.postMessage({ type: 'parse', url });
 
-    void fetchAndParseDanmu();
+    return () => {
+      worker.terminate();
+    };
   }, [url]);
 
   const filteredComments = useMemo(() => {

--- a/rust-srec/frontend/src/components/danmu/danmu-viewer.tsx
+++ b/rust-srec/frontend/src/components/danmu/danmu-viewer.tsx
@@ -27,12 +27,12 @@ interface DanmuViewerProps {
   onClose?: () => void;
 }
 
-interface DanmuComment {
+export interface DanmuComment {
   time: number; // Seconds from start
   mode: number;
   size: number;
   color: number;
-  timestamp: number; // Unix timestamp
+  timestampMs: number | null;
   pool: number;
   userHash: string;
   rowId: string;
@@ -41,6 +41,131 @@ interface DanmuComment {
 }
 
 type FilterMode = 'all' | 'scrolling' | 'top' | 'bottom';
+
+const DEFAULT_FONT_SIZE = 25;
+const DEFAULT_COLOR = 16777215;
+
+function parseNumber(value: string | null): number | null {
+  if (value === null || value.trim() === '') return null;
+
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+export function normalizeDanmuTimestamp(value: string | null): number | null {
+  const timestamp = parseNumber(value);
+  if (timestamp === null) return null;
+
+  return Math.abs(timestamp) < 100_000_000_000 ? timestamp * 1000 : timestamp;
+}
+
+function parseLegacyIdentity(value: string): {
+  rowId: string;
+  username?: string;
+} {
+  const match = value.match(/^(.*?)\s+user=(.*)$/);
+  if (!match) return { rowId: value };
+
+  return { rowId: match[1], username: match[2] };
+}
+
+function parseStandardComment(element: Element): DanmuComment | null {
+  const parts = element.getAttribute('p')?.split(',');
+  if (!parts || parts.length < 8) return null;
+
+  const time = parseNumber(parts[0]);
+  const mode = parseNumber(parts[1]);
+  const size = parseNumber(parts[2]);
+  const color = parseNumber(parts[3]);
+  const pool = parseNumber(parts[5]);
+  if (
+    time === null ||
+    mode === null ||
+    size === null ||
+    color === null ||
+    pool === null
+  ) {
+    return null;
+  }
+
+  const legacyIdentity = parseLegacyIdentity(parts[7]);
+  return {
+    time,
+    mode,
+    size,
+    color,
+    timestampMs: normalizeDanmuTimestamp(parts[4]),
+    pool,
+    userHash: parts[6],
+    rowId: legacyIdentity.rowId,
+    username: element.getAttribute('user') || legacyIdentity.username,
+    content: element.textContent || '',
+  };
+}
+
+function parseGift(element: Element, index: number): DanmuComment | null {
+  const time = parseNumber(element.getAttribute('ts'));
+  if (time === null) return null;
+
+  const giftName = element.getAttribute('giftname') || 'Gift';
+  const giftCount = element.getAttribute('giftcount');
+  return {
+    time,
+    mode: 1,
+    size: DEFAULT_FONT_SIZE,
+    color: DEFAULT_COLOR,
+    timestampMs: normalizeDanmuTimestamp(element.getAttribute('timestamp')),
+    pool: 0,
+    userHash: element.getAttribute('uid') || '',
+    rowId: `gift-${index}`,
+    username: element.getAttribute('user') || undefined,
+    content: giftCount ? `${giftName} x${giftCount}` : giftName,
+  };
+}
+
+function parseSuperChat(element: Element, index: number): DanmuComment | null {
+  const time = parseNumber(element.getAttribute('ts'));
+  if (time === null) return null;
+
+  return {
+    time,
+    mode: 5,
+    size: DEFAULT_FONT_SIZE,
+    color: DEFAULT_COLOR,
+    timestampMs: normalizeDanmuTimestamp(element.getAttribute('timestamp')),
+    pool: 0,
+    userHash: element.getAttribute('uid') || '',
+    rowId: `sc-${index}`,
+    username: element.getAttribute('user') || undefined,
+    content: element.textContent || '',
+  };
+}
+
+export function parseDanmuXml(text: string): DanmuComment[] {
+  const xmlDoc = new DOMParser().parseFromString(text, 'text/xml');
+  if (xmlDoc.querySelector('parsererror')) {
+    throw new Error('Invalid danmu XML');
+  }
+
+  const comments: DanmuComment[] = [];
+  for (const [index, element] of Array.from(
+    xmlDoc.querySelectorAll('d, gift, sc'),
+  ).entries()) {
+    const comment =
+      element.tagName === 'd'
+        ? parseStandardComment(element)
+        : element.tagName === 'gift'
+          ? parseGift(element, index)
+          : parseSuperChat(element, index);
+    if (comment) comments.push(comment);
+  }
+
+  return comments.sort((a, b) => a.time - b.time);
+}
+
+export function formatDanmuOffset(seconds: number): string {
+  return formatDuration(seconds, { nullValue: '0s' });
+}
 
 export function DanmuViewer({ url, title }: DanmuViewerProps) {
   const [comments, setComments] = useState<DanmuComment[]>([]);
@@ -57,50 +182,7 @@ export function DanmuViewer({ url, title }: DanmuViewerProps) {
         if (!response.ok) throw new Error('Failed to fetch danmu file');
 
         const text = await response.text();
-        const parser = new DOMParser();
-        const xmlDoc = parser.parseFromString(text, 'text/xml');
-
-        const dTags = xmlDoc.getElementsByTagName('d');
-        const parsedComments: DanmuComment[] = [];
-
-        for (let i = 0; i < dTags.length; i++) {
-          const d = dTags[i];
-          const p = d.getAttribute('p');
-          if (!p) continue;
-
-          const parts = p.split(',');
-          if (parts.length < 8) continue;
-
-          // Parse rowId and username from the last part
-          const lastPart = parts[7];
-          const spaceIndex = lastPart.indexOf(' ');
-          let rowId = lastPart;
-          let username = '';
-
-          if (spaceIndex !== -1) {
-            rowId = lastPart.substring(0, spaceIndex);
-            const userPart = lastPart.substring(spaceIndex + 1);
-            if (userPart.startsWith('user=')) {
-              username = userPart.substring(5);
-            }
-          }
-
-          parsedComments.push({
-            time: parseFloat(parts[0]),
-            mode: parseInt(parts[1]),
-            size: parseInt(parts[2]),
-            color: parseInt(parts[3]),
-            timestamp: parseInt(parts[4]),
-            pool: parseInt(parts[5]),
-            userHash: parts[6],
-            rowId,
-            username,
-            content: d.textContent || '',
-          });
-        }
-
-        parsedComments.sort((a, b) => a.time - b.time);
-        setComments(parsedComments);
+        setComments(parseDanmuXml(text));
       } catch (err) {
         setError(err instanceof Error ? err.message : 'Unknown error');
       } finally {
@@ -309,7 +391,7 @@ export function DanmuViewer({ url, title }: DanmuViewerProps) {
                       >
                         <div className="w-16 shrink-0 font-mono text-[10px] text-muted-foreground/50 tabular-nums flex items-center gap-1.5 group-hover:text-muted-foreground transition-colors">
                           <Clock className="h-3 w-3 opacity-50" />
-                          {formatDuration(comment.time)}
+                          {formatDanmuOffset(comment.time)}
                         </div>
 
                         <div className="min-w-0 flex-1 flex items-center gap-3">
@@ -334,23 +416,25 @@ export function DanmuViewer({ url, title }: DanmuViewerProps) {
                           </div>
                         </div>
 
-                        <div className="shrink-0 flex items-center gap-2 opacity-0 group-hover:opacity-100 transition-opacity">
-                          <Badge
-                            variant="secondary"
-                            className="text-[9px] h-5 tabular-nums font-mono px-1.5 bg-muted transition-all"
-                          >
-                            {new Date(comment.timestamp * 1000).toLocaleString(
-                              [],
-                              {
-                                month: 'short',
-                                day: 'numeric',
-                                hour: '2-digit',
-                                minute: '2-digit',
-                                second: '2-digit',
-                              },
-                            )}
-                          </Badge>
-                        </div>
+                        {comment.timestampMs !== null && (
+                          <div className="shrink-0 flex items-center gap-2 opacity-0 group-hover:opacity-100 transition-opacity">
+                            <Badge
+                              variant="secondary"
+                              className="text-[9px] h-5 tabular-nums font-mono px-1.5 bg-muted transition-all"
+                            >
+                              {new Date(comment.timestampMs).toLocaleString(
+                                [],
+                                {
+                                  month: 'short',
+                                  day: 'numeric',
+                                  hour: '2-digit',
+                                  minute: '2-digit',
+                                  second: '2-digit',
+                                },
+                              )}
+                            </Badge>
+                          </div>
+                        )}
                       </div>
                     );
                   })

--- a/rust-srec/frontend/src/components/pipeline/workflows/flow-editor/step-node.tsx
+++ b/rust-srec/frontend/src/components/pipeline/workflows/flow-editor/step-node.tsx
@@ -128,16 +128,16 @@ export function StepNode({ data }: NodeProps<StepNode>) {
         <h4 className="text-[14px] font-bold text-foreground truncate tracking-tight uppercase">
           {step.type === 'inline'
             ? (() => {
-              const def = getProcessorDefinition(step.processor);
-              return def ? i18n._(def.label) : step.processor;
-            })()
+                const def = getProcessorDefinition(step.processor);
+                return def ? i18n._(def.label) : step.processor;
+              })()
             : step.type === 'preset'
               ? getJobPresetName({ id: step.name, name: step.name }, i18n)
               : step.type === 'workflow'
                 ? getPipelinePresetName(
-                  { id: step.name, name: step.name },
-                  i18n,
-                )
+                    { id: step.name, name: step.name },
+                    i18n,
+                  )
                 : 'Unknown'}
         </h4>
         <div className="flex items-center justify-between">


### PR DESCRIPTION
## Summary

- normalize danmu timestamps from either Unix seconds or milliseconds
- parse usernames from XML attributes while retaining legacy row-ID compatibility
- include gift and super-chat elements in the danmu timeline
- render the segment start as `0s` and handle malformed XML safely
- fetch and incrementally parse danmu XML in a dedicated Web Worker
- add focused parser, timestamp, and chunk-boundary regression tests

## Root cause

The XML writer changed its absolute timestamp field from Unix seconds to Unix milliseconds, but the frontend viewer continued multiplying the value by 1000. The viewer also expected usernames inside the packed `p` attribute and only selected standard `<d>` elements, while the writer emits usernames as attributes and uses dedicated `<gift>` and `<sc>` elements.

The viewer additionally fetched the complete XML string and built a full browser DOM synchronously on the main thread. Large recordings could therefore block interaction and temporarily require multiple full-file representations in memory.

## Impact

Recorded danmu files now show correct absolute and relative timestamps, sender names, gifts, and super chats. Imported canonical Bilibili XML using second-based timestamps remains supported.

Large files are decoded and parsed incrementally outside the React main thread using `saxes`. Chronological recordings avoid an unnecessary sort, unused fields are no longer retained per comment, stale workers are terminated when the viewer closes, and both web and desktop builds emit the parser as an isolated worker asset.

## Validation

- `pnpm run extract`
- `pnpm run compile`
- `pnpm test` (83 tests)
- `pnpm run lint`
- `pnpm run build`
- `pnpm run build:desktop`
- targeted formatting check for all changed frontend files
- `cargo fmt --all -- --check`
- `git diff --check`

