### PR TITLE
fix(frontend): bind upload translations to active locale

### DIFF
--- a/rust-srec/frontend/src/components/streamers/card/upload-indicator.test.tsx
+++ b/rust-srec/frontend/src/components/streamers/card/upload-indicator.test.tsx
@@ -1,0 +1,32 @@
+import { setupI18n } from '@lingui/core';
+import { I18nProvider } from '@lingui/react';
+import { render } from '@testing-library/react';
+
+import { UploadIndicator } from './upload-indicator';
+
+describe('UploadIndicator', () => {
+  it('uses the activated provider locale for plural messages', () => {
+    const i18n = setupI18n({ locale: 'en', messages: { en: {} } });
+
+    expect(() =>
+      render(
+        <I18nProvider i18n={i18n}>
+          <UploadIndicator
+            uploads={[
+              {
+                jobId: 'job-1',
+                streamerId: 'streamer-1',
+                sessionId: 'session-1',
+                uploader: 'rclone',
+                filesTotal: 2,
+                startedAtMs: 1n,
+                percent: 50,
+                lastEventAtMs: Date.now(),
+              },
+            ]}
+          />
+        </I18nProvider>,
+      ),
+    ).not.toThrow();
+  });
+});

--- a/rust-srec/frontend/src/components/streamers/card/upload-indicator.tsx
+++ b/rust-srec/frontend/src/components/streamers/card/upload-indicator.tsx
@@ -1,6 +1,6 @@
 import { CloudUpload } from 'lucide-react';
 import { Trans } from '@lingui/react/macro';
-import { plural } from '@lingui/core/macro';
+import { plural, t } from '@lingui/core/macro';
 import { useLingui } from '@lingui/react';
 
 import {
@@ -42,12 +42,9 @@ export function UploadIndicator({ uploads }: { uploads: UploadView[] }) {
       </TooltipTrigger>
       <TooltipContent className="space-y-1.5">
         <div className="text-xs font-medium">
-          {i18n._(
-            plural(uploads.length, {
-              one: '# active upload',
-              other: '# active uploads',
-            }),
-          )}
+          {t(
+            i18n,
+          )`${plural(uploads.length, { one: '# active upload', other: '# active uploads' })}`}
         </div>
         {uploads.map((upload) => (
           <div key={upload.jobId} className="text-xs space-y-0.5">
@@ -57,12 +54,9 @@ export function UploadIndicator({ uploads }: { uploads: UploadView[] }) {
                 {upload.filesTotal > 0 && (
                   <>
                     {' · '}
-                    {i18n._(
-                      plural(upload.filesTotal, {
-                        one: '# file',
-                        other: '# files',
-                      }),
-                    )}
+                    {t(
+                      i18n,
+                    )`${plural(upload.filesTotal, { one: '# file', other: '# files' })}`}
                   </>
                 )}
               </span>


### PR DESCRIPTION
## Summary

- Bind upload plural messages to the activated `useLingui` provider instance.
- Avoid the unconfigured global Lingui singleton emitted by standalone `plural` macros.
- Add a regression test that renders an active upload with an activated provider locale.

## Root cause

`i18n._(plural(...))` compiled into a nested translation call: the inner call used the global `@lingui/core` singleton before the provider-bound `i18n` instance. The upload indicator only mounts while an upload is active, which made the failure appear during uploads.

## Verification

- `pnpm test` (109 tests passed)
- `pnpm run lint`
- `pnpm run build` (client and SSR)
- `pnpm run extract` (2,044 messages, 0 missing)
- `pnpm run compile`
- `git diff --check`