### PR TITLE
fix(database): bound retries and preserve transactions

### DIFF
--- a/rust-srec/src/database.rs
+++ b/rust-srec/src/database.rs
@@ -241,66 +241,14 @@ pub async fn run_migrations(pool: &DbPool) -> Result<(), sqlx::Error> {
 }
 
 pub async fn begin_immediate(pool: &WritePool) -> Result<ImmediateTransaction, sqlx::Error> {
-    let mut conn = pool.acquire().await?;
-    sqlx::query("BEGIN IMMEDIATE").execute(&mut *conn).await?;
-    Ok(ImmediateTransaction::new(conn))
+    pool.begin_with("BEGIN IMMEDIATE").await
 }
 
-/// Wrapper for a manual immediate transaction.
+/// An immediate SQLite transaction backed by SQLx's transaction lifecycle.
 ///
-/// This wrapper ensures that the transaction determines the write lock immediately (BEGIN IMMEDIATE),
-/// preventing deadlocks that occur with deferred transactions (default) when multiple readers
-/// try to upgrade to writers simultaneously.
-pub struct ImmediateTransaction {
-    conn: sqlx::pool::PoolConnection<Sqlite>,
-    finished: bool,
-}
-
-impl ImmediateTransaction {
-    pub fn new(conn: sqlx::pool::PoolConnection<Sqlite>) -> Self {
-        Self {
-            conn,
-            finished: false,
-        }
-    }
-}
-
-impl ImmediateTransaction {
-    /// Commit the transaction.
-    pub async fn commit(mut self) -> Result<(), sqlx::Error> {
-        sqlx::query("COMMIT").execute(&mut *self.conn).await?;
-        self.finished = true;
-        Ok(())
-    }
-
-    pub async fn rollback(mut self) -> Result<(), sqlx::Error> {
-        sqlx::query("ROLLBACK").execute(&mut *self.conn).await?;
-        self.finished = true;
-        Ok(())
-    }
-}
-
-impl std::ops::Deref for ImmediateTransaction {
-    type Target = sqlx::SqliteConnection;
-
-    fn deref(&self) -> &Self::Target {
-        &self.conn
-    }
-}
-
-impl std::ops::DerefMut for ImmediateTransaction {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.conn
-    }
-}
-
-impl Drop for ImmediateTransaction {
-    fn drop(&mut self) {
-        if !self.finished {
-            self.conn.close_on_drop();
-        }
-    }
-}
+/// `BEGIN IMMEDIATE` acquires the write reservation at transaction start, and
+/// SQLx queues a rollback before returning a dropped transaction to the pool.
+pub type ImmediateTransaction = sqlx::Transaction<'static, Sqlite>;
 
 #[cfg(test)]
 mod tests {
@@ -319,5 +267,38 @@ mod tests {
         // In-memory databases use "memory" journal mode, not WAL
         // For file-based databases, this would be "wal"
         assert!(result.0 == "memory" || result.0 == "wal");
+    }
+
+    #[tokio::test]
+    async fn dropped_immediate_transaction_rolls_back_on_the_same_connection() {
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect("sqlite::memory:")
+            .await
+            .unwrap();
+        sqlx::query("CREATE TABLE values_to_rollback (value INTEGER NOT NULL)")
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        {
+            let mut tx = begin_immediate(&pool).await.unwrap();
+            sqlx::query("INSERT INTO values_to_rollback (value) VALUES (1)")
+                .execute(&mut *tx)
+                .await
+                .unwrap();
+        }
+
+        let mut tx = tokio::time::timeout(Duration::from_secs(1), begin_immediate(&pool))
+            .await
+            .unwrap()
+            .unwrap();
+        let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM values_to_rollback")
+            .fetch_one(&mut *tx)
+            .await
+            .unwrap();
+
+        assert_eq!(count, 0);
+        tx.commit().await.unwrap();
     }
 }

--- a/rust-srec/src/database/batching.rs
+++ b/rust-srec/src/database/batching.rs
@@ -23,9 +23,17 @@
 
 use std::sync::Arc;
 use std::time::Duration;
-use tokio::sync::mpsc;
+use tokio::sync::{OwnedSemaphorePermit, Semaphore, mpsc};
 use tokio::time::Instant;
 use tokio::time::interval;
+
+/// Maximum number of failed batches retained before producers are backpressured.
+const RETAINED_BATCH_MULTIPLIER: usize = 10;
+
+struct RetainedItem<T> {
+    value: T,
+    _permit: OwnedSemaphorePermit,
+}
 
 /// Configuration for the batch writer.
 #[derive(Debug, Clone)]
@@ -47,38 +55,81 @@ impl Default for BatchWriterConfig {
 
 /// A generic batch writer that buffers items and flushes them periodically.
 pub struct BatchWriter<T> {
-    sender: mpsc::Sender<T>,
+    sender: mpsc::Sender<RetainedItem<T>>,
+    retention_permits: Arc<Semaphore>,
     _handle: tokio::task::JoinHandle<()>,
 }
 
 impl<T: Send + Clone + 'static> BatchWriter<T> {
     /// Create a new batch writer with the given configuration and flush function.
-    pub fn new<F, Fut>(config: BatchWriterConfig, flush_fn: F) -> Self
+    pub fn new<F, Fut>(mut config: BatchWriterConfig, flush_fn: F) -> Self
     where
         F: Fn(Vec<T>) -> Fut + Send + Sync + 'static,
         Fut: std::future::Future<Output = Result<(), crate::Error>> + Send + 'static,
     {
-        let (sender, receiver) = mpsc::channel::<T>(config.max_buffer_size * 2);
+        let requested_buffer_size = config.max_buffer_size;
+        config.max_buffer_size =
+            requested_buffer_size.clamp(1, Semaphore::MAX_PERMITS / RETAINED_BATCH_MULTIPLIER);
+        if config.max_buffer_size != requested_buffer_size {
+            tracing::warn!(
+                requested = requested_buffer_size,
+                effective = config.max_buffer_size,
+                "Batch writer buffer size was outside the supported range"
+            );
+        }
+        let channel_capacity = config.max_buffer_size.saturating_mul(2);
+        let retained_capacity = config
+            .max_buffer_size
+            .saturating_mul(RETAINED_BATCH_MULTIPLIER)
+            .min(Semaphore::MAX_PERMITS);
+        let retention_permits = Arc::new(Semaphore::new(retained_capacity));
+        let (sender, receiver) = mpsc::channel(channel_capacity);
         let flush_fn = Arc::new(flush_fn);
 
         let handle = tokio::spawn(Self::run_flush_loop(receiver, config, flush_fn));
 
         Self {
             sender,
+            retention_permits,
             _handle: handle,
         }
     }
 
     /// Add an item to the batch.
     pub async fn add(&self, item: T) -> Result<(), crate::Error> {
+        let retention_permits = self.retention_permits.clone();
+        let permit = tokio::select! {
+            permit = retention_permits.acquire_owned() => permit
+                .map_err(|_| crate::Error::Other("Batch writer closed".to_string()))?,
+            _ = self.sender.closed() => {
+                return Err(crate::Error::Other("Batch writer channel closed".to_string()));
+            }
+        };
         self.sender
-            .send(item)
+            .send(RetainedItem {
+                value: item,
+                _permit: permit,
+            })
             .await
             .map_err(|_| crate::Error::Other("Batch writer channel closed".to_string()))
     }
 
+    async fn flush_buffer<F, Fut>(
+        buffer: &mut Vec<RetainedItem<T>>,
+        flush_fn: &F,
+    ) -> Result<(), crate::Error>
+    where
+        F: Fn(Vec<T>) -> Fut + Send + Sync + 'static,
+        Fut: std::future::Future<Output = Result<(), crate::Error>> + Send + 'static,
+    {
+        let batch = buffer.iter().map(|item| item.value.clone()).collect();
+        flush_fn(batch).await?;
+        buffer.clear();
+        Ok(())
+    }
+
     async fn run_flush_loop<F, Fut>(
-        mut receiver: mpsc::Receiver<T>,
+        mut receiver: mpsc::Receiver<RetainedItem<T>>,
         config: BatchWriterConfig,
         flush_fn: Arc<F>,
     ) where
@@ -103,10 +154,8 @@ impl<T: Send + Clone + 'static> BatchWriter<T> {
                             // Flush if buffer is full
                             if buffer.len() >= config.max_buffer_size {
                                 if Instant::now() >= next_flush_allowed {
-                                    let mut batch = std::mem::take(&mut buffer);
-                                    if let Err(e) = flush_fn(batch.clone()).await {
+                                    if let Err(e) = Self::flush_buffer(&mut buffer, flush_fn.as_ref()).await {
                                         tracing::error!("Batch flush error: {}", e);
-                                        buffer.append(&mut batch);
                                         backoff = if backoff.is_zero() {
                                             Duration::from_millis(200)
                                         } else {
@@ -125,7 +174,9 @@ impl<T: Send + Clone + 'static> BatchWriter<T> {
                         }
                         None => {
                             // Channel closed, flush remaining items
-                            if !buffer.is_empty() && let Err(e) = flush_fn(buffer).await {
+                            if !buffer.is_empty()
+                                && let Err(e) = Self::flush_buffer(&mut buffer, flush_fn.as_ref()).await
+                            {
                                 tracing::error!("Final batch flush error: {}", e);
                             }
                             break;
@@ -136,10 +187,8 @@ impl<T: Send + Clone + 'static> BatchWriter<T> {
                 // Periodic flush
                 _ = flush_timer.tick() => {
                     if !buffer.is_empty() && Instant::now() >= next_flush_allowed {
-                        let mut batch = std::mem::take(&mut buffer);
-                        if let Err(e) = flush_fn(batch.clone()).await {
+                        if let Err(e) = Self::flush_buffer(&mut buffer, flush_fn.as_ref()).await {
                             tracing::error!("Periodic batch flush error: {}", e);
-                            buffer.append(&mut batch);
                             backoff = if backoff.is_zero() {
                                 Duration::from_millis(200)
                             } else {
@@ -248,5 +297,33 @@ mod tests {
         .await;
 
         assert!(result.is_ok(), "Expected at least 2 flush attempts");
+    }
+
+    #[tokio::test]
+    async fn test_batch_writer_backpressures_when_flush_keeps_failing() {
+        let config = BatchWriterConfig {
+            max_buffer_size: 1,
+            flush_interval: Duration::from_secs(60),
+        };
+        let writer = BatchWriter::new(config, |_items: Vec<i32>| async {
+            Err(crate::Error::Other("flush failed".to_string()))
+        });
+
+        for item in 0..RETAINED_BATCH_MULTIPLIER {
+            tokio::time::timeout(Duration::from_secs(1), writer.add(item as i32))
+                .await
+                .unwrap()
+                .unwrap();
+        }
+
+        let blocked = tokio::time::timeout(
+            Duration::from_millis(50),
+            writer.add(RETAINED_BATCH_MULTIPLIER as i32),
+        )
+        .await;
+        assert!(
+            blocked.is_err(),
+            "producer should wait at the retention limit"
+        );
     }
 }

--- a/rust-srec/src/database/repositories/session.rs
+++ b/rust-srec/src/database/repositories/session.rs
@@ -2,8 +2,7 @@
 
 use async_trait::async_trait;
 use sqlx::SqlitePool;
-use tracing::warn;
-
+use crate::database::begin_immediate;
 use crate::database::models::{
     DanmuStatisticsDbModel, LiveSessionDbModel, MediaOutputDbModel, OutputFilters, Pagination,
     SessionFilters, SessionSegmentDbModel,
@@ -262,118 +261,76 @@ impl SessionRepository for SqlxSessionRepository {
 
     async fn create_media_output(&self, output: &MediaOutputDbModel) -> Result<()> {
         retry_on_sqlite_busy("create_media_output", || async {
-            let mut conn = self.write_pool.acquire().await?;
-            sqlx::query("BEGIN IMMEDIATE").execute(&mut *conn).await?;
+            let mut tx = begin_immediate(&self.write_pool).await?;
 
-            let result: Result<()> = async {
-                sqlx::query(
-                    r#"
-                    INSERT INTO media_outputs (id, session_id, parent_media_output_id, file_path, file_type, size_bytes, created_at)
-                    VALUES (?, ?, ?, ?, ?, ?, ?)
-                    "#,
-                )
-                .bind(&output.id)
-                .bind(&output.session_id)
-                .bind(&output.parent_media_output_id)
-                .bind(&output.file_path)
-                .bind(&output.file_type)
-                .bind(output.size_bytes)
-                .bind(output.created_at)
-                .execute(&mut *conn)
-                .await?;
+            sqlx::query(
+                r#"
+                INSERT INTO media_outputs (id, session_id, parent_media_output_id, file_path, file_type, size_bytes, created_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+                "#,
+            )
+            .bind(&output.id)
+            .bind(&output.session_id)
+            .bind(&output.parent_media_output_id)
+            .bind(&output.file_path)
+            .bind(&output.file_type)
+            .bind(output.size_bytes)
+            .bind(output.created_at)
+            .execute(&mut *tx)
+            .await?;
 
-                // Update session total size
-                sqlx::query(
-                    "UPDATE live_sessions SET total_size_bytes = total_size_bytes + ? WHERE id = ?",
-                )
-                .bind(output.size_bytes)
-                .bind(&output.session_id)
-                .execute(&mut *conn)
-                .await?;
+            // Update session total size
+            sqlx::query(
+                "UPDATE live_sessions SET total_size_bytes = total_size_bytes + ? WHERE id = ?",
+            )
+            .bind(output.size_bytes)
+            .bind(&output.session_id)
+            .execute(&mut *tx)
+            .await?;
 
-                Ok(())
-            }
-            .await;
-
-            match result {
-                Ok(()) => {
-                    sqlx::query("COMMIT").execute(&mut *conn).await?;
-                    Ok(())
-                }
-                Err(err) => {
-                    if let Err(rollback_error) =
-                        sqlx::query("ROLLBACK").execute(&mut *conn).await
-                    {
-                        warn!(
-                            error = %rollback_error,
-                            original_error = %err,
-                            "Failed to roll back media output transaction"
-                        );
-                    }
-                    Err(err)
-                }
-            }
+            tx.commit().await?;
+            Ok(())
         })
         .await
     }
 
     async fn create_session_segment(&self, segment: &SessionSegmentDbModel) -> Result<()> {
         retry_on_sqlite_busy("create_session_segment", || async {
-            let mut conn = self.write_pool.acquire().await?;
-            sqlx::query("BEGIN IMMEDIATE").execute(&mut *conn).await?;
+            let mut tx = begin_immediate(&self.write_pool).await?;
 
-            let result: Result<()> = async {
-                sqlx::query(
-                    r#"
-                    INSERT INTO session_segments (
-                        id,
-                        session_id,
-                        segment_index,
-                        file_path,
-                        duration_secs,
-                        size_bytes,
-                        split_reason_code,
-                        split_reason_details_json,
-                        created_at,
-                        completed_at,
-                        persisted_at
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                    "#,
-                )
-                .bind(&segment.id)
-                .bind(&segment.session_id)
-                .bind(segment.segment_index)
-                .bind(&segment.file_path)
-                .bind(segment.duration_secs)
-                .bind(segment.size_bytes)
-                .bind(&segment.split_reason_code)
-                .bind(&segment.split_reason_details_json)
-                .bind(segment.created_at)
-                .bind(segment.completed_at)
-                .bind(segment.persisted_at)
-                .execute(&mut *conn)
-                .await?;
+            sqlx::query(
+                r#"
+                INSERT INTO session_segments (
+                    id,
+                    session_id,
+                    segment_index,
+                    file_path,
+                    duration_secs,
+                    size_bytes,
+                    split_reason_code,
+                    split_reason_details_json,
+                    created_at,
+                    completed_at,
+                    persisted_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                "#,
+            )
+            .bind(&segment.id)
+            .bind(&segment.session_id)
+            .bind(segment.segment_index)
+            .bind(&segment.file_path)
+            .bind(segment.duration_secs)
+            .bind(segment.size_bytes)
+            .bind(&segment.split_reason_code)
+            .bind(&segment.split_reason_details_json)
+            .bind(segment.created_at)
+            .bind(segment.completed_at)
+            .bind(segment.persisted_at)
+            .execute(&mut *tx)
+            .await?;
 
-                Ok(())
-            }
-            .await;
-
-            match result {
-                Ok(()) => {
-                    sqlx::query("COMMIT").execute(&mut *conn).await?;
-                    Ok(())
-                }
-                Err(err) => {
-                    if let Err(rollback_error) = sqlx::query("ROLLBACK").execute(&mut *conn).await {
-                        warn!(
-                            error = %rollback_error,
-                            original_error = %err,
-                            "Failed to roll back session segment transaction"
-                        );
-                    }
-                    Err(err)
-                }
-            }
+            tx.commit().await?;
+            Ok(())
         })
         .await
     }
@@ -435,44 +392,24 @@ impl SessionRepository for SqlxSessionRepository {
         let output = self.get_media_output(id).await?;
 
         retry_on_sqlite_busy("delete_media_output", || async {
-            let mut conn = self.write_pool.acquire().await?;
-            sqlx::query("BEGIN IMMEDIATE").execute(&mut *conn).await?;
+            let mut tx = begin_immediate(&self.write_pool).await?;
 
-            let result: Result<()> = async {
-                sqlx::query("DELETE FROM media_outputs WHERE id = ?")
-                    .bind(id)
-                    .execute(&mut *conn)
-                    .await?;
-
-                // Update session total size
-                sqlx::query(
-                    "UPDATE live_sessions SET total_size_bytes = total_size_bytes - ? WHERE id = ?",
-                )
-                .bind(output.size_bytes)
-                .bind(&output.session_id)
-                .execute(&mut *conn)
+            sqlx::query("DELETE FROM media_outputs WHERE id = ?")
+                .bind(id)
+                .execute(&mut *tx)
                 .await?;
 
-                Ok(())
-            }
-            .await;
+            // Update session total size
+            sqlx::query(
+                "UPDATE live_sessions SET total_size_bytes = total_size_bytes - ? WHERE id = ?",
+            )
+            .bind(output.size_bytes)
+            .bind(&output.session_id)
+            .execute(&mut *tx)
+            .await?;
 
-            match result {
-                Ok(()) => {
-                    sqlx::query("COMMIT").execute(&mut *conn).await?;
-                    Ok(())
-                }
-                Err(err) => {
-                    if let Err(rollback_error) = sqlx::query("ROLLBACK").execute(&mut *conn).await {
-                        warn!(
-                            error = %rollback_error,
-                            original_error = %err,
-                            "Failed to roll back danmu output transaction"
-                        );
-                    }
-                    Err(err)
-                }
-            }
+            tx.commit().await?;
+            Ok(())
         })
         .await
     }


### PR DESCRIPTION
## Summary

- Use SQLx's native `BEGIN IMMEDIATE` transaction lifecycle so dropped transactions roll back before their connection returns to the pool.
- Migrate the remaining hand-rolled `BEGIN IMMEDIATE`/`COMMIT`/`ROLLBACK` sites (`create_media_output`, `create_session_segment`, `delete_media_output`) to the same lifecycle; previously a cancelled future or failed COMMIT there returned the pooled connection with an open transaction, wedging the serialized write pool until restart.
- Bound retained failed batches with semaphore permits shared by queued and buffered items.
- Apply producer backpressure at the retention limit so sustained flush failure no longer grows the retry buffer without bound.
- Add regression tests for rollback connection reuse and sustained flush failure.

## Context

This is P2-02 from the #713 split series.

The custom transaction wrapper closed a pooled connection whenever an unfinished transaction was dropped. With the serialized write pool, early returns therefore caused reconnection and per-connection setup churn. The batch writer used a bounded channel but drained it into an unbounded retry buffer while its flush function was failing.

Note: `BatchWriter` currently has no production callers; the bound/backpressure semantics are pinned by tests so future call sites inherit them.

## Impact

Immediate transactions now retain SQLx's rollback-on-drop guarantees without discarding healthy connections, and no code path can return a connection to the write pool with an open transaction. Batch memory is bounded across the channel and retry buffer, and producers wait when persistent database failures exhaust that budget.

## Validation

- `cargo test --locked -p rust-srec --lib database::` (197 passed)
- `cargo test --locked -p rust-srec --lib database::batching::tests`
- `cargo clippy --locked -p rust-srec --lib -- -D warnings`
- targeted `rustfmt --check`
- `git diff --check`

The broader all-target filtered test command could not complete locally because Windows returned error 1455 while mapping compiled metadata. The library target containing all changed code and tests completed successfully.
