### PR TITLE
fix(frontend): preserve preset processor on reset

### DIFF
--- a/rust-srec/frontend/src/components/pipeline/presets/__tests__/preset-processor-select.test.tsx
+++ b/rust-srec/frontend/src/components/pipeline/presets/__tests__/preset-processor-select.test.tsx
@@ -1,0 +1,87 @@
+import { setupI18n } from '@lingui/core';
+import { I18nProvider } from '@lingui/react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { useEffect } from 'react';
+import type { PropsWithChildren } from 'react';
+import { useForm } from 'react-hook-form';
+
+import { Form } from '@/components/ui/form';
+import { PresetMetaForm } from '../editor/preset-meta-form';
+
+vi.mock('@tanstack/react-router', () => ({
+  Link: ({ children }: PropsWithChildren) => <a href="#">{children}</a>,
+}));
+
+vi.mock('motion/react', () => ({
+  motion: {
+    div: ({ children }: PropsWithChildren) => <div>{children}</div>,
+  },
+}));
+
+interface PresetValues {
+  id: string;
+  name: string;
+  description: string;
+  category: string;
+  processor: string;
+  config: Record<string, unknown>;
+}
+
+const i18n = setupI18n({ locale: 'en', messages: { en: {} } });
+
+function PresetMetaFormHarness() {
+  const form = useForm<PresetValues>({
+    defaultValues: {
+      id: '',
+      name: '',
+      description: '',
+      category: '',
+      processor: 'remux',
+      config: { mode: 'copy' },
+    },
+  });
+  const processor = form.watch('processor');
+
+  useEffect(() => {
+    form.reset({
+      id: 'preset-default-metadata',
+      name: 'add_metadata',
+      description: 'Add metadata',
+      category: 'metadata',
+      processor: 'metadata',
+      config: { title: 'Example' },
+    });
+  }, [form]);
+
+  return (
+    <I18nProvider i18n={i18n}>
+      <Form {...form}>
+        <form>
+          <PresetMetaForm
+            form={form}
+            initialData={{ id: 'preset-default-metadata' }}
+            title="Edit preset"
+            isUpdating={false}
+          />
+          <output data-testid="processor">{processor}</output>
+          <output data-testid="config">
+            {JSON.stringify(form.watch('config'))}
+          </output>
+        </form>
+      </Form>
+    </I18nProvider>
+  );
+}
+
+describe('preset processor select', () => {
+  it('preserves reset processor and config values', async () => {
+    render(<PresetMetaFormHarness />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('processor')).toHaveTextContent('metadata');
+    });
+    expect(screen.getByTestId('config')).toHaveTextContent(
+      JSON.stringify({ title: 'Example' }),
+    );
+  });
+});

--- a/rust-srec/frontend/src/components/pipeline/presets/editor/preset-meta-form.tsx
+++ b/rust-srec/frontend/src/components/pipeline/presets/editor/preset-meta-form.tsx
@@ -95,6 +95,9 @@ export function PresetMetaForm({
   const CurrentIcon = selectedOption?.icon || Settings2;
 
   const handleProcessorChange = (value: string) => {
+    // Radix's hidden native select can emit an empty value while reset() registers its options.
+    if (!value) return;
+
     form.setValue('processor', value);
     // Reset config when processor type changes to avoid stale config from previous type
     form.setValue('config', {});


### PR DESCRIPTION
## Summary

- preserve the loaded processor and configuration when editing pipeline presets
- add a regression test covering form resets with the controlled processor select

## Root cause

Radix's hidden native select can emit a temporary empty value while React Hook Form resets the preset and registers select options. The processor change handler treated that transition as a user selection, clearing both the processor and its configuration.

## Impact

Pipeline preset editors now render the correct processor configuration instead of showing "No configuration available for this processor."

## Validation

- `pnpm test` (107 tests)
- `pnpm run lint`
- `pnpm run build`
- `pnpm exec oxfmt --check src/components/pipeline/presets/editor/preset-meta-form.tsx src/components/pipeline/presets/__tests__/preset-processor-select.test.tsx`
