### PR TITLE
fix(frontend): repair WebSocket lifecycles

### DIFF
--- a/rust-srec/frontend/src/components/logging/log-viewer.tsx
+++ b/rust-srec/frontend/src/components/logging/log-viewer.tsx
@@ -138,6 +138,7 @@ export function LogViewer() {
   const [logs, setLogs] = useState<DisplayLogEvent[]>([]);
   const [isPaused, setIsPaused] = useState(false);
   const [isConnected, setIsConnected] = useState(false);
+  const [pausedCount, setPausedCount] = useState(0);
   const [filterLevel, setFilterLevel] = useState<FilterLevel>('all');
   const [searchQuery, setSearchQuery] = useState('');
   const [autoScroll, setAutoScroll] = useState(true);
@@ -147,6 +148,7 @@ export function LogViewer() {
   const reconnectTimeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>(
     undefined,
   );
+  const disposedRef = useRef(false);
   const logContainerRef = useRef<HTMLDivElement>(null);
   const logIdRef = useRef(0);
   const pausedLogsRef = useRef<DisplayLogEvent[]>([]);
@@ -184,6 +186,7 @@ export function LogViewer() {
               pausedLogsRef.current =
                 pausedLogsRef.current.slice(-MAX_LOG_ENTRIES);
             }
+            setPausedCount(pausedLogsRef.current.length);
           } else {
             setLogs((prev) => {
               const newLogs = [...prev, logEvent];
@@ -200,12 +203,23 @@ export function LogViewer() {
     [isPaused],
   );
 
+  const handleMessageRef = useRef(handleMessage);
+  useEffect(() => {
+    handleMessageRef.current = handleMessage;
+  }, [handleMessage]);
+
   // Connect to WebSocket
   const connect = useCallback(() => {
     if (!accessToken) return;
     if (typeof window === 'undefined') return;
     if (wsRef.current?.readyState === WebSocket.OPEN) return;
     if (wsRef.current?.readyState === WebSocket.CONNECTING) return;
+
+    if (reconnectTimeoutRef.current) {
+      clearTimeout(reconnectTimeoutRef.current);
+      reconnectTimeoutRef.current = undefined;
+    }
+    disposedRef.current = false;
 
     const wsUrl = buildWebSocketUrl(accessToken, '/logging/stream');
     if (import.meta.env.DEV) {
@@ -215,6 +229,10 @@ export function LogViewer() {
     ws.binaryType = 'arraybuffer';
 
     ws.onopen = () => {
+      if (wsRef.current !== ws) {
+        ws.close();
+        return;
+      }
       if (import.meta.env.DEV) {
         console.debug('[LOG WS] Connected');
       }
@@ -222,9 +240,13 @@ export function LogViewer() {
       reconnectAttemptRef.current = 0;
     };
 
-    ws.onmessage = handleMessage;
+    ws.onmessage = (event) => {
+      if (wsRef.current === ws) handleMessageRef.current(event);
+    };
 
     ws.onclose = (event) => {
+      if (wsRef.current !== ws) return;
+
       if (import.meta.env.DEV) {
         console.debug('[LOG WS] Close', {
           code: event.code,
@@ -235,8 +257,7 @@ export function LogViewer() {
       setIsConnected(false);
       wsRef.current = null;
 
-      // Reconnect if we have a token
-      if (accessToken) {
+      if (!disposedRef.current && accessToken) {
         const delay = Math.min(
           WS_RECONNECT_BASE_DELAY * Math.pow(2, reconnectAttemptRef.current),
           WS_RECONNECT_MAX_DELAY,
@@ -247,6 +268,8 @@ export function LogViewer() {
     };
 
     ws.onerror = (event) => {
+      if (wsRef.current !== ws) return;
+
       if (import.meta.env.DEV) {
         console.error('[LOG WS] Connection error', event);
       }
@@ -254,17 +277,20 @@ export function LogViewer() {
     };
 
     wsRef.current = ws;
-  }, [accessToken, handleMessage]);
+  }, [accessToken]);
 
   // Disconnect
   const disconnect = useCallback(() => {
+    disposedRef.current = true;
     if (reconnectTimeoutRef.current) {
       clearTimeout(reconnectTimeoutRef.current);
+      reconnectTimeoutRef.current = undefined;
     }
     if (wsRef.current) {
       wsRef.current.close();
       wsRef.current = null;
     }
+    setIsConnected(false);
   }, []);
 
   // Connection lifecycle
@@ -293,6 +319,7 @@ export function LogViewer() {
           ? combined.slice(-MAX_LOG_ENTRIES)
           : combined;
       });
+      setPausedCount(0);
     }
     setIsPaused(!isPaused);
   }, [isPaused]);
@@ -301,6 +328,7 @@ export function LogViewer() {
   const clearLogs = useCallback(() => {
     setLogs([]);
     pausedLogsRef.current = [];
+    setPausedCount(0);
   }, []);
 
   // Filter logs - memoized to avoid recalculating on every render
@@ -511,9 +539,9 @@ export function LogViewer() {
         <div className="flex items-center justify-between mt-3 text-xs text-muted-foreground">
           <span>
             {filteredLogs.length} / {logs.length} <Trans>entries</Trans>
-            {isPaused && pausedLogsRef.current.length > 0 && (
+            {isPaused && pausedCount > 0 && (
               <span className="ml-2 text-amber-400">
-                (+{pausedLogsRef.current.length} <Trans>paused</Trans>)
+                (+{pausedCount} <Trans>paused</Trans>)
               </span>
             )}
           </span>

--- a/rust-srec/frontend/src/providers/WebSocketProvider.tsx
+++ b/rust-srec/frontend/src/providers/WebSocketProvider.tsx
@@ -50,6 +50,7 @@ export function WebSocketProvider({ children }: { children: ReactNode }) {
     undefined,
   );
   const isConnectingRef = useRef<boolean>(false);
+  const intentionalCloseRef = useRef<boolean>(false);
 
   // Auth state
   const { user: routeUser } = useRouteContext({ from: '/_authed' }) as {
@@ -341,6 +342,11 @@ export function WebSocketProvider({ children }: { children: ReactNode }) {
     if (wsRef.current?.readyState === WebSocket.OPEN) return;
     if (wsRef.current?.readyState === WebSocket.CONNECTING) return;
 
+    if (reconnectTimeoutRef.current) {
+      clearTimeout(reconnectTimeoutRef.current);
+      reconnectTimeoutRef.current = undefined;
+    }
+    intentionalCloseRef.current = false;
     isConnectingRef.current = true;
     setConnectionStatus('connecting');
 
@@ -352,6 +358,10 @@ export function WebSocketProvider({ children }: { children: ReactNode }) {
     ws.binaryType = 'arraybuffer';
 
     ws.onopen = () => {
+      if (wsRef.current !== ws) {
+        ws.close();
+        return;
+      }
       console.debug('[WS] Connected');
       isConnectingRef.current = false;
       setConnectionStatus('connected');
@@ -365,9 +375,13 @@ export function WebSocketProvider({ children }: { children: ReactNode }) {
       ws.send(toBinary(ClientMessageSchema, clientMessage));
     };
 
-    ws.onmessage = handleMessage;
+    ws.onmessage = (event) => {
+      if (wsRef.current === ws) handleMessage(event);
+    };
 
     ws.onclose = (event) => {
+      if (wsRef.current !== ws) return;
+
       if (import.meta.env.DEV) {
         console.debug('[WS] Close', {
           code: event.code,
@@ -380,12 +394,14 @@ export function WebSocketProvider({ children }: { children: ReactNode }) {
       setConnectionStatus('disconnected');
       wsRef.current = null;
 
-      if (sessionData?.token?.access_token) {
+      if (!intentionalCloseRef.current && sessionData?.token?.access_token) {
         scheduleReconnect();
       }
     };
 
     ws.onerror = (event) => {
+      if (wsRef.current !== ws) return;
+
       if (import.meta.env.DEV) {
         console.error('[WS] Connection error', event);
       } else {
@@ -417,6 +433,8 @@ export function WebSocketProvider({ children }: { children: ReactNode }) {
   }, [connect]);
 
   const disconnect = useCallback(() => {
+    intentionalCloseRef.current = true;
+
     if (reconnectTimeoutRef.current) {
       clearTimeout(reconnectTimeoutRef.current);
       reconnectTimeoutRef.current = undefined;

--- a/rust-srec/frontend/src/providers/__tests__/websocket-lifecycles.test.tsx
+++ b/rust-srec/frontend/src/providers/__tests__/websocket-lifecycles.test.tsx
@@ -1,0 +1,148 @@
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from '@testing-library/react';
+import { setupI18n } from '@lingui/core';
+import { I18nProvider } from '@lingui/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+import { LogViewer } from '@/components/logging/log-viewer';
+import { WebSocketProvider } from '../WebSocketProvider';
+
+const routeContext = vi.hoisted(() => ({
+  user: { token: { access_token: 'token-a' } },
+}));
+
+vi.mock('@tanstack/react-router', () => ({
+  useRouteContext: () => routeContext,
+}));
+
+class MockWebSocket {
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
+  static readonly CLOSING = 2;
+  static readonly CLOSED = 3;
+  static instances: MockWebSocket[] = [];
+
+  readonly url: string;
+  readyState = MockWebSocket.CONNECTING;
+  binaryType: BinaryType = 'blob';
+  onopen: ((event: Event) => void) | null = null;
+  onmessage: ((event: MessageEvent) => void) | null = null;
+  onclose: ((event: CloseEvent) => void) | null = null;
+  onerror: ((event: Event) => void) | null = null;
+  send = vi.fn();
+
+  constructor(url: string | URL) {
+    this.url = url.toString();
+    MockWebSocket.instances.push(this);
+  }
+
+  close() {
+    this.readyState = MockWebSocket.CLOSED;
+  }
+
+  emitClose() {
+    this.onclose?.(new CloseEvent('close'));
+  }
+}
+
+function createQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, staleTime: Infinity },
+    },
+  });
+}
+
+async function rotateToken(queryClient: QueryClient) {
+  await act(async () => {
+    queryClient.setQueryData(['session'], {
+      token: { access_token: 'token-b' },
+    });
+    await vi.advanceTimersByTimeAsync(0);
+  });
+  expect(MockWebSocket.instances).toHaveLength(2);
+}
+
+describe('WebSocket lifecycle ownership', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    MockWebSocket.instances = [];
+    routeContext.user = { token: { access_token: 'token-a' } };
+    vi.stubGlobal('WebSocket', MockWebSocket);
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it('ignores a stale provider socket close after token rotation', async () => {
+    const queryClient = createQueryClient();
+    render(
+      <QueryClientProvider client={queryClient}>
+        <WebSocketProvider>
+          <div>child</div>
+        </WebSocketProvider>
+      </QueryClientProvider>,
+    );
+
+    const staleSocket = MockWebSocket.instances[0];
+    await rotateToken(queryClient);
+
+    act(() => {
+      staleSocket.emitClose();
+      vi.advanceTimersByTime(WS_RECONNECT_WINDOW_MS);
+    });
+
+    expect(MockWebSocket.instances).toHaveLength(2);
+  });
+
+  it('ignores a stale log socket close after token rotation', async () => {
+    const queryClient = createQueryClient();
+    const i18n = setupI18n({ locale: 'en', messages: { en: {} } });
+    render(
+      <QueryClientProvider client={queryClient}>
+        <I18nProvider i18n={i18n}>
+          <LogViewer />
+        </I18nProvider>
+      </QueryClientProvider>,
+    );
+
+    const staleSocket = MockWebSocket.instances[0];
+    await rotateToken(queryClient);
+
+    act(() => {
+      staleSocket.emitClose();
+      vi.advanceTimersByTime(WS_RECONNECT_WINDOW_MS);
+    });
+
+    expect(MockWebSocket.instances).toHaveLength(2);
+  });
+
+  it('keeps the log socket open when pausing the viewer', async () => {
+    const queryClient = createQueryClient();
+    const i18n = setupI18n({ locale: 'en', messages: { en: {} } });
+    render(
+      <QueryClientProvider client={queryClient}>
+        <I18nProvider i18n={i18n}>
+          <LogViewer />
+        </I18nProvider>
+      </QueryClientProvider>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Pause' }));
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(MockWebSocket.instances).toHaveLength(1);
+  });
+});
+
+const WS_RECONNECT_WINDOW_MS = 30_000;


### PR DESCRIPTION
## Severity

P2-06

## What changed

- Mark deliberate socket shutdowns so close handlers do not schedule reconnects during cleanup or token rotation.
- Ignore open, message, error, and close events from sockets that no longer own the active ref.
- Cancel superseded reconnect timers before establishing a replacement connection.
- Route log messages through the latest pause-aware handler without rebuilding the socket when pause state changes.
- Track the paused log count in state and add regression coverage for stale closes and pause toggles.

## Why

Socket event handlers outlive the render that created them. A close event from a replaced socket could clear the current socket ref and schedule another connection, while the log viewer effect rebuilt its socket whenever pause state changed. Cleanup closes could also reconnect after unmount or token rotation.

## Impact

The download and log streams keep one active owner across reconnects, authentication changes, unmounts, and pause toggles. Stale callbacks cannot overwrite current connection state.

## Validation

- `pnpm run lint`
- `pnpm test` (129 passed)
- `pnpm run build`
- `git diff --check`