### PR TITLE
fix(mesio): correct cache lifecycle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3632,6 +3632,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.11.0",
+ "tempfile",
  "thiserror 2.0.19",
  "tokio",
  "tokio-stream",

--- a/crates/mesio/Cargo.toml
+++ b/crates/mesio/Cargo.toml
@@ -51,6 +51,7 @@ hls = { path = "../hls" }
 [dev-dependencies]
 tokio = { version = "1.51.0", features = ["rt-multi-thread", "macros", "time"] }
 axum = { workspace = true }
+tempfile = { workspace = true }
 
 [features]
 default = []

--- a/crates/mesio/src/cache/manager.rs
+++ b/crates/mesio/src/cache/manager.rs
@@ -13,6 +13,7 @@ use crate::cache::providers::memory::MemoryCache;
 use crate::cache::providers::provider::CacheProvider;
 use crate::cache::types::{
     CacheConfig, CacheKey, CacheLookupResult, CacheMetadata, CacheResourceType, CacheResult,
+    CacheStatus,
 };
 
 /// Cache manager handling both memory and file caching
@@ -77,12 +78,18 @@ impl CacheManager {
         }
 
         // Check memory cache first
-        if let Some((data, metadata, status)) = self.memory_cache.get(key).await? {
+        if let Some((data, metadata, status)) = self.memory_cache.get(key).await?
+            && status != CacheStatus::Expired
+        {
             return Ok(Some((data, metadata, status)));
         }
 
         // Try file cache if memory cache misses
         if let Some((data, metadata, status)) = self.file_cache.get(key).await? {
+            if status == CacheStatus::Expired {
+                return Ok(None);
+            }
+
             // Store in memory cache for faster access next time
             if let Err(error) = self
                 .memory_cache
@@ -254,6 +261,8 @@ impl CacheManager {
 
 #[cfg(test)]
 mod tests {
+    use bytes::Bytes;
+
     use super::*;
 
     #[test]
@@ -276,5 +285,29 @@ mod tests {
             Ok(_) => panic!("expected CacheManager::from_config to error inside Tokio runtime"),
             Err(err) => assert_eq!(err.kind(), io::ErrorKind::Other),
         }
+    }
+
+    #[tokio::test]
+    async fn get_does_not_return_or_promote_expired_entries() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let manager = CacheManager::new(CacheConfig {
+            disk_cache_path: Some(temp_dir.path().to_path_buf()),
+            max_disk_cache_size: 1024,
+            max_memory_cache_size: 1024,
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+        let key = CacheKey::new(CacheResourceType::Content, "expired", None);
+        let data = Bytes::from_static(b"stale");
+        let mut metadata = CacheMetadata::new(data.len() as u64);
+        metadata.expires_at = Some(0);
+
+        manager.put(key.clone(), data, metadata).await.unwrap();
+
+        assert!(manager.get(&key).await.unwrap().is_none());
+        manager.memory_cache.sweep().await.unwrap();
+        assert!(!manager.memory_cache.contains(&key).await.unwrap());
+        assert!(manager.get(&key).await.unwrap().is_none());
     }
 }

--- a/crates/mesio/src/cache/providers/file.rs
+++ b/crates/mesio/src/cache/providers/file.rs
@@ -2,11 +2,16 @@
 //!
 //! This module implements a file-based persistent cache provider.
 
-use std::path::{Path, PathBuf};
+use std::{
+    path::{Path, PathBuf},
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+};
 
 use bytes::Bytes;
-use tokio::fs;
-use tokio::io;
+use tokio::{fs, io, sync::Mutex};
 use tracing::{debug, warn};
 
 use crate::cache::types::{CacheKey, CacheLookupResult, CacheMetadata, CacheResult, CacheStatus};
@@ -16,7 +21,8 @@ use super::CacheProvider;
 #[derive(Debug, Clone)]
 pub struct FileCache {
     cache_dir: PathBuf,
-    initialized: std::sync::Arc<std::sync::atomic::AtomicBool>,
+    initialized: Arc<AtomicBool>,
+    init_lock: Arc<Mutex<()>>,
     enabled: bool,
     /// Maximum disk cache size in bytes (0 = unlimited)
     max_size: u64,
@@ -35,7 +41,8 @@ impl FileCache {
     pub fn new(cache_dir: PathBuf, enabled: bool, max_size: u64) -> Self {
         Self {
             cache_dir,
-            initialized: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            initialized: Arc::new(AtomicBool::new(false)),
+            init_lock: Arc::new(Mutex::new(())),
             enabled,
             max_size,
         }
@@ -43,10 +50,8 @@ impl FileCache {
 
     /// Initialize the cache directories
     pub(crate) async fn ensure_initialized(&self) -> io::Result<()> {
-        use std::sync::atomic::Ordering;
-
         // Fast path - already initialized
-        if self.initialized.load(Ordering::Relaxed) {
+        if self.initialized.load(Ordering::Acquire) {
             return Ok(());
         }
 
@@ -55,35 +60,26 @@ impl FileCache {
             return Ok(());
         }
 
-        // Use compare_exchange to ensure only one thread initializes
-        if self
-            .initialized
-            .compare_exchange(false, true, Ordering::Acquire, Ordering::Relaxed)
-            .is_ok()
-        {
-            // We won the race, do initialization
-            fs::create_dir_all(&self.cache_dir).await?;
-
-            // Create subdirectories for different resource types
-            for res_type in &[
-                crate::cache::types::CacheResourceType::Headers,
-                crate::cache::types::CacheResourceType::Content,
-                crate::cache::types::CacheResourceType::Response,
-                crate::cache::types::CacheResourceType::Playlist,
-                crate::cache::types::CacheResourceType::Segment,
-                crate::cache::types::CacheResourceType::Key,
-            ] {
-                fs::create_dir_all(self.cache_dir.join(format!("{res_type:?}"))).await?;
-            }
-
-            // Mark as fully initialized with release ordering
-            self.initialized.store(true, Ordering::Release);
-        } else {
-            // Another thread is initializing, wait for it to complete
-            while !self.initialized.load(Ordering::Acquire) {
-                tokio::task::yield_now().await;
-            }
+        let _guard = self.init_lock.lock().await;
+        if self.initialized.load(Ordering::Acquire) {
+            return Ok(());
         }
+
+        fs::create_dir_all(&self.cache_dir).await?;
+
+        for res_type in &[
+            crate::cache::types::CacheResourceType::Headers,
+            crate::cache::types::CacheResourceType::Content,
+            crate::cache::types::CacheResourceType::Response,
+            crate::cache::types::CacheResourceType::Playlist,
+            crate::cache::types::CacheResourceType::Segment,
+            crate::cache::types::CacheResourceType::Key,
+        ] {
+            fs::create_dir_all(self.cache_dir.join(format!("{res_type:?}"))).await?;
+        }
+
+        // Publish readiness only after every directory was created successfully.
+        self.initialized.store(true, Ordering::Release);
 
         Ok(())
     }
@@ -491,5 +487,27 @@ impl CacheProvider for FileCache {
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn initialization_failure_can_be_retried() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let cache_dir = temp_dir.path().join("cache");
+        fs::write(&cache_dir, b"not a directory").await.unwrap();
+        let cache = FileCache::new(cache_dir.clone(), true, 1024);
+
+        assert!(cache.ensure_initialized().await.is_err());
+        assert!(!cache.initialized.load(Ordering::Acquire));
+
+        fs::remove_file(&cache_dir).await.unwrap();
+        cache.ensure_initialized().await.unwrap();
+
+        assert!(cache.initialized.load(Ordering::Acquire));
+        assert!(fs::try_exists(cache_dir.join("Content")).await.unwrap());
     }
 }

--- a/crates/mesio/src/cache/providers/memory.rs
+++ b/crates/mesio/src/cache/providers/memory.rs
@@ -76,20 +76,13 @@ impl CacheProvider for MemoryCache {
 
             // Manually check for expiration based on metadata, which is necessary when no
             // global TTL is set on the Moka cache.
-            if let Some(expires_at) = metadata.expires_at {
-                let now = std::time::SystemTime::now()
-                    .duration_since(std::time::UNIX_EPOCH)
-                    .unwrap_or_default()
-                    .as_secs();
-
-                if now > 0 && now >= expires_at {
-                    debug!(
-                        key = ?key,
-                        "Memory cache entry expired based on metadata.expires_at"
-                    );
-                    self.cache.invalidate(key).await;
-                    return Ok(Some((data, metadata, CacheStatus::Expired)));
-                }
+            if metadata.is_expired() {
+                debug!(
+                    key = ?key,
+                    "Memory cache entry expired based on metadata.expires_at"
+                );
+                self.cache.invalidate(key).await;
+                return Ok(Some((data, metadata, CacheStatus::Expired)));
             }
 
             // Return a cache hit

--- a/crates/mesio/src/cache/types.rs
+++ b/crates/mesio/src/cache/types.rs
@@ -183,7 +183,7 @@ impl CacheMetadata {
                 .unwrap_or_default()
                 .as_secs();
 
-            expires_at < now
+            expires_at <= now
         } else {
             false
         }
@@ -228,3 +228,22 @@ pub type CacheResult<T> = std::result::Result<T, std::io::Error>;
 
 /// A type representing the result of a cache lookup operation
 pub type CacheLookupResult = CacheResult<Option<(Bytes, CacheMetadata, CacheStatus)>>;
+
+#[cfg(test)]
+mod tests {
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    use super::*;
+
+    #[test]
+    fn expiration_includes_the_deadline() {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        let mut metadata = CacheMetadata::new(0);
+        metadata.expires_at = Some(now);
+
+        assert!(metadata.is_expired());
+    }
+}


### PR DESCRIPTION
## Summary

- Treat expired memory entries as misses and never promote expired disk entries back into memory.
- Mark the file cache ready only after every cache directory exists, while allowing failed initialization to be retried.
- Use one shared inclusive expiration boundary for memory and file cache providers.
- Add regression coverage for stale entry lookup and initialization recovery.

## Context

This is P2-01 from the #713 split series.

Previously, `CacheManager::get` returned entries carrying `CacheStatus::Expired`. A disk entry could also be promoted back into memory after the memory copy expired. Separately, `FileCache` set its initialized flag before creating directories, so an I/O failure permanently latched a false ready state and concurrent callers could proceed before initialization completed.

## Impact

Expired cache content is now treated as a miss so callers fetch fresh data. File-cache initialization remains retryable after transient filesystem errors, and the steady-state read path retains its atomic fast path.

## Validation

- `cargo test --locked -p mesio-engine`
- `cargo clippy --locked -p mesio-engine --all-targets -- -D warnings`
- `cargo fmt -p mesio-engine -- --check`
- `git diff --check`
