### PR TITLE
fix(frontend): preserve sessions across transient errors

### DIFF
--- a/rust-srec/frontend/src/api/session.test.ts
+++ b/rust-srec/frontend/src/api/session.test.ts
@@ -1,0 +1,36 @@
+import { QueryClient } from '@tanstack/react-query';
+
+import { sessionQueryOptions } from './session';
+
+const checkAuthFnMock = vi.hoisted(() => vi.fn());
+
+vi.mock('@/server/functions', () => ({
+  checkAuthFn: checkAuthFnMock,
+}));
+
+describe('sessionQueryOptions', () => {
+  it('retains the last session when an authentication check rejects', async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const session = {
+      username: 'user',
+      token: {
+        access_token: 'access-token',
+        expires_in: Date.now() + 60_000,
+        refresh_expires_in: Date.now() + 120_000,
+      },
+      roles: [],
+      mustChangePassword: false,
+    };
+    queryClient.setQueryData(sessionQueryOptions.queryKey, session);
+    checkAuthFnMock.mockRejectedValueOnce(new Error('temporary failure'));
+
+    await expect(queryClient.fetchQuery(sessionQueryOptions)).rejects.toThrow(
+      'temporary failure',
+    );
+    expect(queryClient.getQueryData(sessionQueryOptions.queryKey)).toEqual(
+      session,
+    );
+  });
+});

--- a/rust-srec/frontend/src/api/session.ts
+++ b/rust-srec/frontend/src/api/session.ts
@@ -3,13 +3,7 @@ import { checkAuthFn } from '@/server/functions';
 
 export const sessionQueryOptions = queryOptions({
   queryKey: ['session'],
-  queryFn: async () => {
-    try {
-      const result = await checkAuthFn();
-      return result;
-    } catch (e) {
-      console.error('Session check failed', e);
-      return null;
-    }
-  },
+  // Only an explicit null means unauthenticated; rejected checks must leave
+  // React Query's last known session intact for retry.
+  queryFn: () => checkAuthFn(),
 });

--- a/rust-srec/frontend/src/server/__tests__/api.test.ts
+++ b/rust-srec/frontend/src/server/__tests__/api.test.ts
@@ -1,0 +1,54 @@
+import { BackendApiError } from '@/lib/api-error';
+import { fetchBackend } from '../api';
+
+const refreshAuthTokenGlobalMock = vi.hoisted(() => vi.fn());
+const useAppSessionMock = vi.hoisted(() => vi.fn());
+
+vi.mock('../tokenRefresh', () => ({
+  refreshAuthTokenGlobal: refreshAuthTokenGlobalMock,
+}));
+
+vi.mock('@/utils/session.server', () => ({
+  useAppSession: useAppSessionMock,
+}));
+
+vi.mock('@/utils/env', () => ({
+  BASE_URL: 'http://backend.test',
+}));
+
+describe('fetchBackend', () => {
+  beforeEach(() => {
+    useAppSessionMock.mockResolvedValue({
+      data: { token: { access_token: 'old-token' } },
+      update: vi.fn(),
+    });
+    refreshAuthTokenGlobalMock.mockResolvedValue('new-token');
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('preserves the retried response error after a successful refresh', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(null, { status: 401 }))
+      .mockResolvedValueOnce(
+        Response.json(
+          { detail: 'invalid request' },
+          { status: 422, statusText: 'Unprocessable Entity' },
+        ),
+      );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const request = fetchBackend('/resource');
+
+    await expect(request).rejects.toMatchObject<Partial<BackendApiError>>({
+      status: 422,
+      body: { detail: 'invalid request' },
+    });
+    const retryHeaders = fetchMock.mock.calls[1][1]?.headers as Headers;
+    expect(retryHeaders.get('Authorization')).toBe('Bearer new-token');
+  });
+});

--- a/rust-srec/frontend/src/server/api.ts
+++ b/rust-srec/frontend/src/server/api.ts
@@ -128,6 +128,9 @@ export const fetchBackend = async <T = any>(
           );
         }
       } catch (refreshError) {
+        if (refreshError instanceof BackendApiError) {
+          throw refreshError;
+        }
         console.error(
           '[API] Token refresh failed during interceptor:',
           refreshError,

--- a/rust-srec/frontend/src/server/functions/config.ts
+++ b/rust-srec/frontend/src/server/functions/config.ts
@@ -34,26 +34,9 @@ const GlobalConfigUpdateSchema = GlobalConfigWriteSchema.extend({
 });
 
 export const updateGlobalConfig = createServerFn({ method: 'POST' })
-  .inputValidator((data: z.infer<typeof GlobalConfigWriteSchema>) => {
-    console.log(
-      'updateGlobalConfig inputValidator - raw data.pipeline:',
-      typeof data.pipeline,
-      data.pipeline,
-    );
-    return data;
-  })
+  .inputValidator((data: z.infer<typeof GlobalConfigWriteSchema>) => data)
   .handler(async ({ data }) => {
-    console.log(
-      'updateGlobalConfig handler - data.pipeline before parse:',
-      typeof data.pipeline,
-      data.pipeline,
-    );
     const payload = GlobalConfigUpdateSchema.parse(data);
-    console.log(
-      'updateGlobalConfig handler - payload.pipeline after parse:',
-      typeof payload.pipeline,
-      payload.pipeline,
-    );
     await fetchBackend('/config/global', {
       method: 'PATCH',
       body: JSON.stringify(payload),
@@ -104,9 +87,7 @@ export const updatePlatformConfig = createServerFn({ method: 'POST' })
       d,
   )
   .handler(async ({ data: { id, data } }) => {
-    console.log('updatePlatformConfig input:', data);
     const payload = PlatformConfigWriteSchema.parse(data);
-    console.log('updatePlatformConfig serialized:', payload);
     const json = await fetchBackend(`/config/platforms/${id}`, {
       method: 'PUT',
       body: JSON.stringify(payload),
@@ -160,13 +141,11 @@ export const createTemplate = createServerFn({ method: 'POST' })
     TemplateWriteSchema.parse(data),
   )
   .handler(async ({ data }) => {
-    console.log('Creating template:', data);
     const payload = data;
     const json = await fetchBackend('/templates', {
       method: 'POST',
       body: JSON.stringify(payload),
     });
-    console.log('Template created:', json);
     return TemplateSchema.parse(json);
   });
 
@@ -178,13 +157,11 @@ export const updateTemplate = createServerFn({ method: 'POST' })
     }),
   )
   .handler(async ({ data: { id, data } }) => {
-    console.log('Updating template:', id, data);
     const payload = data;
     const json = await fetchBackend(`/templates/${id}`, {
       method: 'PUT',
       body: JSON.stringify(payload),
     });
-    console.log('Template updated:', json);
     return TemplateSchema.parse(json);
   });
 

--- a/rust-srec/frontend/src/server/functions/pipeline.ts
+++ b/rust-srec/frontend/src/server/functions/pipeline.ts
@@ -38,7 +38,7 @@ export const getPipelineJobLogs = createServerFn({ method: 'GET' })
     if (data.offset !== undefined) params.set('offset', data.offset.toString());
 
     const json = await fetchBackend(
-      `/pipeline/jobs/${data.id}/logs?${params.toString()}`,
+      `/pipeline/jobs/${encodeURIComponent(data.id)}/logs?${params.toString()}`,
     );
     return z
       .object({
@@ -59,14 +59,18 @@ export const getPipelineJobLogs = createServerFn({ method: 'GET' })
 export const getPipelineJobProgress = createServerFn({ method: 'GET' })
   .inputValidator((d: { id: string }) => d)
   .handler(async ({ data }) => {
-    const json = await fetchBackend(`/pipeline/jobs/${data.id}/progress`);
+    const json = await fetchBackend(
+      `/pipeline/jobs/${encodeURIComponent(data.id)}/progress`,
+    );
     return JobProgressSnapshotSchema.parse(json);
   });
 
 export const getPipelineJobUploads = createServerFn({ method: 'GET' })
   .inputValidator((d: { id: string }) => d)
   .handler(async ({ data }) => {
-    const json = await fetchBackend(`/pipeline/jobs/${data.id}/uploads`);
+    const json = await fetchBackend(
+      `/pipeline/jobs/${encodeURIComponent(data.id)}/uploads`,
+    );
     return UploadRecordListSchema.parse(json);
   });
 
@@ -100,28 +104,32 @@ export const listPipelines = createServerFn({ method: 'GET' })
 export const getDagExecution = createServerFn({ method: 'GET' })
   .inputValidator((id: string) => id)
   .handler(async ({ data: id }) => {
-    const json = await fetchBackend(`/pipeline/dag/${id}`);
+    const json = await fetchBackend(`/pipeline/dag/${encodeURIComponent(id)}`);
     return DagExecutionSchema.parse(json);
   });
 
 export const getDagGraph = createServerFn({ method: 'GET' })
   .inputValidator((id: string) => id)
   .handler(async ({ data: id }) => {
-    const json = await fetchBackend(`/pipeline/dag/${id}/graph`);
+    const json = await fetchBackend(
+      `/pipeline/dag/${encodeURIComponent(id)}/graph`,
+    );
     return DagGraphSchema.parse(json);
   });
 
 export const getDagStats = createServerFn({ method: 'GET' })
   .inputValidator((id: string) => id)
   .handler(async ({ data: id }) => {
-    const json = await fetchBackend(`/pipeline/dag/${id}/stats`);
+    const json = await fetchBackend(
+      `/pipeline/dag/${encodeURIComponent(id)}/stats`,
+    );
     return DagStatsSchema.parse(json);
   });
 
 export const cancelDag = createServerFn({ method: 'POST' })
   .inputValidator((id: string) => id)
   .handler(async ({ data: id }) => {
-    const json = await fetchBackend(`/pipeline/dag/${id}`, {
+    const json = await fetchBackend(`/pipeline/dag/${encodeURIComponent(id)}`, {
       method: 'DELETE',
     });
     return z
@@ -136,9 +144,12 @@ export const cancelDag = createServerFn({ method: 'POST' })
 export const retryDagSteps = createServerFn({ method: 'POST' })
   .inputValidator((id: string) => id)
   .handler(async ({ data: id }) => {
-    const json = await fetchBackend(`/pipeline/dag/${id}/retry`, {
-      method: 'POST',
-    });
+    const json = await fetchBackend(
+      `/pipeline/dag/${encodeURIComponent(id)}/retry`,
+      {
+        method: 'POST',
+      },
+    );
     return z
       .object({
         dag_id: z.string(),
@@ -193,27 +204,36 @@ export const getPipelineStats = createServerFn({ method: 'GET' }).handler(
 export const retryPipelineJob = createServerFn({ method: 'POST' })
   .inputValidator((id: string) => id)
   .handler(async ({ data: id }) => {
-    await fetchBackend(`/pipeline/jobs/${id}/retry`, { method: 'POST' });
+    await fetchBackend(`/pipeline/jobs/${encodeURIComponent(id)}/retry`, {
+      method: 'POST',
+    });
   });
 
 export const cancelActivePipelineJob = createServerFn({ method: 'POST' })
   .inputValidator((id: string) => id)
   .handler(async ({ data: id }) => {
-    await fetchBackend(`/pipeline/jobs/${id}/cancel`, { method: 'POST' });
+    await fetchBackend(`/pipeline/jobs/${encodeURIComponent(id)}/cancel`, {
+      method: 'POST',
+    });
   });
 
 export const deletePipelineJob = createServerFn({ method: 'POST' })
   .inputValidator((id: string) => id)
   .handler(async ({ data: id }) => {
-    await fetchBackend(`/pipeline/jobs/${id}`, { method: 'DELETE' });
+    await fetchBackend(`/pipeline/jobs/${encodeURIComponent(id)}`, {
+      method: 'DELETE',
+    });
   });
 
 export const cancelPipeline = createServerFn({ method: 'POST' })
   .inputValidator((pipelineId: string) => pipelineId)
   .handler(async ({ data: pipelineId }) => {
-    const json = await fetchBackend(`/pipeline/dag/${pipelineId}`, {
-      method: 'DELETE',
-    });
+    const json = await fetchBackend(
+      `/pipeline/dag/${encodeURIComponent(pipelineId)}`,
+      {
+        method: 'DELETE',
+      },
+    );
     return z
       .object({
         dag_id: z.string(),
@@ -226,9 +246,12 @@ export const cancelPipeline = createServerFn({ method: 'POST' })
 export const deletePipeline = createServerFn({ method: 'POST' })
   .inputValidator((pipelineId: string) => pipelineId)
   .handler(async ({ data: pipelineId }) => {
-    const json = await fetchBackend(`/pipeline/dag/${pipelineId}/delete`, {
-      method: 'DELETE',
-    });
+    const json = await fetchBackend(
+      `/pipeline/dag/${encodeURIComponent(pipelineId)}/delete`,
+      {
+        method: 'DELETE',
+      },
+    );
     return z
       .object({
         dag_id: z.string(),
@@ -251,7 +274,7 @@ export const createPipelineJob = createServerFn({ method: 'POST' })
 export const getPipelineJob = createServerFn({ method: 'GET' })
   .inputValidator((id: string) => id)
   .handler(async ({ data: id }) => {
-    const json = await fetchBackend(`/pipeline/jobs/${id}`);
+    const json = await fetchBackend(`/pipeline/jobs/${encodeURIComponent(id)}`);
     return JobSchema.parse(json);
   });
 
@@ -312,7 +335,9 @@ export const listPipelinePresets = createServerFn({ method: 'GET' })
 export const getPipelinePreset = createServerFn({ method: 'GET' })
   .inputValidator((id: string) => id)
   .handler(async ({ data: id }) => {
-    const json = await fetchBackend(`/pipeline/presets/${id}`);
+    const json = await fetchBackend(
+      `/pipeline/presets/${encodeURIComponent(id)}`,
+    );
     console.log(
       '[getPipelinePreset] Raw Response:',
       JSON.stringify(json, null, 2),
@@ -365,10 +390,13 @@ export const updatePipelinePreset = createServerFn({ method: 'POST' })
     );
     const { id, data: body } = data;
     try {
-      const json = await fetchBackend(`/pipeline/presets/${id}`, {
-        method: 'PUT',
-        body: JSON.stringify(body),
-      });
+      const json = await fetchBackend(
+        `/pipeline/presets/${encodeURIComponent(id)}`,
+        {
+          method: 'PUT',
+          body: JSON.stringify(body),
+        },
+      );
       console.log(
         '[updatePipelinePreset] Raw Response:',
         JSON.stringify(json, null, 2),
@@ -395,12 +423,16 @@ export const updatePipelinePreset = createServerFn({ method: 'POST' })
 export const deletePipelinePreset = createServerFn({ method: 'POST' })
   .inputValidator((id: string) => id)
   .handler(async ({ data: id }) => {
-    await fetchBackend(`/pipeline/presets/${id}`, { method: 'DELETE' });
+    await fetchBackend(`/pipeline/presets/${encodeURIComponent(id)}`, {
+      method: 'DELETE',
+    });
   });
 
 export const previewPipelinePreset = createServerFn({ method: 'GET' })
   .inputValidator((id: string) => id)
   .handler(async ({ data: id }) => {
-    const json = await fetchBackend(`/pipeline/presets/${id}/preview`);
+    const json = await fetchBackend(
+      `/pipeline/presets/${encodeURIComponent(id)}/preview`,
+    );
     return PipelinePresetPreviewSchema.parse(json);
   });

--- a/rust-srec/frontend/src/server/functions/pipeline.ts
+++ b/rust-srec/frontend/src/server/functions/pipeline.ts
@@ -338,29 +338,17 @@ export const getPipelinePreset = createServerFn({ method: 'GET' })
     const json = await fetchBackend(
       `/pipeline/presets/${encodeURIComponent(id)}`,
     );
-    console.log(
-      '[getPipelinePreset] Raw Response:',
-      JSON.stringify(json, null, 2),
-    );
     return PipelinePresetSchema.parse(json);
   });
 
 export const createPipelinePreset = createServerFn({ method: 'POST' })
   .inputValidator((d: z.infer<typeof CreatePipelinePresetRequestSchema>) => d)
   .handler(async ({ data }) => {
-    console.log(
-      '[createPipelinePreset] Payload:',
-      JSON.stringify(data, null, 2),
-    );
     try {
       const json = await fetchBackend('/pipeline/presets', {
         method: 'POST',
         body: JSON.stringify(data),
       });
-      console.log(
-        '[createPipelinePreset] Raw Response:',
-        JSON.stringify(json, null, 2),
-      );
       const parsed = PipelinePresetSchema.safeParse(json);
       if (!parsed.success) {
         console.error(
@@ -384,10 +372,6 @@ export const updatePipelinePreset = createServerFn({ method: 'POST' })
     }) => d,
   )
   .handler(async ({ data }) => {
-    console.log(
-      '[updatePipelinePreset] Payload:',
-      JSON.stringify(data, null, 2),
-    );
     const { id, data: body } = data;
     try {
       const json = await fetchBackend(
@@ -397,15 +381,7 @@ export const updatePipelinePreset = createServerFn({ method: 'POST' })
           body: JSON.stringify(body),
         },
       );
-      console.log(
-        '[updatePipelinePreset] Raw Response:',
-        JSON.stringify(json, null, 2),
-      );
       const parsed = PipelinePresetSchema.safeParse(json);
-      console.log(
-        '[updatePipelinePreset] Parsed Response:',
-        JSON.stringify(parsed, null, 2),
-      );
       if (!parsed.success) {
         console.error(
           '[updatePipelinePreset] Zod schema validation failed:',

--- a/rust-srec/frontend/src/utils/session-storage.test.ts
+++ b/rust-srec/frontend/src/utils/session-storage.test.ts
@@ -1,0 +1,37 @@
+import { parseStoredSession } from './session-storage';
+import { resolveSessionSecret } from './session.server';
+
+describe('parseStoredSession', () => {
+  it('returns an object from valid JSON', () => {
+    expect(parseStoredSession('{"username":"user"}')).toEqual({
+      username: 'user',
+    });
+  });
+
+  it.each([null, '', 'invalid', '[]', 'null'])(
+    'rejects non-session input %p',
+    (raw) => {
+      expect(parseStoredSession(raw)).toEqual({});
+    },
+  );
+});
+
+describe('resolveSessionSecret', () => {
+  it('uses the configured secret', () => {
+    expect(resolveSessionSecret('configured-secret', 'production')).toBe(
+      'configured-secret',
+    );
+  });
+
+  it('allows the built-in secret outside production', () => {
+    expect(resolveSessionSecret(undefined, 'development')).toContain(
+      'dev_secret',
+    );
+  });
+
+  it('rejects a missing production secret', () => {
+    expect(() => resolveSessionSecret(undefined, 'production')).toThrow(
+      'SESSION_SECRET must be set in production',
+    );
+  });
+});

--- a/rust-srec/frontend/src/utils/session-storage.ts
+++ b/rust-srec/frontend/src/utils/session-storage.ts
@@ -1,0 +1,27 @@
+import type { SessionData } from './session';
+
+export const BROWSER_SESSION_STORAGE_KEY = 'rust_srec_session_v1';
+
+export function isBrowserRuntime(): boolean {
+  return (
+    typeof window !== 'undefined' && typeof window.localStorage !== 'undefined'
+  );
+}
+
+export function parseStoredSession(raw: string | null): Partial<SessionData> {
+  if (!raw) return {};
+
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (
+      typeof parsed !== 'object' ||
+      parsed === null ||
+      Array.isArray(parsed)
+    ) {
+      return {};
+    }
+    return parsed as Partial<SessionData>;
+  } catch {
+    return {};
+  }
+}

--- a/rust-srec/frontend/src/utils/session.server.ts
+++ b/rust-srec/frontend/src/utils/session.server.ts
@@ -1,5 +1,10 @@
 import type { SessionData } from './session';
 import { isDesktopBuild } from '@/utils/desktop';
+import {
+  BROWSER_SESSION_STORAGE_KEY,
+  isBrowserRuntime,
+  parseStoredSession,
+} from './session-storage';
 
 type SessionLike<T> = {
   data: Partial<T>;
@@ -7,27 +12,18 @@ type SessionLike<T> = {
   clear: () => Promise<void>;
 };
 
-const BROWSER_SESSION_STORAGE_KEY = 'rust_srec_session_v1';
-
-function isBrowserRuntime(): boolean {
-  return (
-    typeof window !== 'undefined' && typeof window.localStorage !== 'undefined'
-  );
-}
-
-function parseStoredSession(raw: string | null): Partial<SessionData> {
-  if (!raw) return {};
-
-  try {
-    const parsed = JSON.parse(raw) as unknown;
-    if (typeof parsed !== 'object' || parsed === null) return {};
-    return parsed as Partial<SessionData>;
-  } catch {
-    return {};
-  }
-}
-
 let browserSessionSingleton: SessionLike<SessionData> | null = null;
+
+export function resolveSessionSecret(
+  sessionSecret = process.env.SESSION_SECRET,
+  nodeEnv = process.env.NODE_ENV,
+): string {
+  if (sessionSecret) return sessionSecret;
+  if (nodeEnv === 'production') {
+    throw new Error('SESSION_SECRET must be set in production');
+  }
+  return 'dev_secret_must_be_at_least_32_chars_long_and_random';
+}
 
 function getBrowserSession(): SessionLike<SessionData> {
   if (browserSessionSingleton) return browserSessionSingleton;
@@ -108,9 +104,7 @@ export async function useAppSession(): Promise<SessionLike<SessionData>> {
 
   const session = await useSession<SessionData>({
     name: 'srec_session',
-    password:
-      process.env.SESSION_SECRET ||
-      'dev_secret_must_be_at_least_32_chars_long_and_random',
+    password: resolveSessionSecret(),
     cookie: {
       secure: isSecureCookie(),
       sameSite: 'lax',

--- a/rust-srec/frontend/src/utils/session.ts
+++ b/rust-srec/frontend/src/utils/session.ts
@@ -12,26 +12,11 @@ export type SessionData = {
 };
 
 import { isDesktopBuild } from '@/utils/desktop';
-
-const BROWSER_SESSION_STORAGE_KEY = 'rust_srec_session_v1';
-
-function isBrowserRuntime(): boolean {
-  return (
-    typeof window !== 'undefined' && typeof window.localStorage !== 'undefined'
-  );
-}
-
-function parseStoredSession(raw: string | null): Partial<SessionData> {
-  if (!raw) return {};
-
-  try {
-    const parsed = JSON.parse(raw) as unknown;
-    if (typeof parsed !== 'object' || parsed === null) return {};
-    return parsed as Partial<SessionData>;
-  } catch {
-    return {};
-  }
-}
+import {
+  BROWSER_SESSION_STORAGE_KEY,
+  isBrowserRuntime,
+  parseStoredSession,
+} from './session-storage';
 
 export function getDesktopAccessToken(): string | null {
   if (!isDesktopBuild()) return null;


### PR DESCRIPTION
## Severity

P2-07

## What changed

- Let authentication-check failures reach React Query so transient errors retain the last known session and use normal retry behavior.
- Preserve the retried backend response when a token refresh succeeds but the retried request fails.
- Require `SESSION_SECRET` in production while retaining the development-only fallback.
- Share desktop session storage parsing between client and server helpers and reject malformed stored values.
- Remove config and pipeline-preset payload/response logging that could expose platform credentials and processor configs.
- URL-encode dynamic pipeline, DAG, job, and preset identifiers before inserting them into request paths.

## Why

The session query converted every thrown check into `null`, making network or server failures indistinguishable from an explicit unauthenticated response. The 401 retry path also caught the retried request's typed error and replaced it with the original 401. Session parsing had two implementations, production could silently use a known signing secret, and dynamic identifiers were interpolated into API paths without segment encoding.

## Impact

Temporary failures of the session check no longer tear down authenticated frontend state, retry errors retain their real status and body, production sessions fail closed when misconfigured, and server request construction avoids leaking configuration values or misrouting encoded identifiers.

## Scope note

This covers transient failures on the browser ↔ frontend-server leg (the session query and the 401-retry proxy path). A transient backend outage during token refresh itself (`tokenRefresh.ts` `performRefresh` catches network errors and clears the session) is a separate gap, left for a follow-up so this PR stays reviewable.

## Validation

- `pnpm run lint`
- `pnpm test` (137 passed)
- `pnpm run build`
- `git diff --check`
