### PR TITLE
fix: harden parsers against malformed input

### DIFF
--- a/crates/amf0/src/decode.rs
+++ b/crates/amf0/src/decode.rs
@@ -17,6 +17,9 @@ pub struct LossyDecodeResult<'a> {
     pub error: Option<Amf0ReadError>,
 }
 
+/// Maximum object/array nesting depth accepted by [`Amf0Decoder::decode`].
+const MAX_DEPTH: usize = 256;
+
 /// An AMF0 Decoder.
 ///
 /// This decoder takes a reference to a byte slice and reads the AMF0 data from
@@ -25,12 +28,17 @@ pub struct LossyDecodeResult<'a> {
 pub struct Amf0Decoder<'a> {
     data: &'a [u8],
     pos: usize,
+    depth: usize,
 }
 
 impl<'a> Amf0Decoder<'a> {
     /// Create a new AMF0 decoder.
     pub const fn new(data: &'a [u8]) -> Self {
-        Self { data, pos: 0 }
+        Self {
+            data,
+            pos: 0,
+            depth: 0,
+        }
     }
 
     /// Check if the decoder has reached the end of the AMF0 data.
@@ -40,13 +48,16 @@ impl<'a> Amf0Decoder<'a> {
 
     /// Read `len` bytes from the buffer, advancing the position.
     fn read_bytes(&mut self, len: usize) -> Result<&'a [u8], Amf0ReadError> {
-        let end = self.pos + len;
-        if end > self.data.len() {
-            return Err(Amf0ReadError::Io(io::Error::new(
-                io::ErrorKind::UnexpectedEof,
-                "not enough data",
-            )));
-        }
+        let end = self
+            .pos
+            .checked_add(len)
+            .filter(|&end| end <= self.data.len())
+            .ok_or_else(|| {
+                Amf0ReadError::Io(io::Error::new(
+                    io::ErrorKind::UnexpectedEof,
+                    "not enough data",
+                ))
+            })?;
         let bytes = &self.data[self.pos..end];
         self.pos = end;
         Ok(bytes)
@@ -161,6 +172,21 @@ impl<'a> Amf0Decoder<'a> {
 
     /// Read the next encoded value from the decoder.
     pub fn decode(&mut self) -> Result<Amf0Value<'a>, Amf0ReadError> {
+        self.depth += 1;
+        if self.depth > MAX_DEPTH {
+            self.depth -= 1;
+            return Err(Amf0ReadError::Io(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "maximum nesting depth exceeded",
+            )));
+        }
+
+        let result = self.decode_value();
+        self.depth -= 1;
+        result
+    }
+
+    fn decode_value(&mut self) -> Result<Amf0Value<'a>, Amf0ReadError> {
         let marker_byte = self.read_u8()?;
         let marker = Amf0Marker::try_from(marker_byte).map_err(Amf0ReadError::UnknownMarker)?;
 
@@ -282,7 +308,10 @@ impl<'a> Amf0Decoder<'a> {
     fn read_strict_array(&mut self) -> Result<Vec<Amf0Value<'a>>, Amf0ReadError> {
         let len = self.read_u32_be()?;
 
-        let mut values = Vec::with_capacity(len as usize);
+        // Every element needs at least a marker byte, so the remaining input is
+        // a safe upper bound for eager allocation.
+        let remaining = self.data.len() - self.pos;
+        let mut values = Vec::with_capacity((len as usize).min(remaining));
 
         for _ in 0..len {
             let val = self.decode()?;
@@ -431,6 +460,31 @@ mod tests {
         );
 
         assert_eq!(value, expected);
+    }
+
+    #[test]
+    fn strict_array_count_is_bounded_by_remaining_input() {
+        let data = [Amf0Marker::StrictArray as u8, 0xff, 0xff, 0xff, 0xff];
+        let mut decoder = Amf0Decoder::new(&data);
+
+        assert!(matches!(decoder.decode(), Err(Amf0ReadError::Io(_))));
+    }
+
+    #[test]
+    fn deeply_nested_arrays_return_an_error() {
+        let mut data = Vec::with_capacity((MAX_DEPTH + 1) * 5 + 1);
+        for _ in 0..=MAX_DEPTH {
+            data.push(Amf0Marker::StrictArray as u8);
+            data.extend_from_slice(&1_u32.to_be_bytes());
+        }
+        data.push(Amf0Marker::Null as u8);
+
+        let mut decoder = Amf0Decoder::new(&data);
+        let error = decoder.decode().unwrap_err();
+        assert!(matches!(
+            error,
+            Amf0ReadError::Io(ref source) if source.kind() == io::ErrorKind::InvalidData
+        ));
     }
 
     #[test]

--- a/crates/h264/src/sps.rs
+++ b/crates/h264/src/sps.rs
@@ -355,6 +355,10 @@ pub struct Sps {
 }
 
 impl Sps {
+    fn apply_crop(base: u64, first_offset: u64, second_offset: u64) -> u64 {
+        base.saturating_sub(first_offset.saturating_add(second_offset).saturating_mul(2))
+    }
+
     /// Parses an Sps from the input bytes.
     ///
     /// Returns an `Sps` struct.
@@ -721,7 +725,11 @@ impl Sps {
             * 16;
 
         self.frame_crop_info.as_ref().map_or(base_height, |crop| {
-            base_height - (crop.frame_crop_top_offset + crop.frame_crop_bottom_offset) * 2
+            Self::apply_crop(
+                base_height,
+                crop.frame_crop_top_offset,
+                crop.frame_crop_bottom_offset,
+            )
         })
     }
 
@@ -732,7 +740,11 @@ impl Sps {
         let base_width = (self.pic_width_in_mbs_minus1 + 1) * 16;
 
         self.frame_crop_info.as_ref().map_or(base_width, |crop| {
-            base_width - (crop.frame_crop_left_offset + crop.frame_crop_right_offset) * 2
+            Self::apply_crop(
+                base_width,
+                crop.frame_crop_left_offset,
+                crop.frame_crop_right_offset,
+            )
         })
     }
 
@@ -755,6 +767,12 @@ mod tests {
     use expgolomb::{BitWriterExpGolombExt, size_of_exp_golomb, size_of_signed_exp_golomb};
 
     use crate::sps::Sps;
+
+    #[test]
+    fn excessive_crop_offsets_saturate_to_zero() {
+        assert_eq!(Sps::apply_crop(16, 9, 0), 0);
+        assert_eq!(Sps::apply_crop(16, u64::MAX, 1), 0);
+    }
 
     #[test]
     fn test_parse_sps_set_forbidden_bit() {

--- a/crates/platforms/src/extractor/platforms/bilibili/danmu.rs
+++ b/crates/platforms/src/extractor/platforms/bilibili/danmu.rs
@@ -340,7 +340,9 @@ impl BilibiliDanmuProtocol {
             let version = BigEndian::read_u16(&data[offset + 6..offset + 8]);
             let operation = BigEndian::read_u32(&data[offset + 8..offset + 12]);
 
-            if offset + packet_len > data.len() {
+            // Every frame has a 16-byte header. Validate the relative length
+            // before slicing, and avoid overflowing `offset + packet_len`.
+            if packet_len < 16 || packet_len > data.len() - offset {
                 break;
             }
 
@@ -798,6 +800,24 @@ mod tests {
         assert_eq!(BigEndian::read_u32(&packet[8..12]), op::AUTH);
         assert_eq!(BigEndian::read_u32(&packet[12..16]), 1);
         assert_eq!(&packet[16..], body);
+    }
+
+    #[test]
+    fn decode_packets_rejects_lengths_shorter_than_the_header() {
+        for packet_len in [0_u32, 15] {
+            let mut packet = vec![0_u8; 16];
+            BigEndian::write_u32(&mut packet[0..4], packet_len);
+
+            assert!(BilibiliDanmuProtocol::decode_packets(&packet).is_empty());
+        }
+    }
+
+    #[test]
+    fn decode_packets_rejects_lengths_beyond_the_frame() {
+        let mut packet = vec![0_u8; 16];
+        BigEndian::write_u32(&mut packet[0..4], 17);
+
+        assert!(BilibiliDanmuProtocol::decode_packets(&packet).is_empty());
     }
 
     #[test]

--- a/crates/platforms/src/extractor/platforms/bilibili/wbi.rs
+++ b/crates/platforms/src/extractor/platforms/bilibili/wbi.rs
@@ -45,6 +45,7 @@ const MIXIN_KEY_ENC_TAB: [usize; 64] = [
     28, 14, 39, 12, 38, 41, 13, 37, 48, 7, 16, 24, 55, 40, 61, 26, 17, 0, 1, 60, 51, 30, 4, 22, 25,
     54, 21, 56, 59, 6, 63, 57, 62, 11, 36, 20, 34, 44, 52,
 ];
+const MIN_MIXIN_KEY_LEN: usize = 59;
 
 #[derive(Deserialize)]
 struct WbiImg {
@@ -63,12 +64,19 @@ struct ResWbi {
 }
 
 // 对 imgKey 和 subKey 进行字符顺序打乱编码
-fn get_mixin_key(orig: &[u8]) -> String {
-    MIXIN_KEY_ENC_TAB
+fn get_mixin_key(orig: &[u8]) -> Result<String, ExtractorError> {
+    if orig.len() < MIN_MIXIN_KEY_LEN {
+        return Err(ExtractorError::ValidationError(format!(
+            "WBI key material is too short: expected at least {MIN_MIXIN_KEY_LEN} bytes, got {}",
+            orig.len()
+        )));
+    }
+
+    Ok(MIXIN_KEY_ENC_TAB
         .iter()
         .take(32)
         .map(|&i| orig[i] as char)
-        .collect::<String>()
+        .collect::<String>())
 }
 
 fn get_url_encoded(s: &str) -> String {
@@ -106,19 +114,15 @@ pub(super) fn encode_wbi(
             ));
         }
     };
-    Ok(_encode_wbi(
-        params,
-        (&keys.img_key, &keys.sub_key),
-        cur_time,
-    ))
+    _encode_wbi(params, (&keys.img_key, &keys.sub_key), cur_time)
 }
 
 fn _encode_wbi(
     mut params: Vec<(&str, String)>,
     (img_key, sub_key): (&str, &str),
     timestamp: u64,
-) -> String {
-    let mixin_key = get_mixin_key((img_key.to_owned() + sub_key).as_bytes());
+) -> Result<String, ExtractorError> {
+    let mixin_key = get_mixin_key((img_key.to_owned() + sub_key).as_bytes())?;
     // 添加当前时间戳
     params.push(("wts", timestamp.to_string()));
     // 重新排序
@@ -134,7 +138,7 @@ fn _encode_wbi(
     hasher.update(query.clone() + &mixin_key);
     let web_sign = crate::digest_to_hex(&hasher.finalize());
     // 返回最终的 query
-    query + &format!("&w_rid={web_sign}")
+    Ok(query + &format!("&w_rid={web_sign}"))
 }
 
 async fn fetch_new_keys(client: &Client) -> Result<WbiKeys, ExtractorError> {
@@ -162,6 +166,9 @@ async fn fetch_new_keys(client: &Client) -> Result<WbiKeys, ExtractorError> {
             wbi_img.sub_url
         ))
     })?;
+
+    // Reject malformed API responses before they enter the shared cache.
+    get_mixin_key((img_key.clone() + &sub_key).as_bytes())?;
 
     Ok(WbiKeys::new(img_key, sub_key))
 }
@@ -246,9 +253,15 @@ mod tests {
         let concat_key =
             "7cd084941338484aae1ad9425b84077c".to_string() + "4932caff0ff746eab6f01bf08b70ac45";
         assert_eq!(
-            get_mixin_key(concat_key.as_bytes()),
+            get_mixin_key(concat_key.as_bytes()).unwrap(),
             "ea1db124af3c7062474693fa704f4ff8"
         );
+    }
+
+    #[test]
+    fn test_get_mixin_key_rejects_short_input() {
+        let error = get_mixin_key(&[b'a'; MIN_MIXIN_KEY_LEN - 1]).unwrap_err();
+        assert!(matches!(error, ExtractorError::ValidationError(_)));
     }
 
     #[test]
@@ -263,7 +276,7 @@ mod tests {
             "4932caff0ff746eab6f01bf08b70ac45",
         );
         assert_eq!(
-            _encode_wbi(params, keys, 1702204169),
+            _encode_wbi(params, keys, 1702204169).unwrap(),
             "bar=514&foo=114&wts=1702204169&zab=1919810&w_rid=8f6f2b5b3d485fe1886cec6a0be8c5d4"
                 .to_string()
         )

--- a/crates/tars-codec/src/de.rs
+++ b/crates/tars-codec/src/de.rs
@@ -6,10 +6,14 @@ use bytes::{Buf, Bytes};
 use rustc_hash::FxHashMap;
 use smallvec::SmallVec;
 
+/// Maximum container nesting depth accepted by the deserializer.
+const MAX_DEPTH: usize = 256;
+
 pub struct TarsDeserializer {
     buffer: Bytes,
     /// When true, strings are parsed as StringRef (zero-copy) instead of String
     pub zero_copy_strings: bool,
+    depth: usize,
 }
 
 impl TarsDeserializer {
@@ -17,6 +21,7 @@ impl TarsDeserializer {
         Self {
             buffer,
             zero_copy_strings: false, // Default to backward compatibility
+            depth: 0,
         }
     }
 
@@ -24,12 +29,66 @@ impl TarsDeserializer {
         Self {
             buffer,
             zero_copy_strings: true,
+            depth: 0,
         }
     }
 
     /// Reset the deserializer with new data for object pool reuse
     pub fn reset(&mut self, buffer: Bytes) {
         self.buffer = buffer;
+        self.depth = 0;
+    }
+
+    #[inline]
+    fn ensure_remaining(&self, count: usize) -> Result<(), TarsError> {
+        if self.buffer.remaining() < count {
+            return Err(TarsError::Io(std::io::Error::new(
+                std::io::ErrorKind::UnexpectedEof,
+                "unexpected EOF reading TARS value",
+            )));
+        }
+        Ok(())
+    }
+
+    fn read_count(&mut self) -> Result<usize, TarsError> {
+        let (_tag, value_type) = self.read_head()?;
+        let count = match value_type {
+            TarsType::Zero => 0_i64,
+            TarsType::Int1 => i64::from(self.read_i8()?),
+            TarsType::Int2 => i64::from(self.read_i16()?),
+            TarsType::Int4 => i64::from(self.read_i32()?),
+            _ => {
+                return Err(TarsError::TypeMismatch {
+                    expected: "integer count",
+                    actual: "Other",
+                });
+            }
+        };
+
+        usize::try_from(count).map_err(|_| {
+            TarsError::Io(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "negative TARS length",
+            ))
+        })
+    }
+
+    fn read_nested<T>(
+        &mut self,
+        read: impl FnOnce(&mut Self) -> Result<T, TarsError>,
+    ) -> Result<T, TarsError> {
+        self.depth += 1;
+        if self.depth > MAX_DEPTH {
+            self.depth -= 1;
+            return Err(TarsError::Io(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "maximum TARS nesting depth exceeded",
+            )));
+        }
+
+        let result = read(self);
+        self.depth -= 1;
+        result
     }
 
     pub fn read_message(&mut self) -> Result<TarsMessage, TarsError> {
@@ -123,34 +182,41 @@ impl TarsDeserializer {
     }
 
     pub fn read_bool(&mut self) -> Result<bool, TarsError> {
+        self.ensure_remaining(1)?;
         Ok(self.buffer.get_u8() != 0)
     }
 
     #[inline]
     pub fn read_i8(&mut self) -> Result<i8, TarsError> {
+        self.ensure_remaining(1)?;
         Ok(self.buffer.get_i8())
     }
 
     #[inline]
     pub fn read_i16(&mut self) -> Result<i16, TarsError> {
+        self.ensure_remaining(2)?;
         Ok(self.buffer.get_i16())
     }
 
     #[inline]
     pub fn read_i32(&mut self) -> Result<i32, TarsError> {
+        self.ensure_remaining(4)?;
         Ok(self.buffer.get_i32())
     }
 
     #[inline]
     pub fn read_i64(&mut self) -> Result<i64, TarsError> {
+        self.ensure_remaining(8)?;
         Ok(self.buffer.get_i64())
     }
 
     pub fn read_f32(&mut self) -> Result<f32, TarsError> {
+        self.ensure_remaining(4)?;
         Ok(self.buffer.get_f32())
     }
 
     pub fn read_f64(&mut self) -> Result<f64, TarsError> {
+        self.ensure_remaining(8)?;
         Ok(self.buffer.get_f64())
     }
 
@@ -158,6 +224,7 @@ impl TarsDeserializer {
         if len == 0 {
             return Ok(String::new());
         }
+        self.ensure_remaining(len)?;
 
         // Avoid temporary buffer allocation for small strings
         if len <= 256 {
@@ -181,6 +248,7 @@ impl TarsDeserializer {
         if len == 0 {
             return Ok(Bytes::new());
         }
+        self.ensure_remaining(len)?;
 
         let bytes = self.buffer.split_to(len);
         // println!("TarsDeserializer::read_string_ref: {:?}", bytes);
@@ -214,8 +282,7 @@ impl TarsDeserializer {
 
     pub fn read_map(&mut self) -> Result<FxHashMap<TarsValue, TarsValue>, TarsError> {
         let mut map = FxHashMap::default();
-        let (_len_tag, len_type) = self.read_head()?;
-        let len = self.read_value_by_type(len_type, 0)?.try_into_i32()? as usize;
+        let len = self.read_count()?;
         for _ in 0..len {
             let (k_tag, k_type) = self.read_head()?;
             let k = self.read_value_by_type(k_type, k_tag)?;
@@ -227,10 +294,10 @@ impl TarsDeserializer {
     }
 
     pub fn read_list(&mut self) -> Result<SmallVec<[Box<TarsValue>; 4]>, TarsError> {
-        let (_len_tag, len_type) = self.read_head()?;
-        let len = self.read_value_by_type(len_type, 0)?.try_into_i32()? as usize;
-        // Pre-allocate with known capacity
-        let mut vec = SmallVec::with_capacity(len);
+        let len = self.read_count()?;
+        // Each value needs at least a one-byte head, so remaining input bounds
+        // any useful eager allocation.
+        let mut vec = SmallVec::with_capacity(len.min(self.buffer.remaining()));
         for _ in 0..len {
             let (tag, type_id) = self.read_head()?;
             let value = self.read_value_by_type(type_id, tag)?;
@@ -241,8 +308,8 @@ impl TarsDeserializer {
 
     pub fn read_simple_list(&mut self) -> Result<Bytes, TarsError> {
         self.read_head()?; // Should be (0, Int1) type
-        let (_len_tag, len_type) = self.read_head()?;
-        let len = self.read_value_by_type(len_type, 0)?.try_into_i32()? as usize;
+        let len = self.read_count()?;
+        self.ensure_remaining(len)?;
         let bytes = self.buffer.split_to(len);
         Ok(bytes)
     }
@@ -270,6 +337,7 @@ impl TarsDeserializer {
             TarsType::Float => self.read_f32().map(TarsValue::Float),
             TarsType::Double => self.read_f64().map(TarsValue::Double),
             TarsType::String1 => {
+                self.ensure_remaining(1)?;
                 let len = self.buffer.get_u8() as usize;
                 if self.zero_copy_strings {
                     self.read_string_ref(len).map(TarsValue::StringRef)
@@ -278,6 +346,7 @@ impl TarsDeserializer {
                 }
             }
             TarsType::String4 => {
+                self.ensure_remaining(4)?;
                 let len = self.buffer.get_u32() as usize;
                 if self.zero_copy_strings {
                     self.read_string_ref(len).map(TarsValue::StringRef)
@@ -285,9 +354,9 @@ impl TarsDeserializer {
                     self.read_string(len).map(TarsValue::String)
                 }
             }
-            TarsType::StructBegin => self.read_struct().map(TarsValue::Struct),
-            TarsType::Map => self.read_map().map(TarsValue::Map),
-            TarsType::List => self.read_list().map(TarsValue::List),
+            TarsType::StructBegin => self.read_nested(Self::read_struct).map(TarsValue::Struct),
+            TarsType::Map => self.read_nested(Self::read_map).map(TarsValue::Map),
+            TarsType::List => self.read_nested(Self::read_list).map(TarsValue::List),
             TarsType::SimpleList => self.read_simple_list().map(TarsValue::SimpleList),
             TarsType::StructEnd => Ok(TarsValue::StructEnd),
         }
@@ -447,4 +516,77 @@ impl TarsDeserializable for TarsValue {
 pub fn from_bytes(buffer: Bytes) -> Result<TarsValue, TarsError> {
     let mut deserializer = TarsDeserializer::new(buffer);
     TarsValue::deserialize(&mut deserializer)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io;
+
+    use super::*;
+
+    fn assert_io_error_kind(result: Result<TarsValue, TarsError>, expected: io::ErrorKind) {
+        assert!(matches!(
+            result,
+            Err(TarsError::Io(ref source)) if source.kind() == expected
+        ));
+    }
+
+    #[test]
+    fn truncated_values_return_unexpected_eof() {
+        let values = [
+            vec![TarsType::Int4 as u8, 0x01, 0x02],
+            vec![TarsType::String1 as u8, 0x03, b'a'],
+            vec![
+                TarsType::SimpleList as u8,
+                TarsType::Int1 as u8,
+                TarsType::Int1 as u8,
+                0x02,
+                b'a',
+            ],
+        ];
+
+        for value in values {
+            assert_io_error_kind(from_bytes(Bytes::from(value)), io::ErrorKind::UnexpectedEof);
+        }
+    }
+
+    #[test]
+    fn negative_container_counts_return_invalid_data() {
+        let counts = [
+            vec![TarsType::Int1 as u8, 0xff],
+            vec![TarsType::Int2 as u8, 0xff, 0xff],
+            vec![TarsType::Int4 as u8, 0xff, 0xff, 0xff, 0xff],
+        ];
+
+        for count in counts {
+            let mut value = vec![TarsType::List as u8];
+            value.extend(count);
+            assert_io_error_kind(from_bytes(Bytes::from(value)), io::ErrorKind::InvalidData);
+        }
+    }
+
+    #[test]
+    fn huge_list_count_does_not_trigger_unbounded_preallocation() {
+        let value = Bytes::from_static(&[
+            TarsType::List as u8,
+            TarsType::Int4 as u8,
+            0x7f,
+            0xff,
+            0xff,
+            0xff,
+        ]);
+
+        assert_io_error_kind(from_bytes(value), io::ErrorKind::UnexpectedEof);
+    }
+
+    #[test]
+    fn deeply_nested_lists_return_invalid_data() {
+        let mut value = Vec::with_capacity((MAX_DEPTH + 1) * 3 + 1);
+        for _ in 0..=MAX_DEPTH {
+            value.extend_from_slice(&[TarsType::List as u8, TarsType::Int1 as u8, 0x01]);
+        }
+        value.push(TarsType::Zero as u8);
+
+        assert_io_error_kind(from_bytes(Bytes::from(value)), io::ErrorKind::InvalidData);
+    }
 }

--- a/crates/ts/src/parser_zero_copy.rs
+++ b/crates/ts/src/parser_zero_copy.rs
@@ -862,9 +862,9 @@ impl TsParser {
             };
 
             if let Ok(packet) = TsPacketRef::parse(chunk) {
-                // Check continuity counter if enabled
+                let status = self.check_cc(&packet);
+                let is_duplicate = matches!(status, crate::packet::ContinuityStatus::Duplicate);
                 if self.continuity_mode != ContinuityMode::Disabled {
-                    let status = self.check_cc(&packet);
                     self.handle_continuity_status(packet.pid, status)?;
                 }
 
@@ -873,7 +873,8 @@ impl TsParser {
                     on_packet_cb(&packet)?;
                 }
 
-                if self.is_relevant_psi_pid(packet.pid)
+                if !is_duplicate
+                    && self.is_relevant_psi_pid(packet.pid)
                     && let Some(payload) = packet.payload()
                 {
                     self.process_packet_psi_payload(
@@ -929,7 +930,11 @@ impl TsParser {
                 return Ok(());
             }
 
-            if pointer_field > 0 {
+            let section_in_progress = self
+                .psi_buffers
+                .get(&pid)
+                .is_some_and(|buffer| !buffer.is_empty());
+            if pointer_field > 0 && section_in_progress {
                 self.append_psi_bytes(pid, &payload[1..pointer_end], on_pat, on_pmt, on_scte35)?;
             }
 
@@ -941,7 +946,11 @@ impl TsParser {
                 }
                 self.append_psi_bytes(pid, &payload[pointer_end..], on_pat, on_pmt, on_scte35)?;
             }
-        } else {
+        } else if self
+            .psi_buffers
+            .get(&pid)
+            .is_some_and(|buffer| !buffer.is_empty())
+        {
             self.append_psi_bytes(pid, &payload, on_pat, on_pmt, on_scte35)?;
         }
 
@@ -1387,6 +1396,82 @@ mod tests {
             .unwrap();
 
         assert_eq!(versions, vec![0, 1]);
+    }
+
+    #[test]
+    fn duplicate_packet_does_not_corrupt_partial_psi_section() {
+        let pat_section = build_pat_section(0, 50, 0x0100);
+        let split_at = 183;
+
+        let mut payload_1 = Vec::with_capacity(184);
+        payload_1.push(0x00);
+        payload_1.extend_from_slice(&pat_section[..split_at]);
+        let payload_2 = pat_section[split_at..].to_vec();
+
+        let packet_1 = build_ts_packet(0x0000, true, 0, &payload_1);
+        let duplicate = build_ts_packet(0x0000, true, 0, &payload_1);
+        let packet_2 = build_ts_packet(0x0000, false, 1, &payload_2);
+
+        let mut stream = Vec::new();
+        stream.extend_from_slice(&packet_1);
+        stream.extend_from_slice(&duplicate);
+        stream.extend_from_slice(&packet_2);
+
+        let mut parser = TsParser::new();
+        let mut pat_count = 0usize;
+        let mut programs = 0usize;
+        parser
+            .parse_packets(
+                Bytes::from(stream),
+                |pat| {
+                    pat_count += 1;
+                    programs = pat.programs().count();
+                    Ok(())
+                },
+                |_pmt| Ok(()),
+                None::<fn(&TsPacketRef) -> Result<()>>,
+            )
+            .unwrap();
+
+        assert_eq!(pat_count, 1);
+        assert_eq!(programs, 50);
+        assert_eq!(parser.continuity_issue_count(), 0);
+    }
+
+    #[test]
+    fn ignores_orphan_psi_continuation_and_pointer_bytes() {
+        let mut parser = TsParser::new();
+        let mut on_pat = |_pat| Ok(());
+        let mut on_pmt = |_pmt| Ok(());
+        let mut on_scte35 = None::<fn(crate::scte35::SpliceInfoSectionRef) -> Result<()>>;
+
+        parser
+            .process_packet_psi_payload(
+                0x0000,
+                Bytes::from_static(&[0x00, 0xb0, 0x10]),
+                false,
+                &mut on_pat,
+                &mut on_pmt,
+                &mut on_scte35,
+            )
+            .unwrap();
+        parser
+            .process_packet_psi_payload(
+                0x0000,
+                Bytes::from_static(&[0x02, 0x12, 0x34]),
+                true,
+                &mut on_pat,
+                &mut on_pmt,
+                &mut on_scte35,
+            )
+            .unwrap();
+
+        assert!(
+            parser
+                .psi_buffers
+                .get(&0x0000)
+                .is_none_or(BytesMut::is_empty)
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What changed

- Bound AMF0 and TARS reads, eager allocations, and recursive container decoding when handling malformed input.
- Reject signed-negative TARS counts instead of reinterpreting them as large unsigned lengths.
- Saturate invalid H.264 crop arithmetic and validate Bilibili frame lengths and WBI key material.
- Keep MPEG-TS PSI reassembly synchronized across duplicate packets, orphan continuations, and pointer bytes.
- Add focused regression coverage for truncation, hostile lengths, excessive nesting, and PSI continuity edge cases.

## Why

Several parsers consume network-controlled lengths and recursive structures. Missing bounds checks could panic, allocate from untrusted counts, overflow arithmetic, or corrupt PSI reassembly state. This change converts malformed data into bounded errors or ignored packets while preserving valid input behavior.

The PSI duplicate check is intentionally active even when continuity reporting is disabled, which is the parser default. TARS counts are decoded with their signed wire representation before conversion to `usize`.

## Impact

Malformed AMF0, TARS, H.264, Bilibili, and MPEG-TS input can no longer trigger the covered panic, overflow, allocation, or reassembly failure paths. There are no dependency or public API changes.

## Validation

- `cargo test --locked -p tars-codec -p amf0 -p h264 -p ts -p platforms-parser`
- `cargo clippy --locked -p tars-codec -p amf0 -p h264 -p ts -p platforms-parser --all-targets -- -D warnings`
- `rustfmt --edition 2024 --check` on all six changed files
- `git diff --check origin/main...HEAD`

Extracted independently from #713 as P1-02.
