### PR TITLE
fix(config): make in-flight resolution cancellation-safe

### DIFF
--- a/rust-srec/src/config/events.rs
+++ b/rust-srec/src/config/events.rs
@@ -226,17 +226,19 @@ impl PendingUpdates {
     }
 
     fn take(&mut self) -> Vec<ConfigUpdateEvent> {
-        let events: Vec<_> = if self.has_global {
-            // Global update supersedes all others
-            vec![ConfigUpdateEvent::GlobalUpdated]
-        } else {
-            self.events.drain().collect()
-        };
+        // Always drain `self.events` so `is_empty()` reports true after this call; when a
+        // GlobalUpdated is pending it supersedes every drained event and is the only one emitted.
+        let had_global = self.has_global;
+        let drained: Vec<_> = self.events.drain().collect();
 
         self.first_event_time = None;
         self.has_global = false;
 
-        events
+        if had_global {
+            vec![ConfigUpdateEvent::GlobalUpdated]
+        } else {
+            drained
+        }
     }
 
     fn is_empty(&self) -> bool {
@@ -441,6 +443,37 @@ mod tests {
         assert_eq!(received, ConfigUpdateEvent::GlobalUpdated);
 
         // No more events
+        assert!(receiver.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn test_coalescer_global_flush_does_not_leak_superseded_events() {
+        let broadcaster = ConfigEventBroadcaster::new();
+        let mut receiver = broadcaster.subscribe();
+        let coalescer = UpdateCoalescer::with_window(broadcaster, Duration::from_millis(50));
+
+        coalescer
+            .queue(ConfigUpdateEvent::StreamerMetadataUpdated {
+                streamer_id: "streamer-1".to_string(),
+            })
+            .await;
+        coalescer
+            .queue(ConfigUpdateEvent::PlatformUpdated {
+                platform_id: "twitch".to_string(),
+            })
+            .await;
+        coalescer.queue(ConfigUpdateEvent::GlobalUpdated).await;
+
+        // First flush emits only GlobalUpdated and must fully drain the pending set.
+        coalescer.flush().await;
+        assert_eq!(
+            receiver.recv().await.unwrap(),
+            ConfigUpdateEvent::GlobalUpdated
+        );
+        assert_eq!(coalescer.pending_count().await, 0);
+
+        // A second flush with nothing queued must emit nothing (no superseded leftovers).
+        coalescer.flush().await;
         assert!(receiver.try_recv().is_err());
     }
 

--- a/rust-srec/src/config/service.rs
+++ b/rust-srec/src/config/service.rs
@@ -340,8 +340,9 @@ where
         &self,
         streamer_id: &str,
     ) -> Result<Arc<ResolvedStreamerContext>> {
-        // One retry is enough to handle "cache invalidated" races without creating
-        // unbounded loops if the config is being updated repeatedly.
+        // One retry is enough to handle "cache invalidated" races and a
+        // cancelled owner (InFlightGuard's drop runs fail_in_flight) without
+        // creating unbounded loops if the config is being updated repeatedly.
         for attempt in 0..2 {
             // Check cache first
             if let Some(context) = self.cache.get(streamer_id) {
@@ -360,10 +361,12 @@ where
                     Err(message)
                         if attempt == 0
                             && (message.contains("Configuration invalidated")
-                                || message.contains("Configuration cache invalidated")) =>
+                                || message.contains("Configuration cache invalidated")
+                                || message.contains("was cancelled")) =>
                     {
                         trace!(
-                            "In-flight config was invalidated for streamer {}, retrying",
+                            "In-flight config was invalidated or its owner was cancelled \
+                             for streamer {}, retrying",
                             streamer_id
                         );
                         continue;

--- a/rust-srec/src/config/service.rs
+++ b/rust-srec/src/config/service.rs
@@ -21,13 +21,48 @@ use crate::database::repositories::{config::ConfigRepository, streamer::Streamer
 use crate::domain::streamer::Streamer;
 use crate::utils::json::{self, JsonContext};
 
-use super::cache::ConfigCache;
+use super::cache::{ConfigCache, InFlightRequest};
 use super::events::{ConfigEventBroadcaster, ConfigUpdateEvent};
 use super::{ConfigResolver, MergedConfig, ResolvedStreamerContext};
 
 /// Hard upper bound for a single streamer config resolution. This prevents `in_flight` entries
 /// from getting stuck forever if an upstream call hangs.
 const CONFIG_RESOLVE_HARD_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Fails the in-flight `ConfigCache` entry for `streamer_id` on drop unless it was disarmed.
+///
+/// The owner that created a new in-flight entry via `ConfigCache::get_or_create_in_flight` must
+/// eventually call `complete_in_flight` or `fail_in_flight`. If its task is cancelled mid-resolve
+/// (e.g. an axum client disconnect during `resolve_context_for_streamer`), this guard's drop runs
+/// `fail_in_flight` so the entry is removed and waiters wake; otherwise every later
+/// `get_context_for_streamer` for that streamer would block on a request that never completes.
+struct InFlightGuard<'a> {
+    cache: &'a ConfigCache,
+    streamer_id: &'a str,
+    cell: InFlightRequest,
+    armed: bool,
+}
+
+impl InFlightGuard<'_> {
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for InFlightGuard<'_> {
+    fn drop(&mut self) {
+        if self.armed {
+            self.cache.fail_in_flight(
+                self.streamer_id,
+                &self.cell,
+                format!(
+                    "Config resolution for streamer {} was cancelled",
+                    self.streamer_id
+                ),
+            );
+        }
+    }
+}
 
 /// Configuration service providing cached access to all configuration data.
 ///
@@ -339,12 +374,25 @@ where
 
             trace!("Cache miss for streamer {}, resolving config", streamer_id);
 
+            // If this task is cancelled during resolution, the guard's drop runs
+            // `fail_in_flight` so `cell` is not left in `ConfigCache::in_flight` forever.
+            let mut guard = InFlightGuard {
+                cache: &self.cache,
+                streamer_id,
+                cell: cell.clone(),
+                armed: true,
+            };
+
             // Resolve the config
             let resolve = tokio::time::timeout(
                 CONFIG_RESOLVE_HARD_TIMEOUT,
                 self.resolve_context_for_streamer(streamer_id),
             )
             .await;
+
+            // Resolution completed without cancellation; the match arms below own the
+            // complete/fail transition, so the guard's drop-time fallback is not needed.
+            guard.disarm();
 
             return match resolve {
                 Ok(Ok(context)) => {


### PR DESCRIPTION
## Severity

P1-06

## What changed

- Added an `InFlightGuard` around config resolution in `ConfigService::get_context_for_streamer`: if the resolving task is dropped mid-resolve, the guard's drop runs `ConfigCache::fail_in_flight` so the in-flight entry is removed and waiters wake. The existing complete/fail match arms disarm the guard when resolution finishes normally.
- `PendingUpdates::take` now always drains the queued event set; when a pending `GlobalUpdated` supersedes the drained events, it is still the only event emitted, but the superseded events can no longer survive into the next flush.
- Added a regression test covering the superseded-event drain.

## Why

The owner that creates an in-flight entry via `ConfigCache::get_or_create_in_flight` must eventually complete or fail it. A cancelled caller (for example an axum client disconnect during `resolve_context_for_streamer`) did neither, so every later `get_context_for_streamer` for that streamer blocked on a request that never completes — the streamer's config was permanently wedged.

Separately, `take` returned early on a pending global update without draining `self.events`, so `is_empty()` stayed false and the next flush re-emitted stale superseded updates.

## Impact

A dropped config request can no longer wedge a streamer's config resolution, and a coalesced global update fully absorbs the events it supersedes.

## Validation

- `cargo test --locked -p rust-srec --lib config::` (61 passed; the new coalescer test fails on pre-fix code, which leaves the pending set undrained)
- `cargo clippy --locked -p rust-srec --lib -- -D warnings`
- `rustfmt --edition 2024 --check` on both files
- `git diff --check`

This is P1-06 from the #713 split series ("config singleflight and timeout behavior only"); the hard-timeout constant already existed on main, so this PR adds only the cancellation-safety and event-drain fixes.
