### PR TITLE
fix(platforms): correct token cache lifecycles

### DIFF
--- a/crates/platforms/src/extractor/platforms/bigo/builder.rs
+++ b/crates/platforms/src/extractor/platforms/bigo/builder.rs
@@ -211,7 +211,7 @@ impl PlatformExtractor for Bigo {
         let password = self.resolve_password();
 
         let integrity_token = if self.mint_token {
-            match token::mint_token(&self.extractor.client).await {
+            match token::pooled_token(&self.extractor.client).await {
                 Ok(t) => {
                     debug!("bigo integrity token minted");
                     Some(t)

--- a/crates/platforms/src/extractor/platforms/bigo/danmu.rs
+++ b/crates/platforms/src/extractor/platforms/bigo/danmu.rs
@@ -130,11 +130,12 @@ impl BigoDanmuProtocol {
 
     fn challenge_response(challenge: &str) -> Message {
         let ts = Self::now_sec().to_string();
-        let tail = if challenge.len() >= 8 {
-            &challenge[challenge.len() - 8..]
-        } else {
-            challenge
-        };
+        let tail_start = challenge
+            .char_indices()
+            .rev()
+            .nth(7)
+            .map_or(0, |(index, _)| index);
+        let tail = &challenge[tail_start..];
         let material = format!("60#4#5#{ts}#1#1#1#1#{tail}");
         let mut hasher = Md5::new();
         hasher.update(material.as_bytes());
@@ -603,12 +604,14 @@ mod tests {
     #[test]
     fn challenge_sign_material() {
         // Just ensure packing challenge response produces text with sign field.
-        let msg = BigoDanmuProtocol::challenge_response("12345678abcdefgh");
-        if let Message::Text(t) = msg {
-            assert!(t.starts_with("79108{"));
-            assert!(t.contains("\"sign\":"));
-        } else {
-            panic!("expected text");
+        for challenge in ["12345678abcdefgh", "挑战令牌abcdefgh"] {
+            let msg = BigoDanmuProtocol::challenge_response(challenge);
+            if let Message::Text(t) = msg {
+                assert!(t.starts_with("79108{"));
+                assert!(t.contains("\"sign\":"));
+            } else {
+                panic!("expected text");
+            }
         }
     }
 

--- a/crates/platforms/src/extractor/platforms/bigo/danmu.rs
+++ b/crates/platforms/src/extractor/platforms/bigo/danmu.rs
@@ -604,7 +604,9 @@ mod tests {
     #[test]
     fn challenge_sign_material() {
         // Just ensure packing challenge response produces text with sign field.
-        for challenge in ["12345678abcdefgh", "挑战令牌abcdefgh"] {
+        // The last input's byte length minus 8 lands inside a multi-byte char,
+        // so byte-based tail slicing in challenge_response would panic on it.
+        for challenge in ["12345678abcdefgh", "挑战令牌abcdefgh", "挑战令牌abcdefg"] {
             let msg = BigoDanmuProtocol::challenge_response(challenge);
             if let Message::Text(t) = msg {
                 assert!(t.starts_with("79108{"));

--- a/crates/platforms/src/extractor/platforms/bigo/token.rs
+++ b/crates/platforms/src/extractor/platforms/bigo/token.rs
@@ -4,6 +4,7 @@
 //! 2. Fingerprint map (all strings, trunc 100) encrypted with OpenSSL-salted AES-256-CBC
 //! 3. JSONP GET `/v1/webjs/status?data=` → server-minted token
 
+use std::sync::LazyLock;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use aes::Aes256;
@@ -14,6 +15,7 @@ use parking_lot::Mutex as ParkingMutex;
 use rand::{RngExt, rng};
 use reqwest::Client;
 use serde_json::{Map, Value};
+use tokio::sync::Mutex as AsyncMutex;
 use tracing::debug;
 
 use crate::digest_to_hex;
@@ -374,9 +376,23 @@ pub async fn mint_token_with_options(
     Ok(token.unwrap())
 }
 
+static SHARED_TOKEN_POOL: LazyLock<TokenPool> = LazyLock::new(TokenPool::default);
+
+/// Return a process-wide cached integrity token, refreshing it when it expires
+/// or reaches its reuse limit.
+///
+/// # Errors
+///
+/// Returns an [`ExtractorError`] if Bigo's token endpoints cannot be reached,
+/// return an unsuccessful status, or omit a valid token.
+pub async fn pooled_token(client: &Client) -> Result<String, ExtractorError> {
+    SHARED_TOKEN_POOL.get(client).await
+}
+
 /// Process-local token cache (TTL + max uses) for multi-poll reuse.
 pub struct TokenPool {
     inner: ParkingMutex<TokenPoolState>,
+    refresh_lock: AsyncMutex<()>,
     ttl: Duration,
     max_uses: u32,
 }
@@ -401,22 +417,33 @@ impl TokenPool {
                 born: None,
                 uses: 0,
             }),
+            refresh_lock: AsyncMutex::new(()),
             ttl,
             max_uses,
         }
     }
 
-    pub async fn get(&self, client: &Client) -> Result<String, ExtractorError> {
+    fn cached_token(&self) -> Option<String> {
+        let mut state = self.inner.lock();
+        if let Some(born) = state.born
+            && born.elapsed() < self.ttl
+            && state.uses < self.max_uses
+            && let Some(token) = state.token.clone()
         {
-            let mut state = self.inner.lock();
-            if let Some(born) = state.born
-                && born.elapsed() < self.ttl
-                && state.uses < self.max_uses
-                && let Some(token) = state.token.clone()
-            {
-                state.uses = state.uses.saturating_add(1);
-                return Ok(token);
-            }
+            state.uses = state.uses.saturating_add(1);
+            return Some(token);
+        }
+        None
+    }
+
+    pub async fn get(&self, client: &Client) -> Result<String, ExtractorError> {
+        if let Some(token) = self.cached_token() {
+            return Ok(token);
+        }
+
+        let _refresh_guard = self.refresh_lock.lock().await;
+        if let Some(token) = self.cached_token() {
+            return Ok(token);
         }
 
         let token = mint_token(client).await?;
@@ -491,5 +518,31 @@ mod tests {
         for key in ["wc", "dz", "dr", "business", "at_time", "ver", "mq", "ni"] {
             assert!(fp.contains_key(key), "missing {key}");
         }
+    }
+
+    #[test]
+    fn token_pool_honors_its_reuse_limit() {
+        let pool = TokenPool::new(Duration::from_secs(60), 2);
+        {
+            let mut state = pool.inner.lock();
+            state.token = Some("cached-token".to_string());
+            state.born = Some(Instant::now());
+        }
+
+        assert_eq!(pool.cached_token().as_deref(), Some("cached-token"));
+        assert_eq!(pool.cached_token().as_deref(), Some("cached-token"));
+        assert_eq!(pool.cached_token(), None);
+    }
+
+    #[test]
+    fn token_pool_rejects_expired_tokens() {
+        let pool = TokenPool::new(Duration::from_secs(1), 50);
+        {
+            let mut state = pool.inner.lock();
+            state.token = Some("expired-token".to_string());
+            state.born = Some(Instant::now() - Duration::from_secs(2));
+        }
+
+        assert_eq!(pool.cached_token(), None);
     }
 }

--- a/crates/platforms/src/extractor/platforms/douyin/builder.rs
+++ b/crates/platforms/src/extractor/platforms/douyin/builder.rs
@@ -432,7 +432,7 @@ impl<'a> DouyinRequest<'a> {
                 if let Some(ttwid) = &self.config.ttwid {
                     ttwid.clone()
                 } else {
-                    fetch_ttwid(&self.config.extractor.client).await
+                    fetch_ttwid(&self.config.extractor.client).await?
                 }
             }
         };
@@ -452,7 +452,7 @@ impl<'a> DouyinRequest<'a> {
 
     /// Ensures a valid `odin_ttid` is present.
     fn ensure_odin_ttid(&mut self) {
-        if self.params.contains_key("odin_ttid") {
+        if self.cookies.contains_key("odin_ttid") {
             return;
         }
         let odin_ttid = generate_odin_ttid();
@@ -461,7 +461,7 @@ impl<'a> DouyinRequest<'a> {
 
     /// Ensures a valid `__ac_nonce` is present.
     fn ensure_nonce(&mut self) {
-        if self.params.contains_key("__ac_nonce") {
+        if self.cookies.contains_key("__ac_nonce") {
             return;
         }
         let nonce = generate_nonce();
@@ -708,7 +708,13 @@ impl<'a> DouyinRequest<'a> {
             .ok_or_else(|| ExtractorError::ValidationError("Stream is not live".to_string()))?;
         let streams = self.extract_streams(stream_url)?;
         let mut extras = FxHashMap::default();
-        extras.insert("id_str".to_string(), self.id_str.clone().unwrap());
+        if let Some(id) = self
+            .id_str
+            .clone()
+            .or_else(|| (!data.id_str.is_empty()).then(|| data.id_str.to_string()))
+        {
+            extras.insert("id_str".to_string(), id);
+        }
 
         Ok(MediaInfo::new(
             self.config.extractor.url.clone(),

--- a/crates/platforms/src/extractor/platforms/douyin/utils.rs
+++ b/crates/platforms/src/extractor/platforms/douyin/utils.rs
@@ -2,10 +2,12 @@ use rand::{RngExt, rng};
 use reqwest::Client;
 use serde_json::json;
 use std::sync::LazyLock;
+use std::time::{Duration, Instant};
 use std::{
     collections::HashMap,
     sync::{Arc, Mutex},
 };
+use tokio::sync::Mutex as AsyncMutex;
 use tracing::debug;
 
 use crate::extractor::platforms::douyin::URL_REGEX;
@@ -16,8 +18,30 @@ use crate::extractor::{
     utils::capture_group_1_owned,
 };
 
-pub static GLOBAL_TTWID: LazyLock<Arc<Mutex<Option<String>>>> =
+const TTWID_CACHE_EXPIRATION: Duration = Duration::from_secs(2 * 60 * 60);
+
+#[derive(Clone)]
+struct CachedTtwid {
+    value: String,
+    fetched_at: Instant,
+}
+
+impl CachedTtwid {
+    fn new(value: String) -> Self {
+        Self {
+            value,
+            fetched_at: Instant::now(),
+        }
+    }
+
+    fn is_stale(&self) -> bool {
+        self.fetched_at.elapsed() >= TTWID_CACHE_EXPIRATION
+    }
+}
+
+static GLOBAL_TTWID: LazyLock<Arc<Mutex<Option<CachedTtwid>>>> =
     LazyLock::new(|| Arc::new(Mutex::new(None)));
+static GLOBAL_TTWID_FETCH_LOCK: LazyLock<AsyncMutex<()>> = LazyLock::new(|| AsyncMutex::new(()));
 
 pub(crate) fn extract_rid(url: &str) -> Result<String, ExtractorError> {
     capture_group_1_owned(&URL_REGEX, url).ok_or(ExtractorError::ValidationError(
@@ -91,10 +115,13 @@ pub(crate) const DEFAULT_TTWID: &str = "1%7Cu7ogdHsSmHtxbt4hjDCNvcLfVJz78CTM0TTW
 ///
 /// * `client` - A `&reqwest::Client` to use for the request.
 ///
-/// # Returns
+/// Returns the freshly fetched `ttwid`.
 ///
-/// A `String` containing the extracted `ttwid`, or the `DEFAULT_TTWID` as a fallback.
-pub async fn fetch_ttwid(client: &Client) -> String {
+/// # Errors
+///
+/// Returns an [`ExtractorError`] if the registration request fails, returns an
+/// unsuccessful status, or omits the `ttwid` cookie.
+pub async fn fetch_ttwid(client: &Client) -> Result<String, ExtractorError> {
     let json = json!({
         "region": "cn",
         "aid": 6383,
@@ -105,19 +132,13 @@ pub async fn fetch_ttwid(client: &Client) -> String {
     });
 
     // Fetch ttwid from Douyin's ttwid endpoint
-    let response = match client
+    let response = client
         .post(UNION_REGISTER_URL)
         .header(reqwest::header::USER_AGENT, DEFAULT_UA)
         .json(&json)
         .send()
-        .await
-    {
-        Ok(resp) => resp,
-        Err(e) => {
-            debug!("Failed to fetch ttwid: {}", e);
-            return DEFAULT_TTWID.to_string();
-        }
-    };
+        .await?
+        .error_for_status()?;
 
     // Extract ttwid from response cookies
     response
@@ -125,7 +146,6 @@ pub async fn fetch_ttwid(client: &Client) -> String {
         .get_all("set-cookie")
         .iter()
         .filter_map(|header_value| {
-            debug!("header_value: {:?}", header_value);
             header_value.to_str().ok().and_then(|cookie_str| {
                 if cookie_str.contains("ttwid=") {
                     cookie_str
@@ -140,9 +160,10 @@ pub async fn fetch_ttwid(client: &Client) -> String {
             })
         })
         .next()
-        .unwrap_or_else(|| {
-            debug!("Failed to extract ttwid from response, using default");
-            DEFAULT_TTWID.to_string()
+        .ok_or_else(|| {
+            ExtractorError::ValidationError(
+                "Failed to extract ttwid from Douyin register response".to_string(),
+            )
         })
 }
 
@@ -162,15 +183,19 @@ impl GlobalTtwidManager {
         Self
     }
 
-    /// Get the current global ttwid if it exists
+    /// Get the current global ttwid if it exists and has not expired.
     pub fn get_global_ttwid() -> Option<String> {
-        GLOBAL_TTWID.lock().ok().and_then(|g| g.clone())
+        let guard = GLOBAL_TTWID.lock().ok()?;
+        guard
+            .as_ref()
+            .filter(|cached| !cached.is_stale())
+            .map(|cached| cached.value.clone())
     }
 
-    /// Set the global ttwid
+    /// Set the global ttwid and reset its cache lifetime.
     pub fn set_global_ttwid(ttwid: &str) {
         if let Ok(mut guard) = GLOBAL_TTWID.lock() {
-            *guard = Some(ttwid.to_string());
+            *guard = Some(CachedTtwid::new(ttwid.to_string()));
         }
     }
 
@@ -189,25 +214,29 @@ impl GlobalTtwidManager {
     }
 
     /// Fetch a fresh ttwid from Douyin's servers and store it globally.
-    /// This method is thread-safe and prevents multiple concurrent requests.
+    /// Concurrent callers share one network fetch.
     ///
-    /// # Returns
+    /// Returns the fetched token without caching failed fallback values.
     ///
-    /// The ttwid value that was fetched and stored globally, or the default ttwid if the request failed.
+    /// # Errors
+    ///
+    /// Returns an [`ExtractorError`] if the registration request fails or does
+    /// not contain a valid `ttwid` cookie.
     pub async fn fetch_and_store_global_ttwid(client: &Client) -> Result<String, ExtractorError> {
-        // First check if we already have a global ttwid
         if let Some(existing_ttwid) = Self::get_global_ttwid() {
-            debug!("Using existing global ttwid: {}", existing_ttwid);
+            debug!("Using cached global ttwid");
+            return Ok(existing_ttwid);
+        }
+
+        let _fetch_guard = GLOBAL_TTWID_FETCH_LOCK.lock().await;
+        if let Some(existing_ttwid) = Self::get_global_ttwid() {
             return Ok(existing_ttwid);
         }
 
         debug!("Fetching fresh ttwid from Douyin servers (global)");
 
-        let ttwid = fetch_ttwid(client).await;
+        let ttwid = fetch_ttwid(client).await?;
 
-        debug!("Fetched global ttwid: {}", ttwid);
-
-        // Store the ttwid globally
         Self::set_global_ttwid(&ttwid);
 
         Ok(ttwid)
@@ -217,9 +246,12 @@ impl GlobalTtwidManager {
     /// This is a convenience method that checks for an existing global ttwid and only
     /// makes a network request if one doesn't exist.
     ///
-    /// # Returns
+    /// Returns the fresh cached token or the token fetched from Douyin.
     ///
-    /// The global ttwid value (either existing or newly fetched)
+    /// # Errors
+    ///
+    /// Returns an [`ExtractorError`] if a fresh token is required and the
+    /// registration request fails or omits the `ttwid` cookie.
     pub async fn ensure_global_ttwid(client: &Client) -> Result<String, ExtractorError> {
         if let Some(existing_ttwid) = Self::get_global_ttwid() {
             Ok(existing_ttwid)
@@ -231,7 +263,7 @@ impl GlobalTtwidManager {
 
 #[cfg(test)]
 mod tests {
-    use crate::extractor::platforms::douyin::utils::GlobalTtwidManager;
+    use super::*;
 
     #[test]
     fn test_global_ttwid_manager() {
@@ -249,6 +281,18 @@ mod tests {
         // Clear it
         GlobalTtwidManager::clear_global_ttwid();
         assert_eq!(GlobalTtwidManager::get_global_ttwid(), None);
+    }
+
+    #[test]
+    fn cached_ttwid_expires() {
+        let fresh = CachedTtwid::new("fresh".to_string());
+        assert!(!fresh.is_stale());
+
+        let stale = CachedTtwid {
+            value: "stale".to_string(),
+            fetched_at: Instant::now() - TTWID_CACHE_EXPIRATION,
+        };
+        assert!(stale.is_stale());
     }
 
     #[tokio::test]

--- a/crates/platforms/src/extractor/platforms/douyin/utils.rs
+++ b/crates/platforms/src/extractor/platforms/douyin/utils.rs
@@ -216,7 +216,8 @@ impl GlobalTtwidManager {
     /// Fetch a fresh ttwid from Douyin's servers and store it globally.
     /// Concurrent callers share one network fetch.
     ///
-    /// Returns the fetched token without caching failed fallback values.
+    /// On failure nothing is stored in `GLOBAL_TTWID`, so the next caller
+    /// retries the fetch.
     ///
     /// # Errors
     ///
@@ -288,9 +289,14 @@ mod tests {
         let fresh = CachedTtwid::new("fresh".to_string());
         assert!(!fresh.is_stale());
 
+        // checked_sub: subtracting the 2h expiration underflows Instant on
+        // hosts whose monotonic clock started less than 2h ago (fresh VMs).
+        let Some(expired_fetch) = Instant::now().checked_sub(TTWID_CACHE_EXPIRATION) else {
+            return;
+        };
         let stale = CachedTtwid {
             value: "stale".to_string(),
-            fetched_at: Instant::now() - TTWID_CACHE_EXPIRATION,
+            fetched_at: expired_fetch,
         };
         assert!(stale.is_stale());
     }

--- a/crates/platforms/src/extractor/platforms/twitch/builder.rs
+++ b/crates/platforms/src/extractor/platforms/twitch/builder.rs
@@ -20,7 +20,6 @@ pub static URL_REGEX: LazyLock<Regex> =
 
 pub struct Twitch {
     extractor: Extractor,
-    skip_live_extraction: bool,
 }
 
 impl Twitch {
@@ -47,10 +46,7 @@ impl Twitch {
         if let Some(cookies) = cookies {
             extractor.set_cookies_from_string(&cookies);
         }
-        Self {
-            extractor,
-            skip_live_extraction: false,
-        }
+        Self { extractor }
     }
 
     fn get_device_id() -> String {
@@ -200,7 +196,7 @@ impl Twitch {
             .and_then(|s| DateTime::parse_from_rfc3339(s).ok())
             .map(|dt| dt.with_timezone(&Utc));
 
-        if !is_live || self.skip_live_extraction {
+        if !is_live {
             return Ok(MediaInfo::builder(Self::BASE_URL, title, artist)
                 .category_opt(category)
                 .live_start_time_opt(live_start_time)

--- a/crates/platforms/src/extractor/platforms/twitch/danmu.rs
+++ b/crates/platforms/src/extractor/platforms/twitch/danmu.rs
@@ -24,22 +24,12 @@ const HEARTBEAT_INTERVAL_SECS: u64 = 300;
 
 /// Twitch Danmu Protocol Implementation using WebSocket IRC
 #[derive(Clone, Default)]
-pub struct TwitchDanmuProtocol {
-    /// Optional OAuth token for authenticated sessions
-    oauth_token: Option<String>,
-}
+pub struct TwitchDanmuProtocol;
 
 impl TwitchDanmuProtocol {
     /// Create a new TwitchDanmuProtocol instance (anonymous).
     pub fn new() -> Self {
-        Self::default()
-    }
-
-    /// Create a new TwitchDanmuProtocol with OAuth token for authenticated access.
-    pub fn with_oauth(token: impl Into<String>) -> Self {
-        Self {
-            oauth_token: Some(token.into()),
-        }
+        Self
     }
 
     /// Generate random anonymous username
@@ -170,26 +160,8 @@ impl DanmuProtocol for TwitchDanmuProtocol {
             "CAP REQ :twitch.tv/tags twitch.tv/commands".into(),
         ));
 
-        // Send PASS (OAuth token or empty for anonymous)
-        let pass = if let Some(ref token) = self.oauth_token {
-            if token.starts_with("oauth:") {
-                format!("PASS {}", token)
-            } else {
-                format!("PASS oauth:{}", token)
-            }
-        } else {
-            "PASS oauth:".to_string()
-        };
-        messages.push(Message::Text(pass.into()));
-
-        // Send NICK
-        let nick = if self.oauth_token.is_some() {
-            // For authenticated, the nick should match the token owner
-            // But for simplicity, we still use anonymous nick pattern
-            Self::generate_anonymous_nick()
-        } else {
-            Self::generate_anonymous_nick()
-        };
+        messages.push(Message::Text("PASS oauth:".into()));
+        let nick = Self::generate_anonymous_nick();
         messages.push(Message::Text(format!("NICK {}", nick).into()));
 
         // Join channel
@@ -272,7 +244,7 @@ pub type TwitchDanmuProvider = WebSocketDanmuProvider<TwitchDanmuProtocol>;
 
 /// Creates a new Twitch danmu provider (anonymous).
 pub fn create_twitch_danmu_provider() -> TwitchDanmuProvider {
-    WebSocketDanmuProvider::with_factory(TwitchDanmuProtocol::default(), None)
+    WebSocketDanmuProvider::with_factory(TwitchDanmuProtocol, None)
 }
 
 #[cfg(test)]
@@ -304,7 +276,7 @@ mod tests {
 
     #[tokio::test]
     async fn ping_returns_pong_as_outbound_protocol_frame() {
-        let mut protocol = TwitchDanmuProtocol::default();
+        let mut protocol = TwitchDanmuProtocol;
         let output = protocol
             .decode_message(&Message::Text("PING :tmi.twitch.tv".into()), "channel")
             .await

--- a/crates/platforms/src/extractor/platforms/weibo/builder.rs
+++ b/crates/platforms/src/extractor/platforms/weibo/builder.rs
@@ -1,8 +1,8 @@
 use async_trait::async_trait;
 use regex::Regex;
 use reqwest::Client;
-use std::sync::LazyLock;
-use tracing::debug;
+use std::sync::{LazyLock, Once};
+use tracing::{debug, warn};
 use url::Url;
 
 use crate::{
@@ -17,6 +17,7 @@ use crate::{
 pub static URL_REGEX: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r"^(?:https?://)?(?:www\.)?weibo\.com/(?:u/\d+|l/wblive/p/show/\d+:\d+)").unwrap()
 });
+static MISSING_COOKIE_WARNING: Once = Once::new();
 
 pub struct Weibo {
     extractor: Extractor,
@@ -41,6 +42,12 @@ impl Weibo {
         extractor.set_referer_static(Self::BASE_URL);
         if let Some(cookies) = cookies {
             extractor.set_cookies_from_string(&cookies);
+        } else {
+            MISSING_COOKIE_WARNING.call_once(|| {
+                warn!(
+                    "weibo: no user cookies configured; using the bundled session, which may expire"
+                );
+            });
         }
         Self {
             extractor,
@@ -143,19 +150,10 @@ impl Weibo {
 
         // debug!("response: {:?}", response);
 
-        if response.data.is_none() {
+        let Some(data) = response.data else {
             return Ok(MediaInfo::builder(self.extractor.url.clone(), "", "")
                 .is_live(false)
                 .build());
-        }
-
-        let data = match response.data {
-            Some(v) => v,
-            None => {
-                return Ok(MediaInfo::builder(self.extractor.url.clone(), "", "")
-                    .is_live(false)
-                    .build());
-            }
         };
         let user_info = data.user_info;
 


### PR DESCRIPTION
## Severity

P2-05

## What changed

- Reuse Bigo integrity tokens across extractor instances with TTL and use-count limits.
- Serialize Bigo cache refreshes so concurrent polls share one mint request.
- Expire Douyin `ttwid` values after two hours, serialize refreshes, and propagate failed refreshes instead of caching a hard-coded fallback.
- Check Douyin cookie state in the cookie map and avoid assuming every live response contains the PC room identifier.
- Make Bigo challenge slicing UTF-8 safe, remove Twitch authentication state that could only produce an invalid anonymous login, and emit the Weibo fallback-cookie warning once per process.

## Why

Platform extractor instances are recreated across polling cycles. The existing per-instance usage bypassed Bigo's cache, while Douyin's process-wide cache never expired and could permanently retain a stale fallback after a transient request failure. Some adjacent state checks also targeted the wrong map or retained authentication state that could not be used correctly.

## Impact

Polling performs fewer token requests, concurrent refreshes do not stampede platform endpoints, stale credentials are retried, and malformed or partial platform responses no longer trigger the covered invalid state paths.

## Validation

- `cargo test --locked -p platforms-parser --lib` (213 passed, 33 ignored)
- `cargo clippy --locked -p platforms-parser --all-targets -- -D warnings`
- `cargo doc --locked -p platforms-parser --no-deps`
- `git diff --check`