### PR TITLE
fix(monitor): restore monitoring lifecycle recovery

### DIFF
--- a/rust-srec/src/monitor/batch_detector.rs
+++ b/rust-srec/src/monitor/batch_detector.rs
@@ -227,26 +227,19 @@ impl BatchDetector {
 
     /// Internal batch check implementation.
     ///
-    /// This is a placeholder that will be replaced with actual platform integration.
+    /// Platform-specific batch APIs are not implemented yet. This returns an error
+    /// instead of fabricating `LiveStatus::Offline` for every streamer, so that any
+    /// caller that wires `StreamerActor::uses_batch_detection` to this path fails the
+    /// check (leaving individual detection to recover) rather than silently ending
+    /// live sessions.
     async fn check_batch_internal(
         &self,
         _platform_id: &str,
-        streamers: &[StreamerMetadata],
+        _streamers: &[StreamerMetadata],
     ) -> Result<BatchResult> {
-        // Placeholder implementation
-        // In the real implementation, this would:
-        // 1. Build the batch API request for the platform
-        // 2. Send the request
-        // 3. Parse the response and map to LiveStatus
-
-        let mut result = BatchResult::new();
-
-        for streamer in streamers {
-            // For now, return offline for all
-            result.add_result(streamer.id.clone(), LiveStatus::Offline);
-        }
-
-        Ok(result)
+        Err(crate::Error::Monitor(
+            "batch detection is not implemented for this platform".to_string(),
+        ))
     }
 
     /// Calculate backoff delay with exponential increase and jitter.
@@ -341,10 +334,16 @@ mod tests {
             create_test_streamer("3"),
         ];
 
-        let result = detector.batch_check("twitch", streamers).await.unwrap();
+        // check_batch_internal has no platform implementation, so batch_check
+        // records every streamer as a failure rather than fabricating an Offline
+        // success for each (which would silently end their live sessions).
+        let result = detector
+            .batch_check("twitch", streamers)
+            .await
+            .expect("batch_check maps per-streamer errors into the result");
 
-        assert_eq!(result.success_count(), 3);
-        assert_eq!(result.failure_count(), 0);
+        assert_eq!(result.success_count(), 0);
+        assert_eq!(result.failure_count(), 3);
     }
 
     #[test]

--- a/rust-srec/src/monitor/batch_detector.rs
+++ b/rust-srec/src/monitor/batch_detector.rs
@@ -227,11 +227,11 @@ impl BatchDetector {
 
     /// Internal batch check implementation.
     ///
-    /// Platform-specific batch APIs are not implemented yet. This returns an error
-    /// instead of fabricating `LiveStatus::Offline` for every streamer, so that any
-    /// caller that wires `StreamerActor::uses_batch_detection` to this path fails the
-    /// check (leaving individual detection to recover) rather than silently ending
-    /// live sessions.
+    /// No platform has a batch API implementation, and
+    /// `Scheduler::is_batch_capable_platform` routes no streamer here. The
+    /// error is a guard for future batch wiring: a failed batch check must
+    /// count as a failed check for every streamer in it, because reporting
+    /// them as `LiveStatus::Offline` would end their live sessions.
     async fn check_batch_internal(
         &self,
         _platform_id: &str,
@@ -335,8 +335,8 @@ mod tests {
         ];
 
         // check_batch_internal has no platform implementation, so batch_check
-        // records every streamer as a failure rather than fabricating an Offline
-        // success for each (which would silently end their live sessions).
+        // must record every streamer as a failure; an Offline result here
+        // would end each streamer's live session.
         let result = detector
             .batch_check("twitch", streamers)
             .await

--- a/rust-srec/src/monitor/service.rs
+++ b/rust-srec/src/monitor/service.rs
@@ -115,7 +115,7 @@ impl Default for StreamMonitorConfig {
     fn default() -> Self {
         Self {
             default_rate_limit: 1.0,
-            platform_rate_limits: vec![("twitch".to_string(), 2.0), ("youtube".to_string(), 1.0)],
+            platform_rate_limits: vec![("twitch".to_string(), 2.0)],
             request_timeout: Duration::ZERO,
             max_concurrent_requests: 10,
         }

--- a/rust-srec/src/monitor/service.rs
+++ b/rust-srec/src/monitor/service.rs
@@ -482,11 +482,13 @@ impl<
             return Ok(LiveStatus::Offline);
         }
 
-        let hard_timeout = if self.config.request_timeout > Duration::ZERO {
-            self.config.request_timeout
-        } else {
-            STREAM_CHECK_HARD_TIMEOUT
-        };
+        // Outer bound for the whole check pipeline (filter load, config resolution,
+        // credential check_and_refresh_source, and platform extraction). request_timeout
+        // is a per-HTTP-request budget applied by the HTTP client, so the pipeline — which
+        // issues several sequential requests — must never be capped below
+        // STREAM_CHECK_HARD_TIMEOUT; only a request_timeout deliberately set larger than it
+        // raises the ceiling.
+        let hard_timeout = std::cmp::max(STREAM_CHECK_HARD_TIMEOUT, self.config.request_timeout);
 
         // Get or create the deduplication cell for this streamer
         let cell = self

--- a/rust-srec/src/scheduler/actor/streamer_actor.rs
+++ b/rust-srec/src/scheduler/actor/streamer_actor.rs
@@ -105,6 +105,13 @@ pub struct StreamerActor {
     platform_actor: Option<mpsc::Sender<PlatformMessage>>,
     /// Current actor state (runtime scheduling state only).
     state: StreamerActorState,
+    /// Floor for the next Live watchdog wake after a failed watchdog check.
+    ///
+    /// `perform_check` sets this when `is_live_watchdog` is true and the check
+    /// errors; the Live scheduling branch of `run` clamps its computed wake up
+    /// to this instant so a failing check does not busy-retry against the stall
+    /// timer. Cleared on the next successful check.
+    live_watchdog_backoff_until: Option<Instant>,
     /// Shared metadata store for fetching fresh streamer data.
     metadata_store: Arc<DashMap<String, StreamerMetadata>>,
     /// Configuration.
@@ -159,6 +166,7 @@ impl StreamerActor {
             self_handle: tx,
             platform_actor: None,
             state,
+            live_watchdog_backoff_until: None,
             metadata_store,
             config,
             cancellation_token,
@@ -208,6 +216,7 @@ impl StreamerActor {
             self_handle: tx,
             platform_actor: None,
             state,
+            live_watchdog_backoff_until: None,
             metadata_store,
             config,
             cancellation_token,
@@ -343,6 +352,15 @@ impl StreamerActor {
                     }
                 }
 
+                // Hold off the watchdog after a failed check: overrides the stall/hint
+                // ZERO wake so an unreachable download does not drive a tight retry loop.
+                if let Some(backoff_until) = self.live_watchdog_backoff_until {
+                    next = std::cmp::max(
+                        next,
+                        backoff_until.saturating_duration_since(Instant::now()),
+                    );
+                }
+
                 sleep_duration = Some(next);
             }
             let check_timer = Self::create_check_timer(sleep_duration);
@@ -464,6 +482,12 @@ impl StreamerActor {
         // If we stop seeing download heartbeats while Live, consider the download "stalled"
         // and verify status sooner than the 2h watchdog.
         Duration::from_secs(5 * 60)
+    }
+
+    fn live_watchdog_error_backoff(&self) -> Duration {
+        // Minimum spacing between Live watchdog re-checks after one failed while the
+        // download is unreachable; caps the stall-timer-driven retry cadence.
+        Duration::from_secs(60)
     }
 
     fn time_until_live_stall_watchdog(&self) -> Duration {
@@ -631,6 +655,11 @@ impl StreamerActor {
             // Wait for acknowledgment (not the result - that comes via BatchResult message)
             match tokio::time::timeout(Duration::from_secs(5), reply_rx).await {
                 Ok(Ok(())) => {
+                    // The result arrives asynchronously via handle_batch_result; park
+                    // next_check so the run loop does not re-fire this timer and issue a
+                    // duplicate RequestCheck before that result lands.
+                    self.state
+                        .schedule_next_check(&self.config, self.get_error_count());
                     debug!("StreamerActor {} check delegated to platform", self.id);
                     Ok(())
                 }
@@ -660,6 +689,10 @@ impl StreamerActor {
         // Perform the actual status check using the status checker
         match self.status_checker.check_status(&metadata).await {
             Ok((result, status)) => {
+                // A successful check clears any watchdog re-check floor set by a prior
+                // failed Live watchdog check.
+                self.live_watchdog_backoff_until = None;
+
                 let previous_runtime_state = self.state.clone();
                 let next_state = result.state;
                 let error_count = self.get_error_count();
@@ -727,6 +760,10 @@ impl StreamerActor {
                     // Do not call status_checker.handle_error() and do not record an Error state:
                     // this would increment consecutive error counts, potentially set disabled_until,
                     // and would also switch scheduling away from the Live watchdog cadence.
+                    // Arm a re-check floor so the Live scheduling branch of `run` does not
+                    // busy-retry against the stall timer while the download is unreachable.
+                    self.live_watchdog_backoff_until =
+                        Some(Instant::now() + self.live_watchdog_error_backoff());
                     return Err(ActorError::recoverable(format!(
                         "Live watchdog status check failed (ignored while download active): {}",
                         e.message

--- a/rust-srec/src/scheduler/actor/supervisor.rs
+++ b/rust-srec/src/scheduler/actor/supervisor.rs
@@ -277,6 +277,10 @@ impl Supervisor {
         self.streamer_configs.remove(id);
         self.platform_senders.remove(id);
         self.restart_tracker.remove(id);
+        // Drop any queued restart so process_pending_restarts does not resurrect
+        // an actor for a streamer that has been removed.
+        self.pending_restarts
+            .retain(|r| !(r.actor_type == "streamer" && r.actor_id == id));
         self.registry.remove_streamer(id).is_some()
     }
 
@@ -284,6 +288,10 @@ impl Supervisor {
     pub fn remove_platform(&mut self, platform_id: &str) -> bool {
         self.platform_configs.remove(platform_id);
         self.restart_tracker.remove(platform_id);
+        // Drop any queued restart so process_pending_restarts does not resurrect
+        // an actor for a platform that has been removed.
+        self.pending_restarts
+            .retain(|r| !(r.actor_type == "platform" && r.actor_id == platform_id));
         self.registry.remove_platform(platform_id).is_some()
     }
 

--- a/rust-srec/src/scheduler/service.rs
+++ b/rust-srec/src/scheduler/service.rs
@@ -628,8 +628,13 @@ impl<R: StreamerRepository + Send + Sync + 'static> Scheduler<R> {
     }
 
     /// Spawn initial actors for all active streamers.
+    ///
+    /// Uses `get_all_active` rather than `get_ready_for_check` so streamers still
+    /// inside their `disabled_until` error backoff also get an actor; the actor's
+    /// `initiate_check` guard defers the first real check until the backoff expires,
+    /// which keeps them monitored once it does.
     async fn spawn_initial_actors(&mut self) -> Result<()> {
-        let streamers = self.streamer_manager.get_ready_for_check();
+        let streamers = self.streamer_manager.get_all_active();
         info!("Spawning actors for {} streamers", streamers.len());
 
         // First, spawn platform actors for batch-capable platforms

--- a/rust-srec/src/scheduler/service.rs
+++ b/rust-srec/src/scheduler/service.rs
@@ -490,10 +490,13 @@ impl<R: StreamerRepository + Send + Sync + 'static> Scheduler<R> {
     }
 
     /// Check if a platform supports batch detection.
-    fn is_batch_capable_platform(&self, platform_id: &str) -> bool {
-        let platform = platform_id.strip_prefix("platform-").unwrap_or(platform_id);
-        // Platforms that support batch API detection
-        matches!(platform, "youtube")
+    ///
+    /// No platform has a batch API implementation
+    /// (`BatchDetector::check_batch_internal` errors unconditionally), so no
+    /// streamer routes checks through `PlatformMessage::RequestCheck`
+    /// delegation; every check runs individually via `perform_check`.
+    fn is_batch_capable_platform(&self, _platform_id: &str) -> bool {
+        false
     }
 
     /// Start the scheduler event loop.
@@ -629,10 +632,10 @@ impl<R: StreamerRepository + Send + Sync + 'static> Scheduler<R> {
 
     /// Spawn initial actors for all active streamers.
     ///
-    /// Uses `get_all_active` rather than `get_ready_for_check` so streamers still
-    /// inside their `disabled_until` error backoff also get an actor; the actor's
-    /// `initiate_check` guard defers the first real check until the backoff expires,
-    /// which keeps them monitored once it does.
+    /// Uses `get_all_active` so streamers still inside their `disabled_until`
+    /// error backoff also get an actor; the actor's `initiate_check` guard
+    /// defers the first real check until the backoff expires, which keeps
+    /// them monitored once it does.
     async fn spawn_initial_actors(&mut self) -> Result<()> {
         let streamers = self.streamer_manager.get_all_active();
         info!("Spawning actors for {} streamers", streamers.len());
@@ -1264,15 +1267,6 @@ mod tests {
         assert_eq!(config.check_interval_ms, 60_000);
         assert_eq!(config.offline_check_interval_ms, 20_000);
         assert_eq!(config.offline_check_count, 3);
-    }
-
-    #[test]
-    fn test_is_batch_capable_platform() {
-        // We can't easily test this without a full Scheduler instance,
-        // but we can verify the logic is correct by checking the match arms
-        assert!(matches!("twitch", "twitch" | "youtube"));
-        assert!(matches!("youtube", "twitch" | "youtube"));
-        assert!(!matches!("bilibili", "twitch" | "youtube"));
     }
 
     #[test]

--- a/rust-srec/src/streamer/manager.rs
+++ b/rust-srec/src/streamer/manager.rs
@@ -564,17 +564,6 @@ where
             .collect()
     }
 
-    /// Get streamers ready for live checking.
-    ///
-    /// Returns active streamers that are not currently disabled.
-    pub fn get_ready_for_check(&self) -> Vec<StreamerMetadata> {
-        self.metadata
-            .iter()
-            .filter(|entry| entry.is_ready_for_check())
-            .map(|entry| entry.value().clone())
-            .collect()
-    }
-
     /// Get streamers sorted by priority (High first, then Normal, then Low).
     pub fn get_all_sorted_by_priority(&self) -> Vec<StreamerMetadata> {
         let mut streamers: Vec<_> = self.get_all();


### PR DESCRIPTION
## Severity

P1-05

## What changed

- `Scheduler::spawn_initial_actors` selects streamers with `get_all_active` instead of `get_ready_for_check`, so streamers inside their `disabled_until` error backoff at startup are still assigned actors; the actor's `initiate_check` guard defers the first real check until the backoff expires. The now-unreferenced `StreamerManager::get_ready_for_check` is removed.
- `BatchDetector::check_batch_internal` returns an error instead of fabricating `LiveStatus::Offline` for every streamer, and `Scheduler::is_batch_capable_platform` no longer classifies YouTube (unsupported) as batch-capable — no platform routes checks through `PlatformMessage::RequestCheck` delegation until a real batch API exists, so every check runs individually. The error is a guard for future batch wiring: a failed batch must count as a failed check per streamer, not offline.
- A failed Live watchdog check arms `live_watchdog_backoff_until` (60s floor), which the Live scheduling branch of `run` clamps against, so an unreachable download no longer drives a tight retry loop against the stall timer; a successful check clears the floor.
- Delegating a check to a platform actor parks `next_check` via `schedule_next_check` (currently unreachable, see above), so the run loop cannot issue a duplicate `RequestCheck` before the batch result lands.
- `Supervisor::remove_streamer`/`remove_platform` drop queued entries in `pending_restarts`, so `process_pending_restarts` cannot resurrect an actor for a removed streamer or platform.
- The stream-check pipeline's outer bound is `max(STREAM_CHECK_HARD_TIMEOUT, request_timeout)`: `request_timeout` is a per-HTTP-request budget, so a small value no longer caps the multi-request check pipeline below its hard timeout.

## Why

Each of these paths could permanently or repeatedly degrade monitoring: streamers in backoff at startup were never monitored again, the batch placeholder reported every streamer offline (and with YouTube classified batch-capable, its streamers had no working check path at all), a failing watchdog check retried as fast as the stall timer fired, removed actors could come back from the pending-restart queue, and a short `request_timeout` starved the whole check pipeline.

## Impact

Monitoring recovers instead of wedging: backoff streamers rejoin monitoring when their backoff expires, every platform uses individual detection (the only implemented path), watchdog failures retry at a bounded cadence, and removed actors stay removed.

## Validation

- `cargo test --locked -p rust-srec --lib monitor::` (40 passed)
- `cargo test --locked -p rust-srec --lib scheduler::` (143 passed)
- `cargo test --locked -p rust-srec --lib streamer::` (45 passed)
- `cargo clippy --locked -p rust-srec --lib -- -D warnings`
- `rustfmt --edition 2024 --check` on all changed files
- `git diff --check`

This is P1-05 from the #713 split series. Intentionally excluded from #713's monitor/scheduler changes: deleting the dead `scheduler::batch` and `scheduler::resource` modules (P3 cleanup follow-up). The failure-backoff/offline-check synchronization in this area landed separately in #716. Known coverage gap: the watchdog floor, delegation parking, and pending-restart removal are pinned by reading, not tests — the batch-delegation paths are unreachable until a platform implements a batch API.
