### PR TITLE
build: retain unwinding in daemon releases

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -7,6 +7,11 @@ on:
         description: 'Cargo package/binary args, e.g. "-p mesio" or "-p mesio -p strev -p rust-srec --bins"'
         required: true
         type: string
+      profile:
+        description: 'Cargo build profile and matching target subdirectory'
+        required: false
+        type: string
+        default: 'release'
       features_normal:
         description: 'Features for non-musl targets'
         required: false
@@ -87,18 +92,18 @@ jobs:
           sudo apt-get install -y musl-tools musl-dev
       - name: Build
         if: "!contains(matrix.target, 'musl')"
-        run: cargo build --locked --release --target ${{ matrix.target }} ${{ inputs.packages }} --features ${{ inputs.features_normal }}
+        run: cargo build --locked --profile ${{ inputs.profile }} --target ${{ matrix.target }} ${{ inputs.packages }} --features ${{ inputs.features_normal }}
       - name: Build (musl)
         if: contains(matrix.target, 'musl')
         env:
           CC: musl-gcc
-        run: cargo build --locked --release --target ${{ matrix.target }} ${{ inputs.packages }} --features ${{ inputs.features_musl }}
+        run: cargo build --locked --profile ${{ inputs.profile }} --target ${{ matrix.target }} ${{ inputs.packages }} --features ${{ inputs.features_musl }}
       - name: Rename binaries
         shell: bash
         run: |
           mkdir -p upload
           for bin in $(echo '${{ inputs.binaries }}' | jq -r '.[]' | tr -d '\r'); do
-            src="target/${{ matrix.target }}/release/${bin}"
+            src="target/${{ matrix.target }}/${{ inputs.profile }}/${bin}"
             if [[ "${{ matrix.target }}" == *windows* ]]; then
               src="${src}.exe"
               dest="upload/${bin}-${{ matrix.target }}.exe"

--- a/.github/workflows/release-mesio.yml
+++ b/.github/workflows/release-mesio.yml
@@ -51,6 +51,7 @@ jobs:
     uses: ./.github/workflows/build-binaries.yml
     with:
       packages: '-p mesio'
+      profile: 'release-cli'
       binaries: '["mesio"]'
 
   release:

--- a/.github/workflows/release-strev.yml
+++ b/.github/workflows/release-strev.yml
@@ -52,6 +52,7 @@ jobs:
     uses: ./.github/workflows/build-binaries.yml
     with:
       packages: '-p strev'
+      profile: 'release-cli'
       binaries: '["strev"]'
       need_protoc: true
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -137,5 +137,12 @@ lto = true
 codegen-units = 1
 strip = true
 opt-level = 3
-panic = "abort"   # Removes panic unwinding code
+# The daemon isolates panicking tasks and finalizes active recordings during
+# graceful shutdown, both of which require unwinding.
 debug = false
+
+# Standalone CLIs can opt back into aborting panics for smaller binaries, for
+# example: `cargo build -p strev --profile release-cli`.
+[profile.release-cli]
+inherits = "release"
+panic = "abort"


### PR DESCRIPTION
## What changed

- Removed `panic = "abort"` from the workspace release profile so daemon release builds retain unwinding.
- Added an opt-in `release-cli` profile that preserves aborting panics for standalone CLI size optimization.
- Added a profile input to the reusable binary workflow and used it for both Cargo builds and artifact lookup.
- Wired the dedicated `strev` and `mesio` release workflows to `release-cli`; daemon and mixed development builds remain on `release`.

## Why

The backend supervises asynchronous tasks with `catch_unwind` and performs graceful shutdown to finalize active recordings. A workspace-wide aborting release profile bypasses both recovery paths and can terminate the process before recordings are finalized.

The CLI profile must also be selected by release CI. Custom Cargo profiles write to a profile-named target directory, so the artifact uploader must follow the selected profile as well.

This PR intentionally excludes the dependency cleanup that accompanied the change in #713.

## Validation

- `cargo metadata --locked --no-deps --format-version 1`
- `cargo check --locked -p rust-srec --release`
- `cargo check --locked -p strev --profile release-cli`
- `cargo build --locked --profile release-cli --target x86_64-pc-windows-msvc -p strev -p mesio --features strev/tls-native-fallback,mesio/tls-native-fallback`
- Verified both CLI artifacts under `target/x86_64-pc-windows-msvc/release-cli/`
- `actionlint` on the reusable builder and both CLI release workflows
- `git diff --check`

Extracted from #713 as P1-01.