### PR TITLE
fix(api): batch session metadata queries

### DIFF
--- a/rust-srec/src/api/routes/credentials.rs
+++ b/rust-srec/src/api/routes/credentials.rs
@@ -593,6 +593,13 @@ pub async fn refresh_template_credentials(
     }
 }
 
+fn bilibili_qr_manager() -> Result<BilibiliCredentialManager, ApiError> {
+    static CLIENT: std::sync::OnceLock<reqwest::Client> = std::sync::OnceLock::new();
+    let client = CLIENT.get_or_init(reqwest::Client::new).clone();
+    BilibiliCredentialManager::new(client)
+        .map_err(|error| ApiError::internal(format!("Failed to create manager: {error}")))
+}
+
 #[utoipa::path(
     post,
     path = "/api/credentials/bilibili/qr/generate",
@@ -604,9 +611,7 @@ pub async fn refresh_template_credentials(
     security(("bearer_auth" = []))
 )]
 pub async fn bilibili_qr_generate() -> ApiResult<Json<QrGenerateApiResponse>> {
-    let client = reqwest::Client::new();
-    let manager = BilibiliCredentialManager::new(client)
-        .map_err(|e| ApiError::internal(format!("Failed to create manager: {}", e)))?;
+    let manager = bilibili_qr_manager()?;
 
     let result = manager
         .generate_qr()
@@ -634,9 +639,7 @@ pub async fn bilibili_qr_poll(
     State(state): State<CredentialRouteState>,
     Json(body): Json<QrPollRequest>,
 ) -> ApiResult<Json<QrPollApiResponse>> {
-    let client = reqwest::Client::new();
-    let manager = BilibiliCredentialManager::new(client)
-        .map_err(|e| ApiError::internal(format!("Failed to create manager: {}", e)))?;
+    let manager = bilibili_qr_manager()?;
 
     let result = manager
         .poll_qr(&body.auth_code)

--- a/rust-srec/src/api/routes/logging.rs
+++ b/rust-srec/src/api/routes/logging.rs
@@ -20,7 +20,6 @@ use prost::Message as ProstMessage;
 use serde::Deserialize;
 use serde::Serialize;
 use std::io::{BufRead, BufReader};
-use std::io::{Read, Write};
 use std::path::PathBuf;
 use std::time::Duration;
 use utoipa::ToSchema;
@@ -413,10 +412,7 @@ fn build_archive_zip(files: &[LogFileInternal]) -> Result<Vec<u8>, ApiError> {
 
         let mut file = std::fs::File::open(&f.path)
             .map_err(|e| ApiError::internal(format!("Failed to open log file: {e}")))?;
-        let mut buf = Vec::new();
-        file.read_to_end(&mut buf)
-            .map_err(|e| ApiError::internal(format!("Failed to read log file: {e}")))?;
-        zip.write_all(&buf)
+        std::io::copy(&mut file, &mut zip)
             .map_err(|e| ApiError::internal(format!("Failed to write zip entry: {e}")))?;
     }
 

--- a/rust-srec/src/api/routes/media.rs
+++ b/rust-srec/src/api/routes/media.rs
@@ -98,7 +98,10 @@ pub async fn get_media_content(
         }
     }
 
-    if !path.exists() {
+    let exists = tokio::fs::try_exists(&path)
+        .await
+        .map_err(|error| ApiError::from(crate::Error::io_path("try_exists", &path, error)))?;
+    if !exists {
         return Err(ApiError::not_found(format!("Media file not found: {}", id)));
     }
 

--- a/rust-srec/src/api/routes/notifications.rs
+++ b/rust-srec/src/api/routes/notifications.rs
@@ -444,10 +444,7 @@ pub async fn get_channel(
 ) -> Result<Json<NotificationChannelDbModel>, ApiError> {
     let repo = &state.notification_repository;
 
-    let channel = repo
-        .get_channel(&id)
-        .await
-        .map_err(|e| ApiError::internal(e.to_string()))?;
+    let channel = repo.get_channel(&id).await.map_err(ApiError::from)?;
     Ok(Json(channel))
 }
 
@@ -507,10 +504,7 @@ pub async fn update_channel(
     let repo = &state.notification_repository;
     let service = &state.notification_service;
 
-    let mut channel = repo
-        .get_channel(&id)
-        .await
-        .map_err(|e| ApiError::internal(e.to_string()))?;
+    let mut channel = repo.get_channel(&id).await.map_err(ApiError::from)?;
 
     channel.name = req.name;
     channel.settings = serde_json::to_string(&req.settings)
@@ -546,9 +540,7 @@ pub async fn delete_channel(
     let repo = &state.notification_repository;
     let service = &state.notification_service;
 
-    repo.delete_channel(&id)
-        .await
-        .map_err(|e| ApiError::internal(e.to_string()))?;
+    repo.delete_channel(&id).await.map_err(ApiError::from)?;
 
     // Reload service
     if let Err(e) = service.reload_from_db().await {
@@ -577,7 +569,7 @@ pub async fn get_subscriptions(
     let subs = repo
         .get_subscriptions_for_channel(&id)
         .await
-        .map_err(|e| ApiError::internal(e.to_string()))?;
+        .map_err(ApiError::from)?;
     Ok(Json(subs))
 }
 
@@ -601,9 +593,7 @@ pub async fn update_subscriptions(
     let service = &state.notification_service;
 
     // Verify channel exists
-    repo.get_channel(&id)
-        .await
-        .map_err(|e| ApiError::internal(e.to_string()))?;
+    repo.get_channel(&id).await.map_err(ApiError::from)?;
 
     // Get existing
     let existing = repo

--- a/rust-srec/src/api/routes/sessions.rs
+++ b/rust-srec/src/api/routes/sessions.rs
@@ -24,7 +24,7 @@ use crate::api::models::{
 };
 use crate::api::server::AppState;
 use crate::database::models::{
-    DanmuRateEntry, Pagination, SessionFilters, TitleEntry, TopTalkerEntry,
+    DanmuRateEntry, MediaFileType, Pagination, SessionFilters, TitleEntry, TopTalkerEntry,
 };
 use crate::session::SessionEvent;
 
@@ -217,70 +217,88 @@ pub async fn list_sessions(
         .await
         .map_err(ApiError::from)?;
 
-    // Fetch all streamers for mapping details
-    let streamers = streamer_repository
-        .list_all_streamers()
-        .await
-        .map_err(ApiError::from)?;
+    let session_ids: Vec<String> = sessions.iter().map(|session| session.id.clone()).collect();
+    let streamer_ids: Vec<String> = sessions
+        .iter()
+        .map(|session| session.streamer_id.clone())
+        .collect::<std::collections::HashSet<_>>()
+        .into_iter()
+        .collect();
+
+    let (streamers, outputs, danmu_statistics) = tokio::try_join!(
+        streamer_repository.get_streamers_by_ids(&streamer_ids),
+        session_repository.get_media_outputs_for_sessions(&session_ids),
+        session_repository.get_danmu_statistics_for_sessions(&session_ids),
+    )
+    .map_err(ApiError::from)?;
 
     let streamer_map: std::collections::HashMap<_, _> =
         streamers.into_iter().map(|s| (s.id.clone(), s)).collect();
-
-    // Convert sessions to API response format
-    let mut session_responses: Vec<SessionResponse> = Vec::with_capacity(sessions.len());
-
-    for session in &sessions {
-        // Get output count for each session
-        let output_count = session_repository
-            .get_output_count(&session.id)
-            .await
-            .unwrap_or(0);
-
-        let start_time = crate::database::time::ms_to_datetime(session.start_time);
-        let end_time = session.end_time.map(crate::database::time::ms_to_datetime);
-
-        // Calculate duration
-        let duration_secs = end_time.map(|end| (end - start_time).num_seconds() as u64);
-
-        // Parse titles JSON
-        let (titles, title) = parse_titles(&session.titles);
-
-        // Get streamer details
-        let (streamer_name, streamer_avatar) =
-            if let Some(s) = streamer_map.get(&session.streamer_id) {
-                (s.name.clone(), s.avatar.clone())
-            } else {
-                (String::new(), None)
-            };
-
-        let danmu_count = session_repository
-            .get_danmu_statistics(&session.id)
-            .await
-            .ok()
-            .flatten()
-            .map(|stats| stats.total_danmus as u64);
-
-        session_responses.push(SessionResponse {
-            id: session.id.clone(),
-            streamer_id: session.streamer_id.clone(),
-            streamer_name,
-            title,
-            titles,
-            // Lifecycle audit log isn't loaded on the list endpoint — N+1
-            // queries on a paginated response. Frontend lists don't render
-            // it; the detail endpoint populates it.
-            events: Vec::new(),
-            start_time,
-            end_time,
-            is_live: end_time.is_none(),
-            duration_secs,
-            output_count,
-            total_size_bytes: session.total_size_bytes as u64,
-            danmu_count,
-            thumbnail_url: get_thumbnail_url(&session.id, session_repository.as_ref()).await,
-            streamer_avatar,
-        });
+    let mut output_counts = std::collections::HashMap::new();
+    let mut thumbnail_urls = std::collections::HashMap::new();
+    for output in outputs {
+        let count = output_counts
+            .entry(output.session_id.clone())
+            .or_insert(0_u32);
+        *count = count.saturating_add(1);
+        if output.file_type == MediaFileType::Thumbnail.as_str() {
+            thumbnail_urls
+                .entry(output.session_id)
+                .or_insert_with(|| format!("/api/media/{}/content", output.id));
+        }
     }
+    let danmu_counts: std::collections::HashMap<_, _> = danmu_statistics
+        .into_iter()
+        .map(|stats| {
+            (
+                stats.session_id,
+                u64::try_from(stats.total_danmus).unwrap_or(0),
+            )
+        })
+        .collect();
+
+    let session_responses = sessions
+        .iter()
+        .map(|session| {
+            let start_time = crate::database::time::ms_to_datetime(session.start_time);
+            let end_time = session.end_time.map(crate::database::time::ms_to_datetime);
+
+            let duration_secs =
+                end_time.map(|end| u64::try_from((end - start_time).num_seconds()).unwrap_or(0));
+
+            // Parse titles JSON
+            let (titles, title) = parse_titles(&session.titles);
+
+            // Get streamer details
+            let (streamer_name, streamer_avatar) =
+                if let Some(s) = streamer_map.get(&session.streamer_id) {
+                    (s.name.clone(), s.avatar.clone())
+                } else {
+                    (String::new(), None)
+                };
+
+            SessionResponse {
+                id: session.id.clone(),
+                streamer_id: session.streamer_id.clone(),
+                streamer_name,
+                title,
+                titles,
+                // Lifecycle audit log isn't loaded on the list endpoint — N+1
+                // queries on a paginated response. Frontend lists don't render
+                // it; the detail endpoint populates it.
+                events: Vec::new(),
+                start_time,
+                end_time,
+                is_live: end_time.is_none(),
+                duration_secs,
+                output_count: output_counts.get(&session.id).copied().unwrap_or(0),
+                total_size_bytes: u64::try_from(session.total_size_bytes).unwrap_or(0),
+                danmu_count: danmu_counts.get(&session.id).copied(),
+                thumbnail_url: thumbnail_urls.get(&session.id).cloned(),
+                streamer_avatar,
+            }
+        })
+        .collect();
 
     let response =
         PaginatedResponse::new(session_responses, total, effective_limit, pagination.offset);

--- a/rust-srec/src/api/routes/sessions.rs
+++ b/rust-srec/src/api/routes/sessions.rs
@@ -381,7 +381,8 @@ pub async fn get_session(
     let end_time = session.end_time.map(crate::database::time::ms_to_datetime);
 
     // Calculate duration
-    let duration_secs = end_time.map(|end| (end - start_time).num_seconds() as u64);
+    let duration_secs =
+        end_time.map(|end| u64::try_from((end - start_time).num_seconds()).unwrap_or(0));
 
     // Parse titles JSON
     let (titles, title) = parse_titles(&session.titles);
@@ -406,7 +407,7 @@ pub async fn get_session(
 
     // Fetch danmu stats by session id (danmu_statistics.session_id).
     let danmu_count = match session_repository.get_danmu_statistics(&session.id).await {
-        Ok(stats) => stats.map(|stats| stats.total_danmus as u64),
+        Ok(stats) => stats.map(|stats| u64::try_from(stats.total_danmus).unwrap_or(0)),
         Err(error) => {
             tracing::warn!(session_id = %id, %error, "Failed to load session danmu statistics");
             None
@@ -439,7 +440,7 @@ pub async fn get_session(
         is_live: end_time.is_none(),
         duration_secs,
         output_count,
-        total_size_bytes: session.total_size_bytes as u64,
+        total_size_bytes: u64::try_from(session.total_size_bytes).unwrap_or(0),
         danmu_count,
         thumbnail_url,
         streamer_avatar,
@@ -535,7 +536,7 @@ pub async fn get_session_danmu_statistics(
 
     let response = SessionDanmuStatisticsResponse {
         session_id: session.id,
-        total_danmus: stats.total_danmus as u64,
+        total_danmus: u64::try_from(stats.total_danmus).unwrap_or(0),
         danmu_rate_timeseries,
         top_talkers,
         word_frequency,

--- a/rust-srec/src/database/repositories/session.rs
+++ b/rust-srec/src/database/repositories/session.rs
@@ -47,6 +47,16 @@ pub trait SessionRepository: Send + Sync {
         &self,
         session_id: &str,
     ) -> Result<Vec<MediaOutputDbModel>>;
+    async fn get_media_outputs_for_sessions(
+        &self,
+        session_ids: &[String],
+    ) -> Result<Vec<MediaOutputDbModel>> {
+        let mut outputs = Vec::new();
+        for session_id in session_ids {
+            outputs.extend(self.get_media_outputs_for_session(session_id).await?);
+        }
+        Ok(outputs)
+    }
     async fn create_media_output(&self, output: &MediaOutputDbModel) -> Result<()>;
     async fn delete_media_output(&self, id: &str) -> Result<()>;
 
@@ -80,6 +90,18 @@ pub trait SessionRepository: Send + Sync {
         &self,
         session_id: &str,
     ) -> Result<Option<DanmuStatisticsDbModel>>;
+    async fn get_danmu_statistics_for_sessions(
+        &self,
+        session_ids: &[String],
+    ) -> Result<Vec<DanmuStatisticsDbModel>> {
+        let mut statistics = Vec::new();
+        for session_id in session_ids {
+            if let Some(session_statistics) = self.get_danmu_statistics(session_id).await? {
+                statistics.push(session_statistics);
+            }
+        }
+        Ok(statistics)
+    }
     async fn create_danmu_statistics(&self, stats: &DanmuStatisticsDbModel) -> Result<()>;
     async fn update_danmu_statistics(&self, stats: &DanmuStatisticsDbModel) -> Result<()>;
     async fn upsert_danmu_statistics(
@@ -258,6 +280,29 @@ impl SessionRepository for SqlxSessionRepository {
         .fetch_all(&self.pool)
         .await?;
         Ok(outputs)
+    }
+
+    async fn get_media_outputs_for_sessions(
+        &self,
+        session_ids: &[String],
+    ) -> Result<Vec<MediaOutputDbModel>> {
+        if session_ids.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let mut builder = sqlx::QueryBuilder::<sqlx::Sqlite>::new(
+            "SELECT * FROM media_outputs WHERE session_id IN (",
+        );
+        let mut separated = builder.separated(", ");
+        for session_id in session_ids {
+            separated.push_bind(session_id);
+        }
+        separated.push_unseparated(") ORDER BY session_id, created_at");
+
+        Ok(builder
+            .build_query_as::<MediaOutputDbModel>()
+            .fetch_all(&self.pool)
+            .await?)
     }
 
     async fn create_media_output(&self, output: &MediaOutputDbModel) -> Result<()> {
@@ -488,6 +533,29 @@ impl SessionRepository for SqlxSessionRepository {
         .fetch_optional(&self.pool)
         .await?;
         Ok(stats)
+    }
+
+    async fn get_danmu_statistics_for_sessions(
+        &self,
+        session_ids: &[String],
+    ) -> Result<Vec<DanmuStatisticsDbModel>> {
+        if session_ids.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let mut builder = sqlx::QueryBuilder::<sqlx::Sqlite>::new(
+            "SELECT * FROM danmu_statistics WHERE session_id IN (",
+        );
+        let mut separated = builder.separated(", ");
+        for session_id in session_ids {
+            separated.push_bind(session_id);
+        }
+        separated.push_unseparated(") ORDER BY session_id");
+
+        Ok(builder
+            .build_query_as::<DanmuStatisticsDbModel>()
+            .fetch_all(&self.pool)
+            .await?)
     }
 
     async fn create_danmu_statistics(&self, stats: &DanmuStatisticsDbModel) -> Result<()> {
@@ -790,7 +858,9 @@ impl SessionRepository for SqlxSessionRepository {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::database::models::{LiveSessionDbModel, Pagination, StreamerDbModel};
+    use crate::database::models::{
+        LiveSessionDbModel, MediaFileType, MediaOutputDbModel, Pagination, StreamerDbModel,
+    };
     use crate::database::repositories::{SqlxStreamerRepository, StreamerRepository as _};
     use crate::database::{init_pool_with_size, run_migrations};
 
@@ -905,5 +975,56 @@ mod tests {
         let next = repo.next_session_segment_index("session-1").await.unwrap();
 
         assert_eq!(next, 4);
+    }
+
+    #[tokio::test]
+    async fn batch_session_metadata_queries_return_requested_rows() {
+        let repo = setup_test_repo().await;
+        let mut second_streamer = StreamerDbModel::new(
+            "Streamer Two",
+            "https://example.com/streamer-2",
+            "platform-twitch",
+        );
+        second_streamer.id = "streamer-2".to_string();
+        SqlxStreamerRepository::new(repo.pool.clone(), repo.write_pool.clone())
+            .create_streamer(&second_streamer)
+            .await
+            .unwrap();
+
+        let mut second_session = LiveSessionDbModel::new("streamer-2");
+        second_session.id = "session-2".to_string();
+        repo.create_session(&second_session).await.unwrap();
+
+        for output in [
+            MediaOutputDbModel::new("session-1", "/video.mp4", MediaFileType::Video, 10),
+            MediaOutputDbModel::new("session-1", "/thumbnail.jpg", MediaFileType::Thumbnail, 2),
+            MediaOutputDbModel::new("session-2", "/audio.m4a", MediaFileType::Audio, 3),
+        ] {
+            repo.create_media_output(&output).await.unwrap();
+        }
+
+        let mut statistics = DanmuStatisticsDbModel::new("session-1");
+        statistics.total_danmus = 42;
+        repo.create_danmu_statistics(&statistics).await.unwrap();
+
+        let session_ids = vec!["session-1".to_string(), "session-2".to_string()];
+        let outputs = repo
+            .get_media_outputs_for_sessions(&session_ids)
+            .await
+            .unwrap();
+        let statistics = repo
+            .get_danmu_statistics_for_sessions(&session_ids)
+            .await
+            .unwrap();
+
+        assert_eq!(outputs.len(), 3);
+        assert_eq!(statistics.len(), 1);
+        assert_eq!(statistics[0].total_danmus, 42);
+        assert!(
+            repo.get_media_outputs_for_sessions(&[])
+                .await
+                .unwrap()
+                .is_empty()
+        );
     }
 }

--- a/rust-srec/src/database/repositories/session.rs
+++ b/rust-srec/src/database/repositories/session.rs
@@ -995,10 +995,19 @@ mod tests {
         second_session.id = "session-2".to_string();
         repo.create_session(&second_session).await.unwrap();
 
+        // A session outside `session_ids`: its rows must be filtered out, so a
+        // batch query missing its `WHERE session_id IN (...)` fails the counts.
+        // Ended, because live_sessions allows one active session per streamer.
+        let mut excluded_session = LiveSessionDbModel::new("streamer-2");
+        excluded_session.id = "session-3".to_string();
+        excluded_session.end_time = Some(1_700_000_100_000);
+        repo.create_session(&excluded_session).await.unwrap();
+
         for output in [
             MediaOutputDbModel::new("session-1", "/video.mp4", MediaFileType::Video, 10),
             MediaOutputDbModel::new("session-1", "/thumbnail.jpg", MediaFileType::Thumbnail, 2),
             MediaOutputDbModel::new("session-2", "/audio.m4a", MediaFileType::Audio, 3),
+            MediaOutputDbModel::new("session-3", "/excluded.mp4", MediaFileType::Video, 4),
         ] {
             repo.create_media_output(&output).await.unwrap();
         }
@@ -1006,6 +1015,12 @@ mod tests {
         let mut statistics = DanmuStatisticsDbModel::new("session-1");
         statistics.total_danmus = 42;
         repo.create_danmu_statistics(&statistics).await.unwrap();
+
+        let mut excluded_statistics = DanmuStatisticsDbModel::new("session-3");
+        excluded_statistics.total_danmus = 7;
+        repo.create_danmu_statistics(&excluded_statistics)
+            .await
+            .unwrap();
 
         let session_ids = vec!["session-1".to_string(), "session-2".to_string()];
         let outputs = repo
@@ -1018,6 +1033,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(outputs.len(), 3);
+        assert!(outputs.iter().all(|output| output.session_id != "session-3"));
         assert_eq!(statistics.len(), 1);
         assert_eq!(statistics[0].total_danmus, 42);
         assert!(

--- a/rust-srec/src/database/repositories/streamer.rs
+++ b/rust-srec/src/database/repositories/streamer.rs
@@ -12,6 +12,13 @@ use chrono::{DateTime, Utc};
 #[async_trait]
 pub trait StreamerRepository: Send + Sync {
     async fn get_streamer(&self, id: &str) -> Result<StreamerDbModel>;
+    async fn get_streamers_by_ids(&self, ids: &[String]) -> Result<Vec<StreamerDbModel>> {
+        let mut streamers = Vec::new();
+        for id in ids {
+            streamers.push(self.get_streamer(id).await?);
+        }
+        Ok(streamers)
+    }
     async fn get_streamer_by_url(&self, url: &str) -> Result<StreamerDbModel>;
     async fn list_streamers(&self) -> Result<Vec<StreamerDbModel>>;
     async fn list_all_streamers(&self) -> Result<Vec<StreamerDbModel>>;
@@ -68,6 +75,25 @@ impl StreamerRepository for SqlxStreamerRepository {
             .fetch_optional(&self.pool)
             .await?
             .ok_or_else(|| Error::not_found("Streamer", id))
+    }
+
+    async fn get_streamers_by_ids(&self, ids: &[String]) -> Result<Vec<StreamerDbModel>> {
+        if ids.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let mut builder =
+            sqlx::QueryBuilder::<sqlx::Sqlite>::new("SELECT * FROM streamers WHERE id IN (");
+        let mut separated = builder.separated(", ");
+        for id in ids {
+            separated.push_bind(id);
+        }
+        separated.push_unseparated(")");
+
+        Ok(builder
+            .build_query_as::<StreamerDbModel>()
+            .fetch_all(&self.pool)
+            .await?)
     }
 
     async fn get_streamer_by_url(&self, url: &str) -> Result<StreamerDbModel> {


### PR DESCRIPTION
## Severity

P2-04

## What changed

- Batch streamer, media-output, and danmu-statistics reads for the sessions list endpoint.
- Build session metadata from page-level lookup maps and clamp invalid negative database values instead of wrapping them into large unsigned values — on the detail endpoints (`get_session`, `get_session_danmu_statistics`) as well as the list, so both render the same value for the same row.
- Reuse the Bilibili QR HTTP client, stream log files into ZIP entries, and use async media existence checks with propagated I/O errors.
- Preserve repository error classification in notification routes.

## Why

The sessions endpoint performed database work per result row and silently replaced several lookup failures with empty metadata. Related API paths also rebuilt an HTTP connection pool per QR poll, buffered entire log files before compression, blocked on filesystem metadata, or flattened typed repository errors into HTTP 500 responses.

## Impact

Session listing now uses a fixed number of database queries per page, failures remain visible, negative stored values render as 0 consistently across list and detail responses, and the smaller API paths preserve their intended resource and error behavior.

## Validation

- `cargo test --locked -p rust-srec --lib api::routes` (78 passed)
- `cargo test --locked -p rust-srec --lib database::repositories::session::` (5 passed; the batch-query test now includes a session outside `session_ids`, so a batch query missing its `IN` filter fails the assertions)
- `cargo clippy --locked -p rust-srec --lib -- -D warnings`
- `git diff --check`
