### PR TITLE
fix(pipeline): upload record attribution, persistence ordering, and refetch races

### DIFF
--- a/rust-srec/frontend/src/providers/WebSocketProvider.tsx
+++ b/rust-srec/frontend/src/providers/WebSocketProvider.tsx
@@ -167,7 +167,16 @@ export function WebSocketProvider({ children }: { children: ReactNode }) {
             // Terminal event - drop the live indicator. Durable per-file
             // results are served by the job uploads REST endpoint.
             if (message.payload.case === 'uploadTerminal') {
-              removeUpload(message.payload.value.jobId);
+              const jobId = message.payload.value.jobId;
+              removeUpload(jobId);
+              // The backend persists upload_records before broadcasting this
+              // event, so it is the reliable signal that the job's uploads
+              // endpoint now returns the final rows. The job detail page's
+              // status-driven invalidation can race the insert (the job row
+              // flips terminal first); this one cannot.
+              void queryClient.invalidateQueries({
+                queryKey: ['pipeline', 'job', jobId, 'uploads'],
+              });
             }
             break;
 

--- a/rust-srec/frontend/src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx
+++ b/rust-srec/frontend/src/routes/_authed/_dashboard/pipeline/jobs/$jobId.lazy.tsx
@@ -109,10 +109,12 @@ function JobDetailsPage() {
   });
   const uploadRecords = uploadsData?.items ?? [];
 
-  // The backend writes upload_records after flipping the job terminal, and
-  // turning refetchInterval off does not trigger a final fetch — so the last
-  // interval fetch predates the records. Refetch once on the terminal
-  // transition so the Uploads card appears without a remount.
+  // Refetch once when the job turns terminal: turning refetchInterval off
+  // does not trigger a final fetch. This is only a fallback for when the
+  // WebSocket is down — the job row flips terminal before upload_records
+  // are written, so this fetch can race the insert. The authoritative
+  // refetch comes from WebSocketProvider, which invalidates this query on
+  // UploadTerminal (broadcast only after the records are persisted).
   const jobStatus = job?.status;
   useEffect(() => {
     if (

--- a/rust-srec/src/api/routes/pipeline/jobs.rs
+++ b/rust-srec/src/api/routes/pipeline/jobs.rs
@@ -596,24 +596,36 @@ pub async fn list_outputs(
     };
 
     // Annotate outputs with their upload results: one batched lookup for the
-    // whole page (≤100 paths), grouped per local_path. DAG retries create
-    // fresh job ids, so the same (path, uploader) pair can have several rows
-    // — keep only the newest (list_by_local_paths orders updated_at DESC).
+    // whole page (≤100 paths), then grouped per (session_id, local_path) —
+    // media_outputs.file_path is not unique across sessions, so a path match
+    // alone could pin another session's upload onto this output. Records
+    // without a session (manually enqueued jobs) are skipped for the same
+    // reason. DAG retries create fresh job ids, so the same
+    // (session, path, uploader) triple can have several rows — keep only the
+    // newest (list_by_local_paths orders updated_at DESC per path).
     let output_paths: Vec<String> = outputs.iter().map(|o| o.file_path.clone()).collect();
-    let mut uploads_by_path: HashMap<String, Vec<MediaOutputUploadInfo>> = HashMap::new();
+    let mut uploads_by_session_path: HashMap<(String, String), Vec<MediaOutputUploadInfo>> =
+        HashMap::new();
     match state
         .upload_record_repository
         .list_by_local_paths(&output_paths)
         .await
     {
         Ok(records) => {
-            let mut seen: HashSet<(String, String)> = HashSet::new();
+            let mut seen: HashSet<(String, String, String)> = HashSet::new();
             for record in records {
-                if !seen.insert((record.local_path.clone(), record.uploader.clone())) {
+                let Some(session_id) = record.session_id else {
+                    continue;
+                };
+                if !seen.insert((
+                    session_id.clone(),
+                    record.local_path.clone(),
+                    record.uploader.clone(),
+                )) {
                     continue;
                 }
-                uploads_by_path
-                    .entry(record.local_path)
+                uploads_by_session_path
+                    .entry((session_id, record.local_path))
                     .or_default()
                     .push(MediaOutputUploadInfo {
                         uploader: record.uploader,
@@ -653,8 +665,11 @@ pub async fn list_outputs(
                 duration_secs: None, // Not stored in current model
                 format: output.file_type.clone(),
                 created_at,
-                uploads: uploads_by_path
-                    .remove(&output.file_path)
+                // get + clone rather than remove: duplicate rows for the same
+                // (session, path) must each carry the annotation.
+                uploads: uploads_by_session_path
+                    .get(&(output.session_id.clone(), output.file_path.clone()))
+                    .cloned()
                     .unwrap_or_default(),
             }
         })

--- a/rust-srec/src/pipeline/job_queue.rs
+++ b/rust-srec/src/pipeline/job_queue.rs
@@ -2215,11 +2215,18 @@ impl JobQueue {
         let mut transitioned = false;
 
         // Upload context must be read before the cache cleanup below evicts
-        // the job. (streamer_id, files_total) for the Terminal event; None
-        // for non-upload job types.
+        // the job: the FAILED-record synthesis and Terminal event need the
+        // job's type, streamer/session, and input paths. None for non-upload
+        // job types.
         let upload_ctx = self.jobs_cache.get(job_id).and_then(|job| {
-            upload_kind_for_job_type(&job.job_type)
-                .map(|_| (non_empty(&job.streamer_id), job.inputs.len() as u32))
+            upload_kind_for_job_type(&job.job_type).map(|_| {
+                (
+                    job.job_type.clone(),
+                    non_empty(&job.streamer_id),
+                    non_empty(&job.session_id),
+                    job.inputs.clone(),
+                )
+            })
         });
 
         // Update database if repository is available
@@ -2303,13 +2310,44 @@ impl JobQueue {
         if transitioned {
             self.decrement_depth(1);
 
-            if let Some((streamer_id, files_total)) = upload_ctx {
+            if let Some((job_type, streamer_id, session_id, inputs)) = upload_ctx {
+                // A failing processor returns Err with no ProcessorOutput, so
+                // the per-file results it computed are lost; every input is
+                // recorded FAILED instead. Deliberately pessimistic: a retry
+                // upserts over these rows via the (job_id, local_path)
+                // conflict key, and RcloneProcessor's move-resume flips
+                // already-transferred files back to COMPLETED.
+                //
+                // Runs only after mark_job_failed's CAS confirmed the FAILED
+                // transition — a cancel that wins the race takes the early
+                // return above, so a CANCELLED job never gets FAILED rows.
+                // Persisted before the Terminal event: the frontend refetches
+                // records on UploadTerminal and must see the final rows.
+                let items: Vec<UploadResultItem> = inputs
+                    .iter()
+                    .map(|path| UploadResultItem {
+                        local_path: path.clone(),
+                        remote_path: None,
+                        size_bytes: None,
+                        status: UploadItemStatus::Failed,
+                        error: Some(error.to_string()),
+                    })
+                    .collect();
+                self.persist_upload_records(
+                    job_id,
+                    &job_type,
+                    streamer_id.as_deref(),
+                    session_id.as_deref(),
+                    &items,
+                )
+                .await;
+
                 self.emit_upload_event(UploadStatusEvent::Terminal {
                     job_id: job_id.to_string(),
                     streamer_id,
                     status: UploadTerminalStatus::Failed,
                     files_succeeded: 0,
-                    files_failed: files_total,
+                    files_failed: items.len() as u32,
                     files_skipped: 0,
                     error: Some(error.to_string()),
                 });
@@ -2908,6 +2946,60 @@ mod tests {
             .await
             .unwrap();
         assert!(upload_repo.list_by_job(&remux_id).await.unwrap().is_empty());
+    }
+
+    /// `fail_internal` synthesizes FAILED records for upload jobs, but only
+    /// after `mark_job_failed`'s CAS confirms the transition — a job that was
+    /// cancelled first must never end up with FAILED rows.
+    #[tokio::test]
+    async fn test_fail_persists_failed_upload_records_only_on_transition() {
+        let pool = crate::database::init_pool_with_size("sqlite::memory:", 1)
+            .await
+            .unwrap();
+        crate::database::run_migrations(&pool).await.unwrap();
+
+        let job_repo: Arc<dyn JobRepository> = Arc::new(
+            crate::database::repositories::job::SqlxJobRepository::new(pool.clone(), pool.clone()),
+        );
+        let upload_repo = Arc::new(
+            crate::database::repositories::upload_record::SqlxUploadRecordRepository::new(
+                pool.clone(),
+                pool.clone(),
+            ),
+        );
+        let queue = JobQueue::with_repository(JobQueueConfig::default(), job_repo);
+        queue.set_upload_repo(upload_repo.clone());
+
+        // Failing a processing upload job records every input as FAILED.
+        let failed = Job::new(
+            "rclone",
+            vec!["/videos/a.mp4".to_string(), "/videos/b.mp4".to_string()],
+            vec![],
+            "",
+            "",
+        );
+        let failed_id = queue.enqueue(failed).await.unwrap();
+        queue.dequeue(None).await.unwrap().unwrap();
+        queue.fail(&failed_id, "network down").await.unwrap();
+        let rows = upload_repo.list_by_job(&failed_id).await.unwrap();
+        assert_eq!(rows.len(), 2);
+        assert!(rows.iter().all(|r| r.status == "FAILED"));
+        assert_eq!(rows[0].error.as_deref(), Some("network down"));
+
+        // A job cancelled before the fail attempt gets no rows: the FAILED
+        // CAS loses and fail_internal takes the early return.
+        let cancelled = Job::new("rclone", vec!["/videos/c.mp4".to_string()], vec![], "", "");
+        let cancelled_id = queue.enqueue(cancelled).await.unwrap();
+        queue.dequeue(None).await.unwrap().unwrap();
+        queue.cancel_job(&cancelled_id).await.unwrap();
+        queue.fail(&cancelled_id, "late failure").await.unwrap();
+        assert!(
+            upload_repo
+                .list_by_job(&cancelled_id)
+                .await
+                .unwrap()
+                .is_empty()
+        );
     }
 
     /// Every terminal status transition must clear the job's persisted

--- a/rust-srec/src/pipeline/worker_pool.rs
+++ b/rust-srec/src/pipeline/worker_pool.rs
@@ -12,50 +12,8 @@ use tracing::{debug, error, info, warn};
 use super::dag_scheduler::{
     DagCompletionInfo, DagJobCompletedUpdate, DagJobFailedUpdate, DagScheduler,
 };
-use super::job_queue::{JobExecutionInfo, JobQueue, JobResult, upload_kind_for_job_type};
-use super::processors::{
-    JobLogSink, Processor, ProcessorContext, ProcessorInput, UploadItemStatus, UploadResultItem,
-};
-
-/// Record every input of a failed upload job as FAILED.
-///
-/// A processor `Err` carries no `ProcessorOutput`, so the per-file results the
-/// uploader computed are lost; synthesizing from `ProcessorInput.inputs` is
-/// the only durable trace of the attempt. Pessimistic on purpose: a retry
-/// upserts over these rows via the `(job_id, local_path)` conflict key, and
-/// RcloneProcessor's move-resume reports already-moved sources as Completed,
-/// flipping them back.
-async fn record_failed_upload_inputs(
-    job_queue: &JobQueue,
-    job_id: &str,
-    job_type: &str,
-    input: &ProcessorInput,
-    error: &str,
-) {
-    if upload_kind_for_job_type(job_type).is_none() {
-        return;
-    }
-    let items: Vec<UploadResultItem> = input
-        .inputs
-        .iter()
-        .map(|path| UploadResultItem {
-            local_path: path.clone(),
-            remote_path: None,
-            size_bytes: None,
-            status: UploadItemStatus::Failed,
-            error: Some(error.to_string()),
-        })
-        .collect();
-    job_queue
-        .persist_upload_records(
-            job_id,
-            job_type,
-            Some(&input.streamer_id),
-            Some(&input.session_id),
-            &items,
-        )
-        .await;
-}
+use super::job_queue::{JobExecutionInfo, JobQueue, JobResult};
+use super::processors::{JobLogSink, Processor, ProcessorContext, ProcessorInput};
 
 /// Type of worker.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -818,15 +776,9 @@ impl WorkerPool {
 
                                     if !job_cancellation_token.is_cancelled() {
                                     // Check if this is a DAG job for fail-fast handling
+                                    // (fail_internal synthesizes FAILED upload
+                                    // records once the transition commits).
                                     let error = e.to_string();
-                                    record_failed_upload_inputs(
-                                        &job_queue,
-                                        &job_id,
-                                        &job.job_type,
-                                        &input,
-                                        &error,
-                                    )
-                                    .await;
                                     if let Some(dag_step_id) = dag_step_execution_id.as_deref() {
                                         // First mark job as failed
                                         let partial_outputs = job_queue
@@ -903,15 +855,9 @@ impl WorkerPool {
                                     if !job_cancellation_token.is_cancelled() {
                                     job_cancellation_token.cancel();
 
-                                    record_failed_upload_inputs(
-                                        &job_queue,
-                                        &job_id,
-                                        &job.job_type,
-                                        &input,
-                                        "Job timed out",
-                                    )
-                                    .await;
                                     // Check if this is a DAG job for fail-fast handling
+                                    // (fail_internal synthesizes FAILED upload
+                                    // records once the transition commits).
                                     if let Some(dag_step_id) = dag_step_execution_id.as_deref() {
                                         // First mark job as failed
                                         let partial_outputs = job_queue


### PR DESCRIPTION
## Summary

Fixes the three P2 findings from review of the upload status feature (#708).

**Upload badges attributed to the wrong session** — `list_outputs` grouped and looked up records by `local_path` alone, but `media_outputs.file_path` is not unique across sessions, so a reused path could pin another session's status/destination onto an output; `.remove()` also meant only one of several duplicate outputs got the annotation. The annotation now keys on `(session_id, local_path)`, skips session-less records (they can't be attributed safely), and uses get+clone so every matching output carries the annotation.

**Uploads card could permanently miss results** — the job row flips terminal *before* `upload_records` are written, and the job page's status-driven invalidation fires once; a fetch landing before the insert cached an empty list until remount. The WebSocket provider now invalidates the job's uploads query on `UPLOAD_TERMINAL`, which the queue broadcasts only after persistence completes (`complete()` awaited it already; `fail_internal` now does too — see below). The status-driven invalidation stays as a WS-down fallback and is documented as such.

**Cancellation could leave FAILED rows on a CANCELLED job** — the worker pool synthesized FAILED records *before* attempting the FAILED transition, so a cancel winning the race in that window kept the rows while the job ended CANCELLED (same ordering on the timeout path). The synthesis moved into `fail_internal`, gated behind `mark_job_failed`'s CAS: records are written only when the FAILED transition actually commits, and a losing fail takes the existing cancelled early-return and writes nothing. This also means every fail path (processor error, timeout, `fail()` for unclaimable jobs) now produces records through one correctly-ordered choke point, and the Terminal event is emitted after persistence on the fail path too.

## Testing

- New `test_fail_persists_failed_upload_records_only_on_transition`: failing a processing upload job records every input FAILED; cancel-then-fail leaves zero rows.
- `cargo clippy --all-targets` clean; `cargo nextest run` 1463 passed.
- Frontend `pnpm lint` / `fmt:check` / `test` (106) / `build` green.