### PR TITLE
fix(pipeline): cancel parent DAG with step jobs

### DIFF
--- a/rust-srec/src/pipeline/manager/jobs.rs
+++ b/rust-srec/src/pipeline/manager/jobs.rs
@@ -179,6 +179,48 @@ where
     /// Returns error for Completed/Failed jobs.
     /// Delegates to JobQueue.
     pub async fn cancel_job(&self, id: &str) -> Result<()> {
+        let job_snapshot = self
+            .job_queue
+            .get_job(id)
+            .await?
+            .ok_or_else(|| Error::not_found("Job", id))?;
+
+        if matches!(
+            job_snapshot.status,
+            JobStatus::Completed | JobStatus::Failed
+        ) {
+            return Err(Error::InvalidStateTransition {
+                from: job_snapshot.status.as_str().to_string(),
+                to: JobStatus::Cancelled.as_str().to_string(),
+            });
+        }
+
+        let parent_dag = if let Some(step_exec_id) = job_snapshot.dag_step_execution_id.as_deref() {
+            let dag_scheduler = self.dag_scheduler.as_ref().ok_or_else(|| {
+                Error::Validation(
+                    "DAG scheduler not configured. Call with_dag_repository() first.".to_string(),
+                )
+            })?;
+            let dag_id = match job_snapshot.pipeline_id {
+                Some(dag_id) => dag_id,
+                None => dag_scheduler.get_step_execution(step_exec_id).await?.dag_id,
+            };
+            Some((dag_scheduler, dag_id))
+        } else {
+            None
+        };
+
+        // Cancelling only a step job leaves its parent DAG processing forever. Cancel the DAG
+        // first so a repository failure cannot strand it after the job becomes terminal.
+        if let Some((dag_scheduler, dag_id)) = parent_dag
+            && let Err(cancel_error) = self.cancel_dag(&dag_id).await
+        {
+            let dag = dag_scheduler.get_dag_status(&dag_id).await?;
+            if !dag.get_status().is_some_and(|status| status.is_terminal()) {
+                return Err(cancel_error);
+            }
+        }
+
         let cancelled_job = self.job_queue.cancel_job(id).await?;
 
         let _ = self.event_tx.send(PipelineEvent::JobFailed {

--- a/rust-srec/src/pipeline/manager/tests.rs
+++ b/rust-srec/src/pipeline/manager/tests.rs
@@ -375,8 +375,23 @@ impl crate::database::repositories::JobRepository for TestJobRepository {
         unimplemented!("not needed for these tests")
     }
 
-    async fn mark_job_cancelled(&self, _id: &str) -> Result<u64> {
-        unimplemented!("not needed for these tests")
+    async fn mark_job_cancelled(&self, id: &str) -> Result<u64> {
+        let mut jobs = self.jobs.lock().expect("lock poisoned");
+        let job = jobs
+            .get_mut(id)
+            .ok_or_else(|| crate::Error::not_found("Job", id))?;
+        if !matches!(
+            JobStatus::parse(&job.status),
+            Some(JobStatus::Pending | JobStatus::Processing)
+        ) {
+            return Ok(0);
+        }
+
+        let now = chrono::Utc::now().timestamp_millis();
+        job.status = JobStatus::Cancelled.as_str().to_string();
+        job.completed_at = Some(now);
+        job.updated_at = now;
+        Ok(1)
     }
 
     async fn reset_job_for_retry(&self, id: &str) -> Result<()> {
@@ -523,14 +538,18 @@ impl crate::database::repositories::JobRepository for TestJobRepository {
 
 struct TestDagRepositoryForRetry {
     dags: Mutex<HashMap<String, DagExecutionDbModel>>,
+    steps: HashMap<String, DagStepExecutionDbModel>,
     reset_calls: AtomicUsize,
+    cancel_calls: AtomicUsize,
 }
 
 impl TestDagRepositoryForRetry {
     fn new() -> Self {
         Self {
             dags: Mutex::new(HashMap::new()),
+            steps: HashMap::new(),
             reset_calls: AtomicUsize::new(0),
+            cancel_calls: AtomicUsize::new(0),
         }
     }
 
@@ -543,6 +562,15 @@ impl TestDagRepositoryForRetry {
 
     fn reset_calls(&self) -> usize {
         self.reset_calls.load(Ordering::SeqCst)
+    }
+
+    fn with_step(mut self, step: DagStepExecutionDbModel) -> Self {
+        self.steps.insert(step.id.clone(), step);
+        self
+    }
+
+    fn cancel_calls(&self) -> usize {
+        self.cancel_calls.load(Ordering::SeqCst)
     }
 }
 
@@ -604,8 +632,11 @@ impl DagRepository for TestDagRepositoryForRetry {
         unimplemented!("not needed for these tests")
     }
 
-    async fn get_step(&self, _id: &str) -> Result<DagStepExecutionDbModel> {
-        unimplemented!("not needed for these tests")
+    async fn get_step(&self, id: &str) -> Result<DagStepExecutionDbModel> {
+        self.steps
+            .get(id)
+            .cloned()
+            .ok_or_else(|| crate::Error::not_found("DAG step execution", id))
     }
 
     async fn get_step_by_dag_and_step_id(
@@ -649,12 +680,18 @@ impl DagRepository for TestDagRepositoryForRetry {
         unimplemented!("not needed for these tests")
     }
 
-    async fn cancel_dag_and_cancel_steps(
-        &self,
-        _dag_id: &str,
-        _error: &str,
-    ) -> Result<Vec<String>> {
-        unimplemented!("not needed for these tests")
+    async fn cancel_dag_and_cancel_steps(&self, dag_id: &str, error: &str) -> Result<Vec<String>> {
+        self.cancel_calls.fetch_add(1, Ordering::SeqCst);
+        let mut dags = self.dags.lock().expect("lock poisoned");
+        let dag = dags
+            .get_mut(dag_id)
+            .ok_or_else(|| crate::Error::not_found("DAG execution", dag_id))?;
+        dag.status = crate::database::models::DagExecutionStatus::Cancelled
+            .as_str()
+            .to_string();
+        dag.completed_at = Some(chrono::Utc::now().timestamp_millis());
+        dag.error = Some(error.to_string());
+        Ok(Vec::new())
     }
 
     async fn reset_dag_for_retry(&self, dag_id: &str) -> Result<()> {
@@ -1005,6 +1042,154 @@ async fn test_retry_job_resets_cancelled_dag_when_job_is_dag_step() {
     let retried = manager.retry_job(&job_id).await.unwrap();
     assert_eq!(retried.status, crate::pipeline::JobStatus::Pending);
     assert_eq!(dag_repo.reset_calls(), 1);
+}
+
+#[tokio::test]
+async fn test_cancel_dag_step_job_cancels_parent_dag() {
+    let job_repo = Arc::new(TestJobRepository::new());
+    let dag_repo = Arc::new(TestDagRepositoryForRetry::new());
+
+    let mut dag = DagExecutionDbModel::new(
+        &crate::database::models::DagPipelineDefinition::new(
+            "test",
+            vec![crate::database::models::DagStep::new(
+                "step-a",
+                crate::database::models::PipelineStep::Inline {
+                    processor: "remux".to_string(),
+                    config: serde_json::json!({}),
+                },
+            )],
+        ),
+        None,
+        None,
+    );
+    dag.status = crate::database::models::DagExecutionStatus::Processing
+        .as_str()
+        .to_string();
+    let dag_id = dag.id.clone();
+    dag_repo.insert(dag);
+
+    let mut job = JobDbModel::new_pipeline_step("remux", "[]", "[]", 0, None, None);
+    job.pipeline_id = Some(dag_id.clone());
+    job.dag_step_execution_id = Some("step-exec-1".to_string());
+    let job_id = job.id.clone();
+    job_repo.insert(job);
+
+    let manager: PipelineManager =
+        PipelineManager::with_repository(PipelineManagerConfig::default(), job_repo)
+            .with_dag_repository(dag_repo.clone());
+
+    manager.cancel_job(&job_id).await.unwrap();
+
+    assert_eq!(
+        manager.get_job(&job_id).await.unwrap().unwrap().status,
+        JobStatus::Cancelled
+    );
+    assert_eq!(
+        dag_repo.get_dag(&dag_id).await.unwrap().get_status(),
+        Some(crate::database::models::DagExecutionStatus::Cancelled)
+    );
+    assert_eq!(dag_repo.cancel_calls(), 1);
+}
+
+#[tokio::test]
+async fn test_cancel_dag_step_job_resolves_parent_before_mutating_job() {
+    let job_repo = Arc::new(TestJobRepository::new());
+    let dag_repo = Arc::new(TestDagRepositoryForRetry::new());
+
+    let mut job = JobDbModel::new_pipeline_step("remux", "[]", "[]", 0, None, None);
+    job.dag_step_execution_id = Some("missing-step-exec".to_string());
+    let job_id = job.id.clone();
+    job_repo.insert(job);
+
+    let manager: PipelineManager =
+        PipelineManager::with_repository(PipelineManagerConfig::default(), job_repo)
+            .with_dag_repository(dag_repo);
+
+    let error = manager.cancel_job(&job_id).await.unwrap_err();
+
+    assert!(matches!(error, crate::Error::NotFound { .. }));
+    assert_eq!(
+        manager.get_job(&job_id).await.unwrap().unwrap().status,
+        JobStatus::Pending
+    );
+}
+
+#[tokio::test]
+async fn test_cancel_dag_step_job_allows_terminal_parent() {
+    let job_repo = Arc::new(TestJobRepository::new());
+
+    let mut dag = DagExecutionDbModel::new(
+        &crate::database::models::DagPipelineDefinition::new("test", Vec::new()),
+        None,
+        None,
+    );
+    dag.status = crate::database::models::DagExecutionStatus::Failed
+        .as_str()
+        .to_string();
+    let dag_id = dag.id.clone();
+
+    let mut step = DagStepExecutionDbModel::new(&dag_id, "step-a", &[]);
+    let step_id = step.id.clone();
+    step.status = crate::database::models::DagStepStatus::Failed
+        .as_str()
+        .to_string();
+    let dag_repo = Arc::new(TestDagRepositoryForRetry::new().with_step(step));
+    dag_repo.insert(dag);
+
+    let mut job = JobDbModel::new_pipeline_step("remux", "[]", "[]", 0, None, None);
+    job.dag_step_execution_id = Some(step_id);
+    let job_id = job.id.clone();
+    job_repo.insert(job);
+
+    let manager: PipelineManager =
+        PipelineManager::with_repository(PipelineManagerConfig::default(), job_repo)
+            .with_dag_repository(dag_repo.clone());
+
+    manager.cancel_job(&job_id).await.unwrap();
+
+    assert_eq!(
+        manager.get_job(&job_id).await.unwrap().unwrap().status,
+        JobStatus::Cancelled
+    );
+    assert_eq!(dag_repo.cancel_calls(), 0);
+}
+
+#[tokio::test]
+async fn test_cancel_terminal_dag_step_job_does_not_cancel_parent() {
+    let job_repo = Arc::new(TestJobRepository::new());
+    let dag_repo = Arc::new(TestDagRepositoryForRetry::new());
+
+    let mut dag = DagExecutionDbModel::new(
+        &crate::database::models::DagPipelineDefinition::new("test", Vec::new()),
+        None,
+        None,
+    );
+    dag.status = crate::database::models::DagExecutionStatus::Processing
+        .as_str()
+        .to_string();
+    let dag_id = dag.id.clone();
+    dag_repo.insert(dag);
+
+    let mut job = JobDbModel::new_pipeline_step("remux", "[]", "[]", 0, None, None);
+    job.pipeline_id = Some(dag_id.clone());
+    job.dag_step_execution_id = Some("step-exec-1".to_string());
+    job.status = JobStatus::Failed.as_str().to_string();
+    let job_id = job.id.clone();
+    job_repo.insert(job);
+
+    let manager: PipelineManager =
+        PipelineManager::with_repository(PipelineManagerConfig::default(), job_repo)
+            .with_dag_repository(dag_repo.clone());
+
+    let error = manager.cancel_job(&job_id).await.unwrap_err();
+
+    assert!(matches!(error, crate::Error::InvalidStateTransition { .. }));
+    assert_eq!(
+        dag_repo.get_dag(&dag_id).await.unwrap().get_status(),
+        Some(crate::database::models::DagExecutionStatus::Processing)
+    );
+    assert_eq!(dag_repo.cancel_calls(), 0);
 }
 
 #[test]


### PR DESCRIPTION
Tracks P1-07 from #713.

## What changed

Cancelling a DAG step job now cancels its parent DAG before finalizing the requested job cancellation. Parent lookup and scheduler/storage errors are propagated, while an already-terminal parent is treated as an idempotent cancellation.

## Why

Cancelling only the step job left the parent DAG in PROCESSING with no completion event, which could block session-complete orchestration indefinitely.

## Impact

User-initiated step cancellation now terminates the full DAG, cancels sibling work through the existing scheduler path, and delivers DAG completion to waiting coordinators. Failed parent cancellation no longer leaves the target job partially cancelled.

## Validation

- cargo test --locked -p rust-srec test_cancel_dag_step_job
- cargo test --locked -p rust-srec test_cancel_terminal_dag_step_job_does_not_cancel_parent
- cargo test --locked -p rust-srec test_retry_job_resets
- cargo clippy --locked -p rust-srec --lib --tests -- -D warnings
- git diff --check