### PR TITLE
fix(pipeline): harden runtime coordination

### DIFF
--- a/rust-srec/src/pipeline/job_queue.rs
+++ b/rust-srec/src/pipeline/job_queue.rs
@@ -1116,8 +1116,7 @@ impl JobQueue {
 
         info!("Enqueued job {} of type {}", job_id, job_type);
 
-        // CPU and I/O pools share this notifier but accept different job types.
-        self.notify.notify_waiters();
+        self.wake_workers();
 
         Ok(job_id)
     }
@@ -1136,8 +1135,7 @@ impl JobQueue {
 
         info!("Enqueued existing job {} of type {}", job_id, job_type);
 
-        // CPU and I/O pools share this notifier but accept different job types.
-        self.notify.notify_waiters();
+        self.wake_workers();
 
         Ok(job_id)
     }
@@ -1645,7 +1643,7 @@ impl JobQueue {
             self.jobs_cache.remove(id);
 
             self.depth.fetch_add(1, Ordering::SeqCst);
-            self.notify.notify_waiters();
+            self.wake_workers();
 
             let updated_job = db_model_to_job(&repo.get_job(id).await?);
             info!("Job {} retried (attempt {})", id, updated_job.retry_count);
@@ -1673,7 +1671,7 @@ impl JobQueue {
         drop(cached_job);
 
         self.depth.fetch_add(1, Ordering::SeqCst);
-        self.notify.notify_waiters();
+        self.wake_workers();
 
         info!("Job {} retried (attempt {})", id, updated_job.retry_count);
         Ok(updated_job)
@@ -2266,6 +2264,18 @@ impl JobQueue {
     /// Get a notifier for new jobs.
     pub fn notifier(&self) -> Arc<Notify> {
         self.notify.clone()
+    }
+
+    /// Wake workers after a job becomes runnable.
+    ///
+    /// `notify_waiters` wakes every currently parked worker, so both the CPU
+    /// and I/O pools (which share this notifier but accept different job
+    /// types) re-check the queue. It stores no permit, so `notify_one` also
+    /// runs for a worker that is mid-iteration and re-enters
+    /// `Notify::notified` only after this call.
+    fn wake_workers(&self) {
+        self.notify.notify_waiters();
+        self.notify.notify_one();
     }
 
     async fn fail_internal(
@@ -2965,6 +2975,67 @@ mod tests {
             state.get("session_start_ms").and_then(|v| v.as_i64()),
             Some(session_start_ms)
         );
+    }
+
+    /// A failed parent finalization must not leave runnable split jobs:
+    /// split_job_for_single_input rolls back already-created jobs through
+    /// cancel_job when marking the original job completed fails.
+    #[tokio::test]
+    async fn split_rollback_cancels_created_jobs_when_parent_finalization_fails() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let db_path = dir.path().join("job_queue_split_rollback.db");
+        let db_url = format!("sqlite:{}?mode=rwc", db_path.to_string_lossy());
+        let pool = crate::database::init_pool(&db_url).await.unwrap();
+        crate::database::run_migrations(&pool).await.unwrap();
+
+        // Satisfy the live_sessions -> streamers -> platform_config FK chain.
+        sqlx::query("INSERT INTO platform_config (id, platform_name) VALUES ('p1', 'test')")
+            .execute(&pool)
+            .await
+            .unwrap();
+        sqlx::query(
+            "INSERT INTO streamers (id, name, url, platform_config_id, state) \
+             VALUES ('streamer-1', 'Streamer', 'https://example.com/s1', 'p1', 'NOT_LIVE')",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO live_sessions (id, streamer_id, start_time) \
+             VALUES ('session-1', 'streamer-1', 1704152700000)",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let job_repo: Arc<dyn JobRepository> = Arc::new(
+            crate::database::repositories::job::SqlxJobRepository::new(pool.clone(), pool.clone()),
+        );
+        let queue = JobQueue::with_repository(JobQueueConfig::default(), job_repo.clone());
+
+        // The parent is never enqueued, so repo.get_job(&job.id) in the
+        // finalization step fails after both split jobs were created.
+        let job = Job::new(
+            "remux",
+            vec!["/input-a.flv".to_string(), "/input-b.flv".to_string()],
+            vec![],
+            "streamer-1",
+            "session-1",
+        );
+
+        let result = queue.split_job_for_single_input(&job).await;
+        assert!(result.is_err());
+
+        let pending = job_repo
+            .list_jobs_by_status(JobStatus::Pending)
+            .await
+            .unwrap();
+        assert!(pending.is_empty(), "split jobs must not stay runnable");
+        let cancelled = job_repo
+            .list_jobs_by_status(JobStatus::Cancelled)
+            .await
+            .unwrap();
+        assert_eq!(cancelled.len(), 2);
     }
 
     #[test]

--- a/rust-srec/src/pipeline/job_queue.rs
+++ b/rust-srec/src/pipeline/job_queue.rs
@@ -1116,8 +1116,8 @@ impl JobQueue {
 
         info!("Enqueued job {} of type {}", job_id, job_type);
 
-        // Notify waiting workers
-        self.notify.notify_one();
+        // CPU and I/O pools share this notifier but accept different job types.
+        self.notify.notify_waiters();
 
         Ok(job_id)
     }
@@ -1136,8 +1136,8 @@ impl JobQueue {
 
         info!("Enqueued existing job {} of type {}", job_id, job_type);
 
-        // Notify waiting workers
-        self.notify.notify_one();
+        // CPU and I/O pools share this notifier but accept different job types.
+        self.notify.notify_waiters();
 
         Ok(job_id)
     }
@@ -1645,7 +1645,7 @@ impl JobQueue {
             self.jobs_cache.remove(id);
 
             self.depth.fetch_add(1, Ordering::SeqCst);
-            self.notify.notify_one();
+            self.notify.notify_waiters();
 
             let updated_job = db_model_to_job(&repo.get_job(id).await?);
             info!("Job {} retried (attempt {})", id, updated_job.retry_count);
@@ -1673,7 +1673,7 @@ impl JobQueue {
         drop(cached_job);
 
         self.depth.fetch_add(1, Ordering::SeqCst);
-        self.notify.notify_one();
+        self.notify.notify_waiters();
 
         info!("Job {} retried (attempt {})", id, updated_job.retry_count);
         Ok(updated_job)
@@ -2043,16 +2043,28 @@ impl JobQueue {
                 split_job = split_job.with_session_start(session_start);
             }
 
-            let job_id = self.enqueue(split_job).await?;
-            created_job_ids.push(job_id);
+            match self.enqueue(split_job).await {
+                Ok(job_id) => created_job_ids.push(job_id),
+                Err(error) => {
+                    self.rollback_split_jobs(&created_job_ids).await;
+                    return Err(error);
+                }
+            }
         }
 
         // Mark the original job as completed (it was split)
         if let Some(repo) = &self.job_repository {
-            let mut db_job = repo.get_job(&job.id).await?;
-            db_job.mark_completed();
-            db_job.set_outputs(&[]); // No outputs, job was split
-            repo.update_job(&db_job).await?;
+            let result = async {
+                let mut db_job = repo.get_job(&job.id).await?;
+                db_job.mark_completed();
+                db_job.set_outputs(&[]); // No outputs, job was split
+                repo.update_job(&db_job).await
+            }
+            .await;
+            if let Err(error) = result {
+                self.rollback_split_jobs(&created_job_ids).await;
+                return Err(error);
+            }
         }
 
         // Update cache for original job
@@ -2081,6 +2093,18 @@ impl JobQueue {
         );
 
         Ok(created_job_ids)
+    }
+
+    async fn rollback_split_jobs(&self, job_ids: &[String]) {
+        for job_id in job_ids {
+            if let Err(error) = self.cancel_job(job_id).await {
+                warn!(
+                    %job_id,
+                    %error,
+                    "Failed to cancel a split job after fan-out failed"
+                );
+            }
+        }
     }
 
     /// Track partial outputs for a job (used for cleanup on failure).

--- a/rust-srec/src/pipeline/processors/delete.rs
+++ b/rust-srec/src/pipeline/processors/delete.rs
@@ -186,8 +186,10 @@ impl Processor for DeleteProcessor {
                 start_msg,
             ));
 
-            // Check if file exists
-            if !path.exists() {
+            let exists = fs::try_exists(path)
+                .await
+                .map_err(|error| crate::Error::io_path("try_exists", path, error))?;
+            if !exists {
                 let msg = format!(
                     "File does not exist, marking job as completed: {}",
                     file_path
@@ -294,7 +296,10 @@ impl Processor for DeleteProcessor {
         for file_path in &input.inputs {
             let path = Path::new(file_path);
 
-            if !path.exists() {
+            let exists = fs::try_exists(path)
+                .await
+                .map_err(|error| crate::Error::io_path("try_exists", path, error))?;
+            if !exists {
                 skipped_missing = skipped_missing.saturating_add(1);
                 let msg = format!("File does not exist, skipping: {}", file_path);
                 warn!("{}", msg);

--- a/rust-srec/src/pipeline/processors/delete.rs
+++ b/rust-srec/src/pipeline/processors/delete.rs
@@ -296,9 +296,22 @@ impl Processor for DeleteProcessor {
         for file_path in &input.inputs {
             let path = Path::new(file_path);
 
-            let exists = fs::try_exists(path)
-                .await
-                .map_err(|error| crate::Error::io_path("try_exists", path, error))?;
+            // A stat failure fails only this input, matching the
+            // delete_with_retry handling below; remaining inputs still run.
+            let exists = match fs::try_exists(path).await {
+                Ok(exists) => exists,
+                Err(error) => {
+                    let error = crate::Error::io_path("try_exists", path, error);
+                    let msg = format!("Failed to check file: {}: {}", file_path, error);
+                    warn!("{}", msg);
+                    logs.push(create_log_entry(
+                        crate::pipeline::job_queue::LogLevel::Error,
+                        msg,
+                    ));
+                    failed.push((file_path.clone(), error.to_string()));
+                    continue;
+                }
+            };
             if !exists {
                 skipped_missing = skipped_missing.saturating_add(1);
                 let msg = format!("File does not exist, skipping: {}", file_path);

--- a/rust-srec/src/pipeline/processors/rclone.rs
+++ b/rust-srec/src/pipeline/processors/rclone.rs
@@ -305,30 +305,36 @@ impl RcloneProcessor {
     /// error from `try_exists` (e.g. an unreadable or unmounted parent
     /// directory) must keep the input pending instead of reporting an
     /// upload that never happened.
-    fn is_confirmed_absent(path: &Path) -> bool {
-        matches!(path.try_exists(), Ok(false))
+    async fn is_confirmed_absent(path: &Path) -> bool {
+        matches!(tokio::fs::try_exists(path).await, Ok(false))
     }
 
     /// Split move inputs into (pending, already moved by an earlier attempt).
-    fn partition_move_inputs(inputs: &[String]) -> (Vec<String>, Vec<String>) {
-        let (moved, pending) = inputs
-            .iter()
-            .cloned()
-            .partition(|input| Self::is_confirmed_absent(Path::new(input)));
+    async fn partition_move_inputs(inputs: &[String]) -> (Vec<String>, Vec<String>) {
+        let mut pending = Vec::new();
+        let mut moved = Vec::new();
+        for input in inputs {
+            if Self::is_confirmed_absent(Path::new(input)).await {
+                moved.push(input.clone());
+            } else {
+                pending.push(input.clone());
+            }
+        }
         (pending, moved)
     }
 
     /// Drain inputs whose sources rclone consumed during the last attempt.
-    fn take_moved_inputs(pending_inputs: &mut Vec<String>) -> Vec<String> {
+    async fn take_moved_inputs(pending_inputs: &mut Vec<String>) -> Vec<String> {
         let mut moved_inputs = Vec::new();
-        pending_inputs.retain(|input| {
-            if Self::is_confirmed_absent(Path::new(input)) {
-                moved_inputs.push(input.clone());
-                false
+        let mut still_pending = Vec::with_capacity(pending_inputs.len());
+        for input in pending_inputs.drain(..) {
+            if Self::is_confirmed_absent(Path::new(&input)).await {
+                moved_inputs.push(input);
             } else {
-                true
+                still_pending.push(input);
             }
-        });
+        }
+        *pending_inputs = still_pending;
         moved_inputs
     }
 
@@ -420,7 +426,7 @@ impl RcloneProcessor {
 
         for attempt in 0..self.max_retries {
             if matches!(*operation, RcloneOperation::Move)
-                && Self::is_confirmed_absent(Path::new(input_path))
+                && Self::is_confirmed_absent(Path::new(input_path)).await
             {
                 info!(
                     input = input_path,
@@ -470,7 +476,7 @@ impl RcloneProcessor {
                 Ok(output) => output,
                 Err(e) => {
                     if matches!(*operation, RcloneOperation::Move)
-                        && Self::is_confirmed_absent(Path::new(input_path))
+                        && Self::is_confirmed_absent(Path::new(input_path)).await
                     {
                         warn!(
                             input = input_path,
@@ -500,7 +506,7 @@ impl RcloneProcessor {
                 logs.extend(command_output.logs);
 
                 if matches!(*operation, RcloneOperation::Move)
-                    && Self::is_confirmed_absent(Path::new(input_path))
+                    && Self::is_confirmed_absent(Path::new(input_path)).await
                 {
                     warn!(
                         input = input_path,
@@ -557,7 +563,7 @@ impl RcloneProcessor {
         let base_dir_str = base_dir.to_string_lossy().to_string();
         let (mut pending_inputs, already_moved_inputs) =
             if matches!(*operation, RcloneOperation::Move) {
-                Self::partition_move_inputs(inputs)
+                Self::partition_move_inputs(inputs).await
             } else {
                 (inputs.to_vec(), Vec::new())
             };
@@ -691,7 +697,7 @@ impl RcloneProcessor {
             }
 
             if matches!(*operation, RcloneOperation::Move) {
-                let moved_inputs = Self::take_moved_inputs(&mut pending_inputs);
+                let moved_inputs = Self::take_moved_inputs(&mut pending_inputs).await;
                 completed_inputs = completed_inputs.saturating_add(moved_inputs.len());
                 if !moved_inputs.is_empty() {
                     info!(
@@ -871,7 +877,11 @@ impl Processor for RcloneProcessor {
         // A retried move may legitimately reference sources consumed by an earlier attempt.
         if !matches!(config.operation, RcloneOperation::Move) {
             for input_path in &input.inputs {
-                if !Path::new(input_path).exists() {
+                let path = Path::new(input_path);
+                let exists = tokio::fs::try_exists(path)
+                    .await
+                    .map_err(|error| crate::Error::io_path("try_exists", path, error))?;
+                if !exists {
                     return Err(crate::Error::Validation(format!(
                         "Input file does not exist: {}",
                         input_path
@@ -1219,15 +1229,15 @@ mod tests {
     /// instead of reporting absence; `partition_move_inputs` must keep such
     /// inputs pending rather than count them as already moved.
     #[cfg(unix)]
-    #[test]
-    fn partition_move_inputs_keeps_unverifiable_paths_pending() {
+    #[tokio::test]
+    async fn partition_move_inputs_keeps_unverifiable_paths_pending() {
         let temp_dir = tempfile::tempdir().unwrap();
         let not_a_dir = temp_dir.path().join("plain.txt");
         std::fs::write(&not_a_dir, b"file").unwrap();
         let unverifiable = not_a_dir.join("child.mp4").to_string_lossy().into_owned();
 
         let (pending, moved) =
-            RcloneProcessor::partition_move_inputs(std::slice::from_ref(&unverifiable));
+            RcloneProcessor::partition_move_inputs(std::slice::from_ref(&unverifiable)).await;
 
         assert_eq!(pending, vec![unverifiable]);
         assert!(moved.is_empty());

--- a/rust-srec/src/pipeline/processors/remux.rs
+++ b/rust-srec/src/pipeline/processors/remux.rs
@@ -640,8 +640,11 @@ impl RemuxProcessor {
         let input_path_string = make_absolute(input_path).await;
         let input_path = input_path_string.as_str();
 
-        // Check if input file exists
-        if !Path::new(input_path).exists() {
+        let input_path_obj = Path::new(input_path);
+        let input_exists = tokio::fs::try_exists(input_path_obj)
+            .await
+            .map_err(|error| crate::Error::io_path("try_exists", input_path_obj, error))?;
+        if !input_exists {
             return Err(crate::Error::PipelineError(format!(
                 "Input file does not exist: {}",
                 input_path
@@ -685,11 +688,11 @@ impl RemuxProcessor {
         let output_path_string = make_absolute(&output_string).await;
         let output_path = output_path_string.as_str();
 
-        if !config.overwrite
-            && Path::new(output_path).try_exists().map_err(|error| {
-                crate::Error::io_path("try_exists", Path::new(output_path), error)
-            })?
-        {
+        let output_path_obj = Path::new(output_path);
+        let output_exists = tokio::fs::try_exists(output_path_obj)
+            .await
+            .map_err(|error| crate::Error::io_path("try_exists", output_path_obj, error))?;
+        if !config.overwrite && output_exists {
             return Err(crate::Error::PipelineError(format!(
                 "Output file already exists and overwrite is disabled: {}",
                 output_path

--- a/rust-srec/src/services/session_cancels.rs
+++ b/rust-srec/src/services/session_cancels.rs
@@ -80,12 +80,8 @@ impl SessionCancelHandle {
 
 impl Drop for SessionCancelHandle {
     fn drop(&mut self) {
-        if let Some(entry) = self.registry.get(&self.session_id)
-            && entry.value().id == self.id
-        {
-            drop(entry);
-            self.registry.remove(&self.session_id);
-        }
+        self.registry
+            .remove_if(&self.session_id, |_, entry| entry.id == self.id);
     }
 }
 


### PR DESCRIPTION
## Summary

- Wake every parked worker pool when jobs are enqueued or retried so type-filtered workers do not wait for polling backoff; pair `notify_waiters` with `notify_one` so a wakeup that lands while workers are mid-iteration is stored as a permit instead of lost.
- Cancel already-created fan-out jobs when a later enqueue or parent finalization fails, with a regression test pinning the rollback.
- Move delete, rclone, and remux existence checks to Tokio filesystem APIs while preserving I/O errors; in the batch-delete loop a stat failure now fails only that input, matching the per-file `delete_with_retry` handling, instead of aborting the remaining inputs.
- Remove session cancellation tokens with an atomic identity check.

## Context

This is P2-03 from the #713 split series.

The CPU and I/O pools share one notifier but accept different job types, so waking one arbitrary worker could leave the eligible pool asleep. Fan-out creation could also leave runnable duplicates after partial failure. Several async processors performed blocking metadata probes, and the session cancellation handle used a check-then-remove sequence that could delete a replacement token.

## Impact

Eligible workers react promptly with no lost-wakeup latency window, failed fan-out does not leave active partial work, filesystem metadata calls do not block runtime workers, and older pipeline handles cannot remove newly registered cancellation tokens.

## Validation

- `cargo test --locked -p rust-srec --lib pipeline::` (322 passed, 1 ignored; includes a new test that fails on pre-fix code by leaving split jobs pending)
- `cargo test --locked -p rust-srec --lib services::session_cancels::tests` (6 passed)
- `cargo clippy --locked -p rust-srec --lib -- -D warnings`
- `git diff --check`
