### PR TITLE
fix(pipeline): clear job progress snapshots on terminal transitions

### DIFF
--- a/rust-srec/frontend/src/components/pipeline/jobs/job-uploads-card.tsx
+++ b/rust-srec/frontend/src/components/pipeline/jobs/job-uploads-card.tsx
@@ -1,4 +1,3 @@
-import { useMutation } from '@tanstack/react-query';
 import { Trans } from '@lingui/react/macro';
 import { useLingui } from '@lingui/react';
 import { msg } from '@lingui/core/macro';
@@ -19,26 +18,29 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from '@/components/ui/tooltip';
-import { formatBytes } from '@/lib/format';
+import { basename, formatBytes } from '@/lib/format';
 import { cn } from '@/lib/utils';
 import type { UploadRecord, UploadRecordStatus } from '@/api/schemas';
 
 const STATUS_STYLE: Record<
   UploadRecordStatus,
-  { icon: typeof CircleCheck; className: string }
+  { icon: typeof CircleCheck; badgeClassName: string; iconClassName: string }
 > = {
   COMPLETED: {
     icon: CircleCheck,
-    className:
+    badgeClassName:
       'bg-emerald-500/10 text-emerald-600 border-emerald-500/20 dark:text-emerald-400',
+    iconClassName: 'text-emerald-500',
   },
   FAILED: {
     icon: CircleX,
-    className: 'bg-destructive/10 text-destructive border-destructive/20',
+    badgeClassName: 'bg-destructive/10 text-destructive border-destructive/20',
+    iconClassName: 'text-destructive',
   },
   SKIPPED: {
     icon: CircleMinus,
-    className: 'bg-muted/60 text-muted-foreground border-border/50',
+    badgeClassName: 'bg-muted/60 text-muted-foreground border-border/50',
+    iconClassName: 'text-muted-foreground',
   },
 };
 
@@ -53,11 +55,6 @@ function statusLabel(status: UploadRecordStatus) {
   }
 }
 
-function basename(path: string): string {
-  const idx = Math.max(path.lastIndexOf('/'), path.lastIndexOf('\\'));
-  return idx >= 0 ? path.slice(idx + 1) : path;
-}
-
 /**
  * Per-file upload results for a job (durable `upload_records`). Rendered on
  * the job detail page only when the job produced at least one record.
@@ -65,11 +62,14 @@ function basename(path: string): string {
 export function JobUploadsCard({ records }: { records: UploadRecord[] }) {
   const { i18n } = useLingui();
 
-  const copyMutation = useMutation({
-    mutationFn: (text: string) => navigator.clipboard.writeText(text),
-    onSuccess: () => toast.success(i18n._(msg`Destination copied`)),
-    onError: () => toast.error(i18n._(msg`Failed to copy destination`)),
-  });
+  const handleCopyDestination = async (text: string) => {
+    try {
+      await navigator.clipboard.writeText(text);
+      toast.success(i18n._(msg`Destination copied`));
+    } catch {
+      toast.error(i18n._(msg`Failed to copy destination`));
+    }
+  };
 
   if (records.length === 0) return null;
 
@@ -95,12 +95,7 @@ export function JobUploadsCard({ records }: { records: UploadRecord[] }) {
                 className="flex items-center gap-3 p-3 rounded-xl bg-background/50 border border-border/50 hover:bg-background/80 transition-colors"
               >
                 <StatusIcon
-                  className={cn(
-                    'h-4 w-4 shrink-0',
-                    record.status === 'COMPLETED' && 'text-emerald-500',
-                    record.status === 'FAILED' && 'text-destructive',
-                    record.status === 'SKIPPED' && 'text-muted-foreground',
-                  )}
+                  className={cn('h-4 w-4 shrink-0', style.iconClassName)}
                 />
                 <div className="flex-1 min-w-0">
                   <Tooltip>
@@ -138,7 +133,7 @@ export function JobUploadsCard({ records }: { records: UploadRecord[] }) {
                 )}
                 <Badge
                   variant="outline"
-                  className={cn('shrink-0 text-[10px]', style.className)}
+                  className={cn('shrink-0 text-[10px]', style.badgeClassName)}
                 >
                   {statusLabel(record.status)}
                 </Badge>
@@ -147,7 +142,9 @@ export function JobUploadsCard({ records }: { records: UploadRecord[] }) {
                     variant="ghost"
                     size="icon"
                     className="h-7 w-7 shrink-0 text-muted-foreground hover:text-foreground"
-                    onClick={() => copyMutation.mutate(record.remote_path!)}
+                    onClick={() =>
+                      void handleCopyDestination(record.remote_path!)
+                    }
                   >
                     <Copy className="h-3.5 w-3.5" />
                   </Button>

--- a/rust-srec/frontend/src/components/pipeline/outputs/output-card.tsx
+++ b/rust-srec/frontend/src/components/pipeline/outputs/output-card.tsx
@@ -54,7 +54,7 @@ const FORMAT_COLORS: Record<string, string> = {
   webp: 'from-amber-500/10 to-amber-500/5 text-amber-500 border-amber-500/20',
 };
 
-import { formatBytes } from '@/lib/format';
+import { basename, formatBytes } from '@/lib/format';
 
 export function OutputCard({ output }: OutputCardProps) {
   const { i18n } = useLingui();
@@ -73,12 +73,12 @@ export function OutputCard({ output }: OutputCardProps) {
     setTimeout(() => setCopied(false), 2000);
   };
 
-  const filename =
-    output.file_path.split(/[\\/]/).pop() || i18n._(msg`Unknown File`);
+  const filename = basename(output.file_path) || i18n._(msg`Unknown File`);
   const formatLower = output.format.toLowerCase();
   const colorClass =
     FORMAT_COLORS[formatLower] ||
     'from-gray-500/10 to-gray-500/5 text-gray-500 border-gray-500/20';
+  const hasFailedUpload = output.uploads.some((u) => u.status === 'FAILED');
 
   return (
     <Card className="relative h-full flex flex-col transition-all duration-500 hover:-translate-y-1 hover:shadow-2xl hover:shadow-primary/10 group overflow-hidden bg-gradient-to-br from-background/80 to-background/40 backdrop-blur-xl border-border/40 hover:border-primary/20">
@@ -117,12 +117,12 @@ export function OutputCard({ output }: OutputCardProps) {
               <div
                 className={cn(
                   'p-1.5 rounded-lg border',
-                  output.uploads.some((u) => u.status === 'FAILED')
+                  hasFailedUpload
                     ? 'bg-destructive/10 text-destructive border-destructive/20'
                     : 'bg-emerald-500/10 text-emerald-600 border-emerald-500/20 dark:text-emerald-400',
                 )}
               >
-                {output.uploads.some((u) => u.status === 'FAILED') ? (
+                {hasFailedUpload ? (
                   <CloudAlert className="h-3.5 w-3.5" />
                 ) : (
                   <CloudUpload className="h-3.5 w-3.5" />
@@ -130,8 +130,8 @@ export function OutputCard({ output }: OutputCardProps) {
               </div>
             </TooltipTrigger>
             <TooltipContent className="max-w-sm space-y-1.5">
-              {output.uploads.map((upload, i) => (
-                <div key={i} className="text-xs space-y-0.5">
+              {output.uploads.map((upload) => (
+                <div key={upload.uploader} className="text-xs space-y-0.5">
                   <div className="font-medium">
                     {upload.status === 'COMPLETED' && (
                       <Trans>Uploaded via {upload.uploader}</Trans>

--- a/rust-srec/frontend/src/components/streamers/card/upload-indicator.tsx
+++ b/rust-srec/frontend/src/components/streamers/card/upload-indicator.tsx
@@ -20,6 +20,8 @@ import type { UploadView } from '@/store/uploads';
 export function UploadIndicator({ uploads }: { uploads: UploadView[] }) {
   const { i18n } = useLingui();
 
+  if (uploads.length === 0) return null;
+
   // With several concurrent upload jobs, surface the one with the most
   // recent progress in the compact percent label.
   const latest = uploads.reduce((a, b) =>
@@ -73,10 +75,9 @@ export function UploadIndicator({ uploads }: { uploads: UploadView[] }) {
             {(upload.bytesDone != null || upload.speedBytesPerSec != null) && (
               <div className="flex items-center justify-between gap-4 font-mono opacity-60">
                 <span>
-                  {upload.bytesDone != null &&
-                    formatBytes(Number(upload.bytesDone))}
+                  {upload.bytesDone != null && formatBytes(upload.bytesDone)}
                   {upload.bytesTotal != null &&
-                    ` / ${formatBytes(Number(upload.bytesTotal))}`}
+                    ` / ${formatBytes(upload.bytesTotal)}`}
                 </span>
                 {upload.speedBytesPerSec != null && (
                   <span>{formatSpeed(upload.speedBytesPerSec)}</span>

--- a/rust-srec/frontend/src/lib/format.ts
+++ b/rust-srec/frontend/src/lib/format.ts
@@ -104,6 +104,15 @@ export function formatSpeed(
 }
 
 /**
+ * Final path component of a file path, handling both `/` and `\` separators.
+ * Returns the input unchanged when it contains no separator.
+ */
+export function basename(path: string): string {
+  const idx = Math.max(path.lastIndexOf('/'), path.lastIndexOf('\\'));
+  return idx >= 0 ? path.slice(idx + 1) : path;
+}
+
+/**
  * Remove null and undefined values from an object or array recursively
  */
 export function removeEmpty(obj: any): any {

--- a/rust-srec/frontend/src/locales/en/messages.po
+++ b/rust-srec/frontend/src/locales/en/messages.po
@@ -61,7 +61,7 @@ msgid "(Preserve source)"
 msgstr "(Preserve source)"
 
 #. placeholder {0}: uploads.length
-#: src/components/streamers/card/upload-indicator.tsx:44
+#: src/components/streamers/card/upload-indicator.tsx:46
 msgid "{0, plural, one {# active upload} other {# active uploads}}"
 msgstr "{0, plural, one {# active upload} other {# active uploads}}"
 
@@ -71,7 +71,7 @@ msgid "{0, plural, one {# done} other {# done}}"
 msgstr "{0, plural, one {# done} other {# done}}"
 
 #. placeholder {0}: job.execution_info.log_error_count
-#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:670
+#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:687
 msgid "{0, plural, one {# Error} other {# Errors}}"
 msgstr "{0, plural, one {# Error} other {# Errors}}"
 
@@ -81,12 +81,12 @@ msgid "{0, plural, one {# failed} other {# failed}}"
 msgstr "{0, plural, one {# failed} other {# failed}}"
 
 #. placeholder {0}: upload.filesTotal
-#: src/components/streamers/card/upload-indicator.tsx:59
+#: src/components/streamers/card/upload-indicator.tsx:61
 msgid "{0, plural, one {# file} other {# files}}"
 msgstr "{0, plural, one {# file} other {# files}}"
 
 #. placeholder {0}: job.execution_info.log_lines_total
-#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:690
+#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:707
 msgid "{0, plural, one {# Line} other {# Lines}}"
 msgstr "{0, plural, one {# Line} other {# Lines}}"
 
@@ -99,7 +99,7 @@ msgid "{0, plural, one {# step} other {# steps}}"
 msgstr "{0, plural, one {# step} other {# steps}}"
 
 #. placeholder {0}: job.execution_info.log_warn_count
-#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:680
+#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:697
 msgid "{0, plural, one {# Warning} other {# Warnings}}"
 msgstr "{0, plural, one {# Warning} other {# Warnings}}"
 
@@ -577,7 +577,7 @@ msgstr "Are you sure you want to delete {0} sessions? This action cannot be undo
 msgid "Are you sure you want to delete the template \"{0}\"? This action cannot be undone."
 msgstr "Are you sure you want to delete the template \"{0}\"? This action cannot be undone."
 
-#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:349
+#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:366
 msgid "Are you sure you want to delete this job? This will permanently remove it from your list."
 msgstr "Are you sure you want to delete this job? This will permanently remove it from your list."
 
@@ -760,7 +760,7 @@ msgstr "Awaiting first check"
 msgid "Back"
 msgstr "Back"
 
-#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:249
+#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:266
 #: src/routes/_authed/_dashboard/pipeline/jobs/new.lazy.tsx:143
 msgid "Back to Jobs"
 msgstr "Back to Jobs"
@@ -991,7 +991,7 @@ msgstr "Cache"
 msgid "Cancel"
 msgstr "Cancel"
 
-#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:338
+#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:355
 msgid "Cancel Execution"
 msgstr "Cancel Execution"
 
@@ -1280,7 +1280,7 @@ msgstr "Complete workflow: Remux, generate thumbnail, add metadata, and upload."
 #: src/components/pipeline/status-config.ts:106
 #: src/routes/_authed/_dashboard/dashboard.lazy.tsx:356
 #: src/routes/_authed/_dashboard/pipeline/executions.$pipelineId.lazy.tsx:288
-#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:607
+#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:624
 #: src/routes/_authed/_dashboard/pipeline/jobs/index.lazy.tsx:103
 #: src/routes/_authed/_dashboard/pipeline/jobs/index.lazy.tsx:352
 msgid "Completed"
@@ -1487,7 +1487,7 @@ msgstr "Consecutive Failures"
 msgid "Container"
 msgstr "Container"
 
-#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:378
+#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:395
 msgid "Context"
 msgstr "Context"
 
@@ -1698,7 +1698,7 @@ msgstr "Create your first workflow to define a sequence of processing steps for 
 
 #: src/components/config/global/backup-restore-card.tsx:178
 #: src/components/pipeline/outputs/output-card.tsx:239
-#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:593
+#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:610
 msgid "Created"
 msgstr "Created"
 
@@ -2091,7 +2091,7 @@ msgstr "Delete File"
 msgid "Delete filter"
 msgstr "Delete filter"
 
-#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:358
+#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:375
 msgid "Delete Job"
 msgstr "Delete Job"
 
@@ -2206,7 +2206,7 @@ msgstr "Desktop Notifications"
 msgid "Desktop notifications are shown by the operating system even when the app is minimized."
 msgstr "Desktop notifications are shown by the operating system even when the app is minimized."
 
-#: src/components/pipeline/jobs/job-uploads-card.tsx:76
+#: src/components/pipeline/jobs/job-uploads-card.tsx:68
 msgid "Destination copied"
 msgstr "Destination copied"
 
@@ -2391,7 +2391,7 @@ msgstr "Dual Format"
 #: src/components/pipeline/presets/processors/remux-config-form.tsx:682
 #: src/components/streamers/edit/active-download-card.tsx:153
 #: src/components/streamers/progress-indicator.tsx:124
-#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:550
+#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:567
 msgid "Duration"
 msgstr "Duration"
 
@@ -2704,11 +2704,11 @@ msgstr "Error"
 
 #: src/components/streamers/card/use-streamer-status.tsx:195
 #: src/components/streamers/card/use-streamer-status.tsx:235
-#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:633
+#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:650
 msgid "Error Details"
 msgstr "Error Details"
 
-#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:208
+#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:225
 msgid "Error Loading Job"
 msgstr "Error Loading Job"
 
@@ -2749,7 +2749,7 @@ msgstr "Error:"
 msgid "Error: Could not load preset details."
 msgstr "Error: Could not load preset details."
 
-#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:579
+#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:596
 msgid "ETA"
 msgstr "ETA"
 
@@ -2926,7 +2926,7 @@ msgctxt "Friday initial"
 msgid "F"
 msgstr "F"
 
-#: src/components/pipeline/jobs/job-uploads-card.tsx:56
+#: src/components/pipeline/jobs/job-uploads-card.tsx:52
 #: src/components/pipeline/status-config.ts:108
 #: src/routes/_authed/_dashboard/dashboard.lazy.tsx:367
 #: src/routes/_authed/_dashboard/pipeline/jobs/index.lazy.tsx:106
@@ -2947,7 +2947,7 @@ msgstr "Failed steps retry initiated"
 msgid "Failed to autofill name"
 msgstr "Failed to autofill name"
 
-#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:167
+#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:184
 msgid "Failed to cancel job"
 msgstr "Failed to cancel job"
 
@@ -2978,7 +2978,7 @@ msgstr "Failed to clone template: {0}"
 msgid "Failed to copy"
 msgstr "Failed to copy"
 
-#: src/components/pipeline/jobs/job-uploads-card.tsx:77
+#: src/components/pipeline/jobs/job-uploads-card.tsx:70
 msgid "Failed to copy destination"
 msgstr "Failed to copy destination"
 
@@ -3025,7 +3025,7 @@ msgstr "Failed to delete engine"
 msgid "Failed to delete filter"
 msgstr "Failed to delete filter"
 
-#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:177
+#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:194
 msgid "Failed to delete job"
 msgstr "Failed to delete job"
 
@@ -3156,7 +3156,7 @@ msgstr "Failed to refresh credentials"
 msgid "Failed to retry all failed pipelines"
 msgstr "Failed to retry all failed pipelines"
 
-#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:156
+#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:173
 msgid "Failed to retry job"
 msgstr "Failed to retry job"
 
@@ -3608,7 +3608,7 @@ msgid "Go back"
 msgstr "Go back"
 
 #: src/components/default-catch-boundary.tsx:58
-#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:216
+#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:233
 #: src/routes/_authed/_dashboard/sessions/$sessionId.lazy.tsx:243
 msgid "Go Back"
 msgstr "Go Back"
@@ -4052,7 +4052,7 @@ msgstr "Input Arguments"
 msgid "Input Options (-i flags)"
 msgstr "Input Options (-i flags)"
 
-#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:453
+#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:470
 msgid "Input Path"
 msgstr "Input Path"
 
@@ -4114,7 +4114,7 @@ msgstr "Isolation level for tracking identifiers. Global is usually best."
 msgid "Jitter"
 msgstr "Jitter"
 
-#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:162
+#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:179
 msgid "Job cancelled"
 msgstr "Job cancelled"
 
@@ -4134,15 +4134,15 @@ msgstr "Job creation time"
 msgid "Job creation time (default)"
 msgstr "Job creation time (default)"
 
-#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:173
+#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:190
 msgid "Job deleted"
 msgstr "Job deleted"
 
-#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:278
+#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:295
 msgid "Job Details"
 msgstr "Job Details"
 
-#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:211
+#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:228
 msgid "Job not found"
 msgstr "Job not found"
 
@@ -4150,7 +4150,7 @@ msgstr "Job not found"
 msgid "Job Presets"
 msgstr "Job Presets"
 
-#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:151
+#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:168
 msgid "Job retry initiated"
 msgstr "Job retry initiated"
 
@@ -4342,7 +4342,7 @@ msgstr "Loading Danmu"
 msgid "Loading editor components..."
 msgstr "Loading editor components..."
 
-#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:709
+#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:726
 msgid "Loading logs..."
 msgstr "Loading logs..."
 
@@ -4351,7 +4351,7 @@ msgstr "Loading logs..."
 msgid "Loading more..."
 msgstr "Loading more..."
 
-#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:746
+#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:763
 msgid "Loading older logs..."
 msgstr "Loading older logs..."
 
@@ -4643,12 +4643,12 @@ msgstr "Maximum quality compression with HEVC, then upload to cloud storage."
 
 #: src/components/streamers/edit/recent-sessions-list.tsx:103
 #: src/components/ui/input-with-unit.tsx:29
-#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:421
-#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:432
+#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:438
+#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:449
 msgid "MB"
 msgstr "MB"
 
-#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:573
+#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:590
 msgid "MB/s"
 msgstr "MB/s"
 
@@ -5006,7 +5006,7 @@ msgstr "No events found"
 msgid "No filters yet"
 msgstr "No filters yet"
 
-#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:475
+#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:492
 msgid "No input paths"
 msgstr "No input paths"
 
@@ -5031,7 +5031,7 @@ msgstr "No limit"
 msgid "No log files found"
 msgstr "No log files found"
 
-#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:758
+#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:775
 msgid "No logs available for this execution."
 msgstr "No logs available for this execution."
 
@@ -5063,7 +5063,7 @@ msgstr "No modules configured"
 msgid "No other steps available to depend on."
 msgstr "No other steps available to depend on."
 
-#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:510
+#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:527
 msgid "No output generated"
 msgstr "No output generated"
 
@@ -5548,7 +5548,7 @@ msgstr "Output Format"
 msgid "Output Options"
 msgstr "Output Options"
 
-#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:488
+#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:505
 msgid "Output Path"
 msgstr "Output Path"
 
@@ -5815,7 +5815,7 @@ msgstr "Per-Streamer"
 
 #: src/components/pipeline/presets/processors/remux-config-form.tsx:781
 #: src/components/sessions/overview-tab.tsx:195
-#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:543
+#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:560
 msgid "Performance"
 msgstr "Performance"
 
@@ -5831,7 +5831,7 @@ msgstr "Pick a preset theme or import a custom one."
 #: src/components/layout/site-header.tsx:36
 #: src/components/sidebar/navbar.tsx:30
 #: src/lib/menu-list.ts:70
-#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:396
+#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:413
 msgid "Pipeline"
 msgstr "Pipeline"
 
@@ -6332,7 +6332,7 @@ msgstr "Quality Settings"
 msgid "Query Parameters"
 msgstr "Query Parameters"
 
-#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:558
+#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:575
 msgid "Queue"
 msgstr "Queue"
 
@@ -6670,7 +6670,7 @@ msgstr "Resolution change"
 msgid "Resource Limits"
 msgstr "Resource Limits"
 
-#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:410
+#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:427
 msgid "Resources"
 msgstr "Resources"
 
@@ -6736,7 +6736,7 @@ msgstr "Retry Delay (ms)"
 msgid "Retry Delay Base (ms)"
 msgstr "Retry Delay Base (ms)"
 
-#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:327
+#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:344
 msgid "Retry Job"
 msgstr "Retry Job"
 
@@ -7292,7 +7292,7 @@ msgid "SESSION ENDED"
 msgstr "SESSION ENDED"
 
 #: src/components/pipeline/presets/processors/execute-config-form.tsx:140
-#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:383
+#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:400
 msgid "Session ID"
 msgstr "Session ID"
 
@@ -7435,7 +7435,7 @@ msgstr "Skip after duration"
 msgid "Skip Interactive Games"
 msgstr "Skip Interactive Games"
 
-#: src/components/pipeline/jobs/job-uploads-card.tsx:58
+#: src/components/pipeline/jobs/job-uploads-card.tsx:54
 msgid "Skipped"
 msgstr "Skipped"
 
@@ -7486,7 +7486,7 @@ msgid "Specify preferred content delivery network (e.g., ws-h5, hw-h5)."
 msgstr "Specify preferred content delivery network (e.g., ws-h5, hw-h5)."
 
 #: src/components/streamers/edit/active-download-card.tsx:125
-#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:568
+#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:585
 msgid "Speed"
 msgstr "Speed"
 
@@ -7537,7 +7537,7 @@ msgstr "Start Time"
 #: src/components/pipeline/jobs/pipeline-summary-card.tsx:253
 #: src/components/sessions/overview-tab.tsx:217
 #: src/routes/_authed/_dashboard/pipeline/executions.$pipelineId.lazy.tsx:294
-#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:598
+#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:615
 msgid "Started"
 msgstr "Started"
 
@@ -7669,7 +7669,7 @@ msgid "Streamer deleted"
 msgstr "Streamer deleted"
 
 #: src/components/pipeline/presets/processors/execute-config-form.tsx:133
-#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:389
+#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:406
 msgid "Streamer ID"
 msgstr "Streamer ID"
 
@@ -8190,7 +8190,7 @@ msgstr "Top Words"
 msgid "total"
 msgstr "total"
 
-#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:695
+#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:712
 msgid "Total"
 msgstr "Total"
 
@@ -8460,7 +8460,7 @@ msgstr "Unknown engine type: {engineType}"
 msgid "Unknown error"
 msgstr "Unknown error"
 
-#: src/components/pipeline/outputs/output-card.tsx:77
+#: src/components/pipeline/outputs/output-card.tsx:76
 msgid "Unknown File"
 msgstr "Unknown File"
 
@@ -8501,7 +8501,7 @@ msgstr "Updated"
 msgid "Updates existing items and creates new ones. Nothing is deleted."
 msgstr "Updates existing items and creates new ones. Nothing is deleted."
 
-#: src/components/streamers/card/upload-indicator.tsx:54
+#: src/components/streamers/card/upload-indicator.tsx:56
 msgid "upload"
 msgstr "upload"
 
@@ -8541,7 +8541,7 @@ msgstr "Upload file to cloud storage using rclone. Configure remote in rclone co
 msgid "Upload skipped via {0}"
 msgstr "Upload skipped via {0}"
 
-#: src/components/pipeline/jobs/job-uploads-card.tsx:54
+#: src/components/pipeline/jobs/job-uploads-card.tsx:50
 msgid "Uploaded"
 msgstr "Uploaded"
 
@@ -8550,7 +8550,7 @@ msgstr "Uploaded"
 msgid "Uploaded via {0}"
 msgstr "Uploaded via {0}"
 
-#: src/components/pipeline/jobs/job-uploads-card.tsx:87
+#: src/components/pipeline/jobs/job-uploads-card.tsx:81
 msgid "Uploads"
 msgstr "Uploads"
 

--- a/rust-srec/frontend/src/locales/zh-CN/messages.po
+++ b/rust-srec/frontend/src/locales/zh-CN/messages.po
@@ -61,7 +61,7 @@ msgid "(Preserve source)"
 msgstr "（保留源文件）"
 
 #. placeholder {0}: uploads.length
-#: src/components/streamers/card/upload-indicator.tsx:44
+#: src/components/streamers/card/upload-indicator.tsx:46
 msgid "{0, plural, one {# active upload} other {# active uploads}}"
 msgstr "{0, plural, other {# 个进行中的上传}}"
 
@@ -71,7 +71,7 @@ msgid "{0, plural, one {# done} other {# done}}"
 msgstr "{0, plural, other {# 已完成}}"
 
 #. placeholder {0}: job.execution_info.log_error_count
-#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:670
+#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:687
 msgid "{0, plural, one {# Error} other {# Errors}}"
 msgstr "{0, plural, other {# 个错误}}"
 
@@ -81,12 +81,12 @@ msgid "{0, plural, one {# failed} other {# failed}}"
 msgstr "{0, plural, other {# 失败}}"
 
 #. placeholder {0}: upload.filesTotal
-#: src/components/streamers/card/upload-indicator.tsx:59
+#: src/components/streamers/card/upload-indicator.tsx:61
 msgid "{0, plural, one {# file} other {# files}}"
 msgstr "{0, plural, other {# 个文件}}"
 
 #. placeholder {0}: job.execution_info.log_lines_total
-#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:690
+#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:707
 msgid "{0, plural, one {# Line} other {# Lines}}"
 msgstr "{0, plural, other {# 行}}"
 
@@ -99,7 +99,7 @@ msgid "{0, plural, one {# step} other {# steps}}"
 msgstr "{0, plural, other {# 步}}"
 
 #. placeholder {0}: job.execution_info.log_warn_count
-#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:680
+#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:697
 msgid "{0, plural, one {# Warning} other {# Warnings}}"
 msgstr "{0, plural, other {# 个警告}}"
 
@@ -577,7 +577,7 @@ msgstr "你确定要删除 {0} 个会话吗？此操作无法撤销。"
 msgid "Are you sure you want to delete the template \"{0}\"? This action cannot be undone."
 msgstr "确定要删除模板“{0}”吗？此操作无法撤销。"
 
-#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:349
+#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:366
 msgid "Are you sure you want to delete this job? This will permanently remove it from your list."
 msgstr "确定要删除此任务吗？此操作将永久从列表中删除。"
 
@@ -760,7 +760,7 @@ msgstr "等待首次检查"
 msgid "Back"
 msgstr "返回"
 
-#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:249
+#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:266
 #: src/routes/_authed/_dashboard/pipeline/jobs/new.lazy.tsx:143
 msgid "Back to Jobs"
 msgstr "返回处理任务列表"
@@ -991,7 +991,7 @@ msgstr "缓存"
 msgid "Cancel"
 msgstr "取消"
 
-#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:338
+#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:355
 msgid "Cancel Execution"
 msgstr "取消执行"
 
@@ -1280,7 +1280,7 @@ msgstr "完整流程：重封装、生成缩略图、添加元数据并上传。
 #: src/components/pipeline/status-config.ts:106
 #: src/routes/_authed/_dashboard/dashboard.lazy.tsx:356
 #: src/routes/_authed/_dashboard/pipeline/executions.$pipelineId.lazy.tsx:288
-#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:607
+#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:624
 #: src/routes/_authed/_dashboard/pipeline/jobs/index.lazy.tsx:103
 #: src/routes/_authed/_dashboard/pipeline/jobs/index.lazy.tsx:352
 msgid "Completed"
@@ -1487,7 +1487,7 @@ msgstr "连续失败"
 msgid "Container"
 msgstr "容器"
 
-#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:378
+#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:395
 msgid "Context"
 msgstr "上下文"
 
@@ -1698,7 +1698,7 @@ msgstr "创建你的第一个工作流，用于定义录制内容的处理步骤
 
 #: src/components/config/global/backup-restore-card.tsx:178
 #: src/components/pipeline/outputs/output-card.tsx:239
-#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:593
+#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:610
 msgid "Created"
 msgstr "已创建"
 
@@ -2091,7 +2091,7 @@ msgstr "删除文件"
 msgid "Delete filter"
 msgstr "删除过滤器"
 
-#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:358
+#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:375
 msgid "Delete Job"
 msgstr "删除处理任务"
 
@@ -2206,7 +2206,7 @@ msgstr "桌面通知"
 msgid "Desktop notifications are shown by the operating system even when the app is minimized."
 msgstr "即使应用已最小化，操作系统仍会显示桌面通知。"
 
-#: src/components/pipeline/jobs/job-uploads-card.tsx:76
+#: src/components/pipeline/jobs/job-uploads-card.tsx:68
 msgid "Destination copied"
 msgstr "已复制目标路径"
 
@@ -2391,7 +2391,7 @@ msgstr "双格式输出"
 #: src/components/pipeline/presets/processors/remux-config-form.tsx:682
 #: src/components/streamers/edit/active-download-card.tsx:153
 #: src/components/streamers/progress-indicator.tsx:124
-#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:550
+#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:567
 msgid "Duration"
 msgstr "时长"
 
@@ -2704,11 +2704,11 @@ msgstr "错误"
 
 #: src/components/streamers/card/use-streamer-status.tsx:195
 #: src/components/streamers/card/use-streamer-status.tsx:235
-#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:633
+#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:650
 msgid "Error Details"
 msgstr "错误详情"
 
-#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:208
+#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:225
 msgid "Error Loading Job"
 msgstr "加载处理任务失败"
 
@@ -2749,7 +2749,7 @@ msgstr "错误："
 msgid "Error: Could not load preset details."
 msgstr "错误：无法加载预设详情。"
 
-#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:579
+#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:596
 msgid "ETA"
 msgstr "预计剩余时间"
 
@@ -2926,7 +2926,7 @@ msgctxt "Friday initial"
 msgid "F"
 msgstr "五"
 
-#: src/components/pipeline/jobs/job-uploads-card.tsx:56
+#: src/components/pipeline/jobs/job-uploads-card.tsx:52
 #: src/components/pipeline/status-config.ts:108
 #: src/routes/_authed/_dashboard/dashboard.lazy.tsx:367
 #: src/routes/_authed/_dashboard/pipeline/jobs/index.lazy.tsx:106
@@ -2947,7 +2947,7 @@ msgstr "已开始重试失败的步骤"
 msgid "Failed to autofill name"
 msgstr "自动填充名称失败"
 
-#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:167
+#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:184
 msgid "Failed to cancel job"
 msgstr "取消处理任务失败"
 
@@ -2978,7 +2978,7 @@ msgstr "克隆模板失败：{0}"
 msgid "Failed to copy"
 msgstr "复制失败"
 
-#: src/components/pipeline/jobs/job-uploads-card.tsx:77
+#: src/components/pipeline/jobs/job-uploads-card.tsx:70
 msgid "Failed to copy destination"
 msgstr "复制目标路径失败"
 
@@ -3025,7 +3025,7 @@ msgstr "删除引擎失败"
 msgid "Failed to delete filter"
 msgstr "删除过滤器失败"
 
-#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:177
+#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:194
 msgid "Failed to delete job"
 msgstr "删除处理任务失败"
 
@@ -3156,7 +3156,7 @@ msgstr "刷新凭据失败"
 msgid "Failed to retry all failed pipelines"
 msgstr "重试所有失败的处理任务失败"
 
-#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:156
+#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:173
 msgid "Failed to retry job"
 msgstr "重试处理任务失败"
 
@@ -3608,7 +3608,7 @@ msgid "Go back"
 msgstr "返回"
 
 #: src/components/default-catch-boundary.tsx:58
-#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:216
+#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:233
 #: src/routes/_authed/_dashboard/sessions/$sessionId.lazy.tsx:243
 msgid "Go Back"
 msgstr "返回"
@@ -4052,7 +4052,7 @@ msgstr "输入参数"
 msgid "Input Options (-i flags)"
 msgstr "输入选项（-i 参数）"
 
-#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:453
+#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:470
 msgid "Input Path"
 msgstr "输入路径"
 
@@ -4114,7 +4114,7 @@ msgstr "追踪标识符的隔离级别。全局通常是最佳选择。"
 msgid "Jitter"
 msgstr "抖动"
 
-#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:162
+#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:179
 msgid "Job cancelled"
 msgstr "处理任务已取消"
 
@@ -4134,15 +4134,15 @@ msgstr "任务创建时间"
 msgid "Job creation time (default)"
 msgstr "任务创建时间（默认）"
 
-#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:173
+#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:190
 msgid "Job deleted"
 msgstr "处理任务已删除"
 
-#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:278
+#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:295
 msgid "Job Details"
 msgstr "处理任务详情"
 
-#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:211
+#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:228
 msgid "Job not found"
 msgstr "未找到处理任务"
 
@@ -4150,7 +4150,7 @@ msgstr "未找到处理任务"
 msgid "Job Presets"
 msgstr "任务预设"
 
-#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:151
+#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:168
 msgid "Job retry initiated"
 msgstr "已开始重试处理任务"
 
@@ -4342,7 +4342,7 @@ msgstr "正在加载弹幕"
 msgid "Loading editor components..."
 msgstr "正在加载编辑器组件..."
 
-#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:709
+#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:726
 msgid "Loading logs..."
 msgstr "正在加载日志..."
 
@@ -4351,7 +4351,7 @@ msgstr "正在加载日志..."
 msgid "Loading more..."
 msgstr "正在加载更多..."
 
-#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:746
+#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:763
 msgid "Loading older logs..."
 msgstr "正在加载历史日志..."
 
@@ -4643,12 +4643,12 @@ msgstr "使用 HEVC 进行最高质量压缩，然后上传到云存储。"
 
 #: src/components/streamers/edit/recent-sessions-list.tsx:103
 #: src/components/ui/input-with-unit.tsx:29
-#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:421
-#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:432
+#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:438
+#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:449
 msgid "MB"
 msgstr "MB"
 
-#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:573
+#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:590
 msgid "MB/s"
 msgstr "MB/s"
 
@@ -5006,7 +5006,7 @@ msgstr "未找到事件"
 msgid "No filters yet"
 msgstr "暂无过滤器"
 
-#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:475
+#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:492
 msgid "No input paths"
 msgstr "没有输入路径"
 
@@ -5031,7 +5031,7 @@ msgstr "不限"
 msgid "No log files found"
 msgstr "未找到日志文件"
 
-#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:758
+#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:775
 msgid "No logs available for this execution."
 msgstr "该执行记录暂无日志。"
 
@@ -5063,7 +5063,7 @@ msgstr "未配置模块"
 msgid "No other steps available to depend on."
 msgstr "没有其他可依赖的步骤。"
 
-#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:510
+#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:527
 msgid "No output generated"
 msgstr "未生成输出"
 
@@ -5548,7 +5548,7 @@ msgstr "输出格式"
 msgid "Output Options"
 msgstr "输出选项"
 
-#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:488
+#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:505
 msgid "Output Path"
 msgstr "输出路径"
 
@@ -5815,7 +5815,7 @@ msgstr "按主播"
 
 #: src/components/pipeline/presets/processors/remux-config-form.tsx:781
 #: src/components/sessions/overview-tab.tsx:195
-#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:543
+#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:560
 msgid "Performance"
 msgstr "性能"
 
@@ -5831,7 +5831,7 @@ msgstr "选择预设主题或导入自定义主题。"
 #: src/components/layout/site-header.tsx:36
 #: src/components/sidebar/navbar.tsx:30
 #: src/lib/menu-list.ts:70
-#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:396
+#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:413
 msgid "Pipeline"
 msgstr "处理管道"
 
@@ -6332,7 +6332,7 @@ msgstr "画质设置"
 msgid "Query Parameters"
 msgstr "查询参数"
 
-#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:558
+#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:575
 msgid "Queue"
 msgstr "队列"
 
@@ -6670,7 +6670,7 @@ msgstr "分辨率变化"
 msgid "Resource Limits"
 msgstr "资源限制"
 
-#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:410
+#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:427
 msgid "Resources"
 msgstr "资源"
 
@@ -6736,7 +6736,7 @@ msgstr "重试延迟（ms）"
 msgid "Retry Delay Base (ms)"
 msgstr "重试延迟基数（毫秒）"
 
-#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:327
+#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:344
 msgid "Retry Job"
 msgstr "重试处理任务"
 
@@ -7292,7 +7292,7 @@ msgid "SESSION ENDED"
 msgstr "会话已结束"
 
 #: src/components/pipeline/presets/processors/execute-config-form.tsx:140
-#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:383
+#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:400
 msgid "Session ID"
 msgstr "录制会话 ID"
 
@@ -7435,7 +7435,7 @@ msgstr "达到时长后跳过"
 msgid "Skip Interactive Games"
 msgstr "跳过互动玩法"
 
-#: src/components/pipeline/jobs/job-uploads-card.tsx:58
+#: src/components/pipeline/jobs/job-uploads-card.tsx:54
 msgid "Skipped"
 msgstr "已跳过"
 
@@ -7486,7 +7486,7 @@ msgid "Specify preferred content delivery network (e.g., ws-h5, hw-h5)."
 msgstr "指定首选的内容分发网络（例如 ws-h5, hw-h5）。"
 
 #: src/components/streamers/edit/active-download-card.tsx:125
-#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:568
+#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:585
 msgid "Speed"
 msgstr "速度"
 
@@ -7537,7 +7537,7 @@ msgstr "开始时间"
 #: src/components/pipeline/jobs/pipeline-summary-card.tsx:253
 #: src/components/sessions/overview-tab.tsx:217
 #: src/routes/_authed/_dashboard/pipeline/executions.$pipelineId.lazy.tsx:294
-#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:598
+#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:615
 msgid "Started"
 msgstr "已开始"
 
@@ -7669,7 +7669,7 @@ msgid "Streamer deleted"
 msgstr "主播已删除"
 
 #: src/components/pipeline/presets/processors/execute-config-form.tsx:133
-#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:389
+#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:406
 msgid "Streamer ID"
 msgstr "主播 ID"
 
@@ -8190,7 +8190,7 @@ msgstr "高频词"
 msgid "total"
 msgstr "总计"
 
-#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:695
+#: src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx:712
 msgid "Total"
 msgstr "总计"
 
@@ -8460,7 +8460,7 @@ msgstr "未知的引擎类型：{engineType}"
 msgid "Unknown error"
 msgstr "未知错误"
 
-#: src/components/pipeline/outputs/output-card.tsx:77
+#: src/components/pipeline/outputs/output-card.tsx:76
 msgid "Unknown File"
 msgstr "未知文件"
 
@@ -8501,7 +8501,7 @@ msgstr "已更新"
 msgid "Updates existing items and creates new ones. Nothing is deleted."
 msgstr "更新现有项目并创建新项目，不会删除任何内容。"
 
-#: src/components/streamers/card/upload-indicator.tsx:54
+#: src/components/streamers/card/upload-indicator.tsx:56
 msgid "upload"
 msgstr "上传"
 
@@ -8541,7 +8541,7 @@ msgstr "使用 rclone 将文件上传到云存储。在 rclone 配置中设置�
 msgid "Upload skipped via {0}"
 msgstr "通过 {0} 跳过了上传"
 
-#: src/components/pipeline/jobs/job-uploads-card.tsx:54
+#: src/components/pipeline/jobs/job-uploads-card.tsx:50
 msgid "Uploaded"
 msgstr "已上传"
 
@@ -8550,7 +8550,7 @@ msgstr "已上传"
 msgid "Uploaded via {0}"
 msgstr "已通过 {0} 上传"
 
-#: src/components/pipeline/jobs/job-uploads-card.tsx:87
+#: src/components/pipeline/jobs/job-uploads-card.tsx:81
 msgid "Uploads"
 msgstr "上传记录"
 

--- a/rust-srec/frontend/src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx
+++ b/rust-srec/frontend/src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx
@@ -109,6 +109,23 @@ function JobDetailsPage() {
   });
   const uploadRecords = uploadsData?.items ?? [];
 
+  // The backend writes upload_records after flipping the job terminal, and
+  // turning refetchInterval off does not trigger a final fetch — so the last
+  // interval fetch predates the records. Refetch once on the terminal
+  // transition so the Uploads card appears without a remount.
+  const jobStatus = job?.status;
+  useEffect(() => {
+    if (
+      jobStatus === 'COMPLETED' ||
+      jobStatus === 'FAILED' ||
+      jobStatus === 'CANCELLED'
+    ) {
+      void queryClient.invalidateQueries({
+        queryKey: ['pipeline', 'job', jobId, 'uploads'],
+      });
+    }
+  }, [jobStatus, jobId, queryClient]);
+
   // Fetch logs separately with infinite scroll
   const {
     data: logsData,

--- a/rust-srec/frontend/src/store/uploads.ts
+++ b/rust-srec/frontend/src/store/uploads.ts
@@ -59,6 +59,12 @@ function isFresh(view: UploadView, nowMs: number): boolean {
 
 interface UploadStoreState {
   uploadsByJobId: Map<string, UploadView>;
+  // Jobs that received UPLOAD_TERMINAL. Progress flows through the server's
+  // async coalescing channel, so a late UPLOAD_PROGRESS can arrive after the
+  // terminal event; without this guard it would resurrect the removed entry
+  // (same rationale as terminatedIds in store/downloads.ts). Cleared on
+  // snapshot/clearAll.
+  terminatedIds: Set<string>;
   // Bumps on any mutation; can be selected to force rerenders.
   version: number;
 
@@ -76,11 +82,13 @@ interface UploadStoreState {
 
 export const useUploadStore = create<UploadStoreState>((set, get) => ({
   uploadsByJobId: new Map(),
+  terminatedIds: new Set(),
   version: 0,
 
   setSnapshot: (uploads, progress) =>
     set((state) => {
       state.uploadsByJobId.clear();
+      state.terminatedIds.clear();
       const now = Date.now();
       for (const started of uploads) {
         state.uploadsByJobId.set(started.jobId, {
@@ -96,24 +104,31 @@ export const useUploadStore = create<UploadStoreState>((set, get) => ({
       }
       return {
         uploadsByJobId: state.uploadsByJobId,
+        terminatedIds: state.terminatedIds,
         version: state.version + 1,
       };
     }),
 
   upsertStarted: (started) =>
     set((state) => {
+      // A retried job reuses its job id, and STARTED is only ever emitted
+      // after the previous run's terminal event (same broadcast channel,
+      // FIFO per connection) — so STARTED authoritatively un-terminates.
+      state.terminatedIds.delete(started.jobId);
       state.uploadsByJobId.set(started.jobId, {
         ...started,
         lastEventAtMs: Date.now(),
       });
       return {
         uploadsByJobId: state.uploadsByJobId,
+        terminatedIds: state.terminatedIds,
         version: state.version + 1,
       };
     }),
 
   upsertProgress: (progress) =>
     set((state) => {
+      if (state.terminatedIds.has(progress.jobId)) return state;
       const existing = state.uploadsByJobId.get(progress.jobId);
       if (existing) {
         state.uploadsByJobId.set(progress.jobId, {
@@ -142,9 +157,11 @@ export const useUploadStore = create<UploadStoreState>((set, get) => ({
 
   remove: (jobId) =>
     set((state) => {
+      state.terminatedIds.add(jobId);
       if (!state.uploadsByJobId.delete(jobId)) return state;
       return {
         uploadsByJobId: state.uploadsByJobId,
+        terminatedIds: state.terminatedIds,
         version: state.version + 1,
       };
     }),
@@ -152,8 +169,10 @@ export const useUploadStore = create<UploadStoreState>((set, get) => ({
   clearAll: () =>
     set((state) => {
       state.uploadsByJobId.clear();
+      state.terminatedIds.clear();
       return {
         uploadsByJobId: state.uploadsByJobId,
+        terminatedIds: state.terminatedIds,
         version: state.version + 1,
       };
     }),
@@ -169,3 +188,28 @@ export const useUploadStore = create<UploadStoreState>((set, get) => ({
     return result;
   },
 }));
+
+// Selectors only re-run on store mutations, so without a sweep an entry
+// whose terminal event was dropped by broadcast lag would keep its badge
+// (and its map slot) forever once events stop arriving. The sweep deletes
+// stale entries and bumps `version` so subscribers re-render. Interval is
+// coarse on purpose: STALE_AFTER_MS is minutes, cadence needn't be finer.
+const STALE_SWEEP_INTERVAL_MS = 30 * 1000;
+
+if (typeof window !== 'undefined') {
+  setInterval(() => {
+    const { uploadsByJobId, version } = useUploadStore.getState();
+    if (uploadsByJobId.size === 0) return;
+    const now = Date.now();
+    let removed = false;
+    for (const [jobId, view] of uploadsByJobId) {
+      if (!isFresh(view, now)) {
+        uploadsByJobId.delete(jobId);
+        removed = true;
+      }
+    }
+    if (removed) {
+      useUploadStore.setState({ uploadsByJobId, version: version + 1 });
+    }
+  }, STALE_SWEEP_INTERVAL_MS);
+}

--- a/rust-srec/migrations/20260726000000_clear_terminal_job_progress.sql
+++ b/rust-srec/migrations/20260726000000_clear_terminal_job_progress.sql
@@ -7,9 +7,9 @@
 --
 -- A trigger (rather than per-call cleanup in JobQueue) covers every terminal
 -- path with one definition: complete, fail, cancel, bulk pipeline cancels,
--- and DAG fail-fast cancellations. The progress aggregator's flush-time
--- liveness check prevents an in-flight snapshot from re-inserting the row
--- after this fires.
+-- and DAG fail-fast cancellations. An in-flight snapshot cannot re-insert
+-- the row after this fires: upsert_job_execution_progress only inserts
+-- while job.status is still PROCESSING, atomically with the write.
 CREATE TRIGGER trg_job_terminal_clears_progress
 AFTER UPDATE OF status ON job
 WHEN NEW.status IN ('COMPLETED', 'FAILED', 'CANCELLED')

--- a/rust-srec/migrations/20260726000000_clear_terminal_job_progress.sql
+++ b/rust-srec/migrations/20260726000000_clear_terminal_job_progress.sql
@@ -1,0 +1,26 @@
+-- Drop a job's live-progress snapshot the moment the job reaches a terminal
+-- state. job_execution_progress rows only mean anything while the job is
+-- PROCESSING (the API's progress endpoint is polled only then); a leftover
+-- terminal row is dead data at best and misleading at worst (a FAILED job
+-- frozen at "42%"). Counterpart of trg_job_reset_clears_progress, which
+-- clears the row on the way back to PENDING.
+--
+-- A trigger (rather than per-call cleanup in JobQueue) covers every terminal
+-- path with one definition: complete, fail, cancel, bulk pipeline cancels,
+-- and DAG fail-fast cancellations. The progress aggregator's flush-time
+-- liveness check prevents an in-flight snapshot from re-inserting the row
+-- after this fires.
+CREATE TRIGGER trg_job_terminal_clears_progress
+AFTER UPDATE OF status ON job
+WHEN NEW.status IN ('COMPLETED', 'FAILED', 'CANCELLED')
+     AND OLD.status NOT IN ('COMPLETED', 'FAILED', 'CANCELLED')
+BEGIN
+    DELETE FROM job_execution_progress WHERE job_id = NEW.id;
+END;
+
+-- One-time sweep of rows that terminal jobs left behind before this trigger
+-- existed.
+DELETE FROM job_execution_progress
+WHERE job_id IN (
+    SELECT id FROM job WHERE status IN ('COMPLETED', 'FAILED', 'CANCELLED')
+);

--- a/rust-srec/src/api/models.rs
+++ b/rust-srec/src/api/models.rs
@@ -753,7 +753,7 @@ pub struct MediaOutputResponse {
     /// per uploader, newest record wins (DAG retries produce rows under
     /// fresh job ids). Empty (and omitted from JSON) when the file was
     /// never part of an upload job.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub uploads: Vec<MediaOutputUploadInfo>,
 }
 

--- a/rust-srec/src/api/routes/downloads.rs
+++ b/rust-srec/src/api/routes/downloads.rs
@@ -144,7 +144,16 @@ async fn handle_socket(socket: WebSocket, state: DownloadRouteState) {
 
     let (mut sender, mut receiver) = socket.split();
 
-    // 1. Send initial snapshot as protobuf binary
+    // 1. Subscribe to the broadcasts BEFORE building the snapshot: receivers
+    // buffer from subscription time, so events that fire while the snapshot
+    // is assembled are delivered afterwards instead of being lost in the
+    // snapshot/subscribe gap (the snapshot is the only recovery path for a
+    // missed UploadStarted).
+    let mut event_rx = download_manager.subscribe();
+    let mut check_history_rx = state.check_history_broadcaster.subscribe();
+    let mut upload_rx = state.upload_status_broadcaster.subscribe();
+
+    // 2. Send initial snapshot as protobuf binary
     let downloads = download_manager.get_active_downloads();
     let queued = download_manager.snapshot_pending();
     let uploads = snapshot_uploads(&state.pipeline_manager, &None).await;
@@ -159,12 +168,6 @@ async fn handle_socket(socket: WebSocket, state: DownloadRouteState) {
         debug!("Failed to send initial snapshot, client disconnected");
         return;
     }
-    // debug!("Sent initial snapshot with {} downloads", downloads.len());
-
-    // 2. Subscribe to broadcast
-    let mut event_rx = download_manager.subscribe();
-    let mut check_history_rx = state.check_history_broadcaster.subscribe();
-    let mut upload_rx = state.upload_status_broadcaster.subscribe();
 
     // 3. Track filter state and heartbeat
     let mut filter: Option<String> = None;
@@ -313,7 +316,7 @@ async fn handle_socket(socket: WebSocket, state: DownloadRouteState) {
             // Upload status events (started/progress/terminal), pre-encoded
             // once by the UploadStatusBroadcaster's encoder. Filtered against
             // the same per-connection streamer subscription as download
-            // events; uploads without a streamer pass any filter is None.
+            // events; streamer-less uploads pass only when no filter is set.
             envelope = upload_rx.recv() => {
                 match envelope {
                     Ok(envelope) => {

--- a/rust-srec/src/database/maintenance.rs
+++ b/rust-srec/src/database/maintenance.rs
@@ -859,10 +859,9 @@ mod tests {
     use super::*;
     use crate::database::models::{
         ChannelType, DagExecutionDbModel, DagStepExecutionDbModel, DagStepStatus, JobDbModel,
-        JobExecutionLogDbModel, JobExecutionProgressDbModel, LiveSessionDbModel, MediaFileType,
-        MediaOutputDbModel, NotificationChannelDbModel, NotificationDeadLetterDbModel,
-        NotificationEventLogDbModel, RefreshTokenDbModel, SessionEventDbModel,
-        SessionSegmentDbModel, StreamerDbModel,
+        JobExecutionLogDbModel, LiveSessionDbModel, MediaFileType, MediaOutputDbModel,
+        NotificationChannelDbModel, NotificationDeadLetterDbModel, NotificationEventLogDbModel,
+        RefreshTokenDbModel, SessionEventDbModel, SessionSegmentDbModel, StreamerDbModel,
     };
     use crate::database::repositories::{
         ConfigRepository as _, DagRepository as _, JobRepository as _, NotificationRepository as _,
@@ -1192,16 +1191,17 @@ mod tests {
             .add_execution_log(&log)
             .await
             .expect("job log");
-        database
-            .job_repository
-            .upsert_job_execution_progress(&JobExecutionProgressDbModel {
-                job_id: "old-completed".to_string(),
-                kind: "percent".to_string(),
-                progress: "{}".to_string(),
-                updated_at: old,
-            })
-            .await
-            .expect("job progress");
+        // Raw insert: the repository's upsert refuses rows for non-PROCESSING
+        // jobs, but this fixture needs one on a COMPLETED job to prove the
+        // FK cascade removes it together with the pruned job row.
+        sqlx::query(
+            "INSERT INTO job_execution_progress (job_id, kind, progress, updated_at) \
+             VALUES ('old-completed', 'percent', '{}', ?)",
+        )
+        .bind(old)
+        .execute(&database.pool)
+        .await
+        .expect("job progress");
 
         let user_id = "default-admin-00000000-0000-0000-0000-000000000001";
         for (id, expires_at, revoked_at) in [

--- a/rust-srec/src/database/models/upload_record.rs
+++ b/rust-srec/src/database/models/upload_record.rs
@@ -30,7 +30,7 @@ pub struct UploadRecordDbModel {
     /// Expanded remote destination (e.g. `remote:bucket/streamer/file.mp4`).
     /// NULL when the destination could not be computed (failure synthesis).
     pub remote_path: Option<String>,
-    /// One of [`status::ALL`]; the table CHECK constraint enforces it.
+    /// One of [`upload_status::ALL`]; the table CHECK constraint enforces it.
     pub status: String,
     pub size_bytes: Option<i64>,
     pub error: Option<String>,

--- a/rust-srec/src/database/repositories/job.rs
+++ b/rust-srec/src/database/repositories/job.rs
@@ -332,10 +332,17 @@ impl JobRepository for SqlxJobRepository {
         progress: &JobExecutionProgressDbModel,
     ) -> Result<()> {
         retry_on_sqlite_busy("upsert_job_execution_progress", || async {
+            // Guarded on the job still being PROCESSING, atomically with the
+            // write: the progress aggregator flushes asynchronously, so a
+            // snapshot can arrive here after the job's terminal transition
+            // already fired trg_job_terminal_clears_progress — an
+            // unconditional upsert would re-insert the row it just deleted
+            // and orphan it until job retention.
             sqlx::query(
                 r#"
                 INSERT INTO job_execution_progress (job_id, kind, progress, updated_at)
-                VALUES (?, ?, ?, ?)
+                SELECT ?, ?, ?, ?
+                WHERE (SELECT status FROM job WHERE id = ?) = 'PROCESSING'
                 ON CONFLICT(job_id) DO UPDATE SET
                     kind = excluded.kind,
                     progress = excluded.progress,
@@ -346,6 +353,7 @@ impl JobRepository for SqlxJobRepository {
             .bind(&progress.kind)
             .bind(&progress.progress)
             .bind(progress.updated_at)
+            .bind(&progress.job_id)
             .execute(&self.write_pool)
             .await?;
             Ok(())

--- a/rust-srec/src/database/repositories/upload_record.rs
+++ b/rust-srec/src/database/repositories/upload_record.rs
@@ -57,10 +57,11 @@ pub trait UploadRecordRepository: Send + Sync {
     /// All records for one job, ordered by local path.
     async fn list_by_job(&self, job_id: &str) -> Result<Vec<UploadRecordDbModel>>;
 
-    /// Records whose `local_path` is in `paths`, newest-updated first.
-    /// Callers dedupe per `(local_path, uploader)` if they need one row per
-    /// file (DAG retries create fresh job ids, so a file can have rows from
-    /// several jobs).
+    /// Records whose `local_path` is in `paths`, newest-updated first within
+    /// each chunk of up to `LOCAL_PATH_CHUNK` paths (a single path never
+    /// spans chunks, so per-path ordering always holds). Callers dedupe per
+    /// `(local_path, uploader)` if they need one row per file (DAG retries
+    /// create fresh job ids, so a file can have rows from several jobs).
     async fn list_by_local_paths(&self, paths: &[String]) -> Result<Vec<UploadRecordDbModel>>;
 }
 

--- a/rust-srec/src/pipeline/job_queue.rs
+++ b/rust-srec/src/pipeline/job_queue.rs
@@ -2379,6 +2379,21 @@ fn spawn_progress_aggregator(
                         continue;
                     }
                     for (job_id, snapshot) in pending.drain() {
+                        // A job can reach a terminal state between receive and
+                        // this flush tick. The terminal status transition fires
+                        // trg_job_terminal_clears_progress, so persisting now
+                        // would resurrect a row that stays orphaned until job
+                        // retention; likewise the terminal WS event has already
+                        // been broadcast. cancel_job cancels the token before
+                        // the worker finalizes, hence the is_cancelled check on
+                        // top of plain presence.
+                        let job_is_live = cancellation_tokens
+                            .get(&job_id)
+                            .is_some_and(|token| !token.is_cancelled());
+                        if !job_is_live {
+                            continue;
+                        }
+
                         // Rclone is the only upload progress emitter (see
                         // RcloneProcessor / run_rclone_with_progress), so its
                         // snapshots double as live upload-status WS events.
@@ -2422,8 +2437,13 @@ fn spawn_progress_aggregator(
                     let Some(update) = update else { break; };
                     // Only retain/persist progress for actively-processing jobs. This prevents
                     // late progress messages (after completion/cancellation) from reintroducing
-                    // entries into the in-memory cache.
-                    if !cancellation_tokens.contains_key(&update.job_id) {
+                    // entries into the in-memory cache. The token is also checked for
+                    // cancellation: cancel_job cancels it but leaves it in the map until the
+                    // worker calls finalize_cancelled_job.
+                    let job_is_live = cancellation_tokens
+                        .get(&update.job_id)
+                        .is_some_and(|token| !token.is_cancelled());
+                    if !job_is_live {
                         continue;
                     }
                     progress_cache.insert(update.job_id.clone(), update.snapshot.clone());
@@ -2880,6 +2900,79 @@ mod tests {
             .await
             .unwrap();
         assert!(upload_repo.list_by_job(&remux_id).await.unwrap().is_empty());
+    }
+
+    /// Every terminal status transition must clear the job's persisted
+    /// progress row via `trg_job_terminal_clears_progress` — a snapshot only
+    /// means anything while the job is PROCESSING, and a leftover row would
+    /// otherwise linger until job retention prunes the job itself.
+    #[tokio::test]
+    async fn test_terminal_transition_clears_persisted_progress() {
+        async fn progress_count(pool: &sqlx::SqlitePool, job_id: &str) -> i64 {
+            sqlx::query_scalar("SELECT COUNT(*) FROM job_execution_progress WHERE job_id = ?")
+                .bind(job_id)
+                .fetch_one(pool)
+                .await
+                .unwrap()
+        }
+
+        async fn seed_progress(repo: &Arc<dyn JobRepository>, job_id: &str) {
+            repo.upsert_job_execution_progress(&JobExecutionProgressDbModel {
+                job_id: job_id.to_string(),
+                kind: "ffmpeg".to_string(),
+                progress: "{}".to_string(),
+                updated_at: 1,
+            })
+            .await
+            .unwrap();
+        }
+
+        let pool = crate::database::init_pool_with_size("sqlite::memory:", 1)
+            .await
+            .unwrap();
+        crate::database::run_migrations(&pool).await.unwrap();
+
+        let job_repo: Arc<dyn JobRepository> = Arc::new(
+            crate::database::repositories::job::SqlxJobRepository::new(pool.clone(), pool.clone()),
+        );
+        let queue = JobQueue::with_repository(JobQueueConfig::default(), job_repo.clone());
+
+        // COMPLETED clears the row.
+        let completed = Job::new("remux", vec!["/in.mp4".to_string()], vec![], "", "");
+        let completed_id = queue.enqueue(completed).await.unwrap();
+        queue.dequeue(None).await.unwrap().unwrap();
+        seed_progress(&job_repo, &completed_id).await;
+        assert_eq!(progress_count(&pool, &completed_id).await, 1);
+        queue
+            .complete(
+                &completed_id,
+                JobResult {
+                    outputs: vec![],
+                    duration_secs: 1.0,
+                    metadata: None,
+                    uploads: vec![],
+                    logs: vec![],
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(progress_count(&pool, &completed_id).await, 0);
+
+        // FAILED clears the row.
+        let failed = Job::new("remux", vec!["/in.mp4".to_string()], vec![], "", "");
+        let failed_id = queue.enqueue(failed).await.unwrap();
+        queue.dequeue(None).await.unwrap().unwrap();
+        seed_progress(&job_repo, &failed_id).await;
+        queue.fail(&failed_id, "boom").await.unwrap();
+        assert_eq!(progress_count(&pool, &failed_id).await, 0);
+
+        // CANCELLED clears the row.
+        let cancelled = Job::new("remux", vec!["/in.mp4".to_string()], vec![], "", "");
+        let cancelled_id = queue.enqueue(cancelled).await.unwrap();
+        queue.dequeue(None).await.unwrap().unwrap();
+        seed_progress(&job_repo, &cancelled_id).await;
+        queue.cancel_job(&cancelled_id).await.unwrap();
+        assert_eq!(progress_count(&pool, &cancelled_id).await, 0);
     }
 
     #[test]

--- a/rust-srec/src/pipeline/job_queue.rs
+++ b/rust-srec/src/pipeline/job_queue.rs
@@ -691,6 +691,24 @@ impl JobQueue {
         });
     }
 
+    /// Publish `Terminal { Cancelled }` when the job is an upload job.
+    /// Cancellation produces no per-file records (the job's CANCELLED status
+    /// is the durable truth), so the file counters are zero by construction.
+    fn emit_upload_cancelled(&self, job_id: &str, job_type: &str, streamer_id: &str) {
+        if upload_kind_for_job_type(job_type).is_none() {
+            return;
+        }
+        self.emit_upload_event(UploadStatusEvent::Terminal {
+            job_id: job_id.to_string(),
+            streamer_id: non_empty(streamer_id),
+            status: UploadTerminalStatus::Cancelled,
+            files_succeeded: 0,
+            files_failed: 0,
+            files_skipped: 0,
+            error: None,
+        });
+    }
+
     /// Persist per-file upload results to `upload_records`.
     ///
     /// Best-effort, same policy as `persist_thumbnail_output`: a bookkeeping
@@ -1309,10 +1327,14 @@ impl JobQueue {
 
         // Persist per-file upload results and broadcast the terminal event
         // for upload job types (persist_upload_records itself no-ops for
-        // everything else).
-        if let Some(job_type) = completed_job_type
-            .as_deref()
-            .filter(|jt| upload_kind_for_job_type(jt).is_some())
+        // everything else). Gated on `transitioned`, matching fail_internal
+        // and cancel_job: in the repository-less queue a complete() racing a
+        // cancel must not persist COMPLETED records or emit
+        // Terminal{Completed} after Terminal{Cancelled}.
+        if transitioned
+            && let Some(job_type) = completed_job_type
+                .as_deref()
+                .filter(|jt| upload_kind_for_job_type(jt).is_some())
         {
             self.persist_upload_records(
                 job_id,
@@ -1684,17 +1706,7 @@ impl JobQueue {
 
             // job was fetched before the transition, so its type/streamer
             // fields are intact even though the cache entry is gone now.
-            if upload_kind_for_job_type(&job.job_type).is_some() {
-                self.emit_upload_event(UploadStatusEvent::Terminal {
-                    job_id: id.to_string(),
-                    streamer_id: non_empty(&job.streamer_id),
-                    status: UploadTerminalStatus::Cancelled,
-                    files_succeeded: 0,
-                    files_failed: 0,
-                    files_skipped: 0,
-                    error: None,
-                });
-            }
+            self.emit_upload_cancelled(id, &job.job_type, &job.streamer_id);
         }
 
         info!("Job {} cancelled", id);
@@ -1851,17 +1863,7 @@ impl JobQueue {
         }
 
         for job in &cancelled_jobs {
-            if upload_kind_for_job_type(&job.job_type).is_some() {
-                self.emit_upload_event(UploadStatusEvent::Terminal {
-                    job_id: job.id.clone(),
-                    streamer_id: non_empty(&job.streamer_id),
-                    status: UploadTerminalStatus::Cancelled,
-                    files_succeeded: 0,
-                    files_failed: 0,
-                    files_skipped: 0,
-                    error: None,
-                });
-            }
+            self.emit_upload_cancelled(&job.id, &job.job_type, &job.streamer_id);
         }
 
         info!(
@@ -2381,12 +2383,14 @@ fn spawn_progress_aggregator(
                     for (job_id, snapshot) in pending.drain() {
                         // A job can reach a terminal state between receive and
                         // this flush tick. The terminal status transition fires
-                        // trg_job_terminal_clears_progress, so persisting now
-                        // would resurrect a row that stays orphaned until job
-                        // retention; likewise the terminal WS event has already
-                        // been broadcast. cancel_job cancels the token before
-                        // the worker finalizes, hence the is_cancelled check on
-                        // top of plain presence.
+                        // trg_job_terminal_clears_progress and broadcasts the
+                        // terminal WS event, so this snapshot must be dropped.
+                        // This check narrows the race; the DB write is closed
+                        // for good by upsert_job_execution_progress, which
+                        // inserts only while job.status is still PROCESSING.
+                        // cancel_job cancels the token before the worker
+                        // finalizes, hence the is_cancelled check on top of
+                        // plain presence.
                         let job_is_live = cancellation_tokens
                             .get(&job_id)
                             .is_some_and(|token| !token.is_cancelled());
@@ -2399,8 +2403,12 @@ fn spawn_progress_aggregator(
                         // snapshots double as live upload-status WS events.
                         // Publishing on the flush tick reuses this loop's
                         // coalescing instead of adding a second throttle.
+                        // has_subscribers first: without it the jobs_cache
+                        // lookup and snapshot clone (including its raw JSON
+                        // tree) would run on every flush of an idle deployment.
                         if matches!(snapshot.kind, ProgressKind::Rclone)
                             && let Some(broadcaster) = upload_broadcaster.get()
+                            && broadcaster.has_subscribers()
                         {
                             let streamer_id = jobs_cache
                                 .get(&job_id)
@@ -2956,6 +2964,11 @@ mod tests {
             )
             .await
             .unwrap();
+        assert_eq!(progress_count(&pool, &completed_id).await, 0);
+
+        // A late aggregator flush cannot resurrect the row: the upsert
+        // inserts only while the job is still PROCESSING.
+        seed_progress(&job_repo, &completed_id).await;
         assert_eq!(progress_count(&pool, &completed_id).await, 0);
 
         // FAILED clears the row.

--- a/rust-srec/src/pipeline/upload_events.rs
+++ b/rust-srec/src/pipeline/upload_events.rs
@@ -115,6 +115,14 @@ impl UploadStatusBroadcaster {
         self.tx.subscribe()
     }
 
+    /// True when at least one WS connection is subscribed. `send` already
+    /// early-returns without one, but producers on hot paths (the progress
+    /// aggregator flush) check this first to skip building the event —
+    /// cloning a `JobProgressSnapshot` and its `raw` JSON tree — at all.
+    pub fn has_subscribers(&self) -> bool {
+        self.tx.receiver_count() > 0
+    }
+
     /// Encode once and fan out. No subscribers → no encode, no send; an
     /// idle or headless deployment pays nothing on the job hot path.
     pub fn send(&self, event: UploadStatusEvent) {


### PR DESCRIPTION
## Summary

Follow-up to #702. A `job_execution_progress` row is only meaningful while its job is PROCESSING (the frontend polls `/api/pipeline/jobs/{id}/progress` only in that state), but rows survived terminal transitions and lingered until job retention pruned the job itself — leaving, e.g., a FAILED job frozen at a stale "42%".

- **New trigger `trg_job_terminal_clears_progress`**: deletes the job's progress row when `job.status` transitions into `COMPLETED`/`FAILED`/`CANCELLED`. One definition covers every terminal path — complete, fail, cancel, bulk pipeline cancels, and DAG fail-fast cancellations — mirroring the existing `trg_job_reset_clears_progress` (which handles the way back to `PENDING`). The migration also does a one-time sweep of rows left behind by jobs that reached terminal states before the trigger existed.
- **Flush-time liveness check in the progress aggregator**: a snapshot received just before the terminal transition could otherwise be flushed ~250ms later and re-insert the row after the trigger fired (orphaning it until retention). The aggregator now re-checks the job's cancellation token at flush time — treating a cancelled-but-not-yet-finalized token as dead — and skips both the DB upsert and the upload-progress WS publish for jobs that are no longer live. (Targets `dev` because this check depends on the Arc-shared aggregator maps from #702.)

No API or UI changes: the progress endpoint already returned nothing useful for terminal jobs as far as the UI is concerned, and terminal upload state is served by `upload_records`.

## Testing

- New test `test_terminal_transition_clears_persisted_progress` covers all three terminal transitions (complete / fail / cancel) against a real migrated SQLite DB.
- `cargo nextest run -p rust-srec`: 1462 passed. `cargo clippy --all-targets` clean.