### PR TITLE
fix(hls): stop dropping data in defragment, limiter, split, and AV1 validation

### DIFF
--- a/crates/hls-fix/src/operators/defragment.rs
+++ b/crates/hls-fix/src/operators/defragment.rs
@@ -48,11 +48,9 @@ pub struct DefragmentOperator {
 }
 
 impl DefragmentOperator {
-    // The minimum number of tags required to consider a segment valid.
+    // The minimum number of fMP4 items (init + trailing media) buffered before a gathered
+    // segment is flushed mid-stream.
     const MIN_TAGS_NUM: usize = 5;
-
-    // The minimum number of tags for TS segments (PAT, PMT, and at least one IDR frame)
-    const MIN_TS_TAGS_NUM: usize = 3;
 
     const DEFAULT_PRE_INIT_BUFFER_LIMIT: usize = 64 * 1024 * 1024;
 
@@ -100,16 +98,12 @@ impl DefragmentOperator {
         Ok(())
     }
 
-    fn process_ts_segment(
-        &mut self,
-        data: HlsData,
-        output: &mut dyn FnMut(HlsData) -> Result<(), PipelineError>,
-    ) -> Result<(), PipelineError> {
-        output(data)?;
-        Ok(())
-    }
-
-    // Handle cases for FMP4s init segment
+    // Handle cases for FMP4s init segment.
+    //
+    // Pre-init policy: media buffered while waiting for an init segment is orphaned once a
+    // real init arrives (it is encoded against an unknown configuration), so any such buffer
+    // is dropped here and gathering restarts from this init. handle_end_of_playlist still
+    // emits pre-init media if the stream ends before an init ever arrives.
     fn handle_new_header(&mut self, data: HlsData) {
         if !self.buffer.is_empty() {
             warn!(
@@ -138,40 +132,17 @@ impl DefragmentOperator {
     ) -> Result<(), PipelineError> {
         debug!("{} End of playlist marker received", self.context.name);
 
-        // Flush any buffered data
+        // The buffer only ever holds fMP4 items; process_internal forwards TS directly.
+        // Flush everything gathered regardless of item count so a mid-stream discontinuity or
+        // recording end never drops a freshly re-gathered init segment or its trailing media.
         if !self.buffer.is_empty() {
-            let min_required = match self.segment_type {
-                Some(SegmentType::Ts) => Self::MIN_TS_TAGS_NUM,
-                Some(SegmentType::M4sInit) | Some(SegmentType::M4sMedia) => Self::MIN_TAGS_NUM,
-                Some(SegmentType::EndMarker) => 0,
-                None => Self::MIN_TAGS_NUM,
-            };
-
-            if matches!(self.segment_type, Some(SegmentType::Ts)) {
-                if self.buffer.len() < min_required {
-                    warn!(
-                        "{} Flushing short TS buffer on playlist end ({} < {} items) to preserve data",
-                        self.context.name,
-                        self.buffer.len(),
-                        min_required
-                    );
-                } else {
-                    debug!("{} Flushing TS buffer on playlist end", self.context.name);
-                }
-                self.flush_buffer(output)?;
-                self.reset();
-            } else if self.buffer.len() >= min_required {
-                debug!("{} Flushing buffer on playlist end", self.context.name);
-                self.flush_buffer(output)?;
-                self.reset();
-            } else {
-                warn!(
-                    "{} Discarding incomplete segment on playlist end ({} items)",
-                    self.context.name,
-                    self.buffer.len()
-                );
-                self.reset();
-            }
+            debug!(
+                "{} Flushing buffer on playlist end ({} items)",
+                self.context.name,
+                self.buffer.len()
+            );
+            self.flush_buffer(output)?;
+            self.reset();
         }
 
         // Output the end of playlist marker
@@ -226,8 +197,10 @@ impl DefragmentOperator {
             _ => {} // Type hasn't changed
         }
 
+        // TS segments are passed through untouched; only fMP4 data is ever buffered.
         if self.segment_type == Some(SegmentType::Ts) {
-            return self.process_ts_segment(data, output);
+            output(data)?;
+            return Ok(());
         }
 
         // Special handling for M4S initialization segments
@@ -297,65 +270,18 @@ impl DefragmentOperator {
             return Ok(());
         }
 
-        // // Check buffer size and force emission if too large
-        // if self.buffer.len() >= Self::MAX_BUFFER_SIZE {
-        //     warn!(
-        //         "{} Buffer size limit reached ({}), force emitting",
-        //         self.context.name, Self::MAX_BUFFER_SIZE
-        //     );
+        // Only fMP4 data reaches here (TS returned above), and gathering starts from
+        // handle_new_header, so an init segment is always present. Emit the init plus its
+        // trailing media once MIN_TAGS_NUM items are buffered.
+        if self.is_gathering && self.has_init_segment && self.buffer.len() >= Self::MIN_TAGS_NUM {
+            debug!(
+                "{} Gathered complete segment ({} items), processing",
+                self.context.name,
+                self.buffer.len()
+            );
 
-        //     // Force emit all buffered items
-        //     for item in self.buffer.drain(..) {
-        //         output(item)?;
-        //     }
-        //     self.is_gathering = false;
-        //     return Ok(());
-        // }
-
-        // Check if we've gathered enough data and if gathering is active
-        if self.is_gathering && !self.buffer.is_empty() {
-            // Determine minimum number of tags based on segment type
-            let min_required = match self.segment_type {
-                Some(SegmentType::Ts) => Self::MIN_TS_TAGS_NUM,
-                Some(SegmentType::M4sInit) | Some(SegmentType::M4sMedia) => Self::MIN_TAGS_NUM,
-                Some(SegmentType::EndMarker) => 0,
-                None => Self::MIN_TAGS_NUM, // Default if type not yet determined
-            };
-
-            // Check if we've gathered enough tags to consider this a complete segment
-            if self.buffer.len() >= min_required {
-                // Enhanced completion check using stream profiling
-                let is_complete = match self.segment_type {
-                    Some(SegmentType::Ts) => {
-                        // Use advanced stream analysis for TS segments
-                        // self.validate_ts_segment_completeness()
-                        true
-                    }
-                    Some(SegmentType::M4sInit) | Some(SegmentType::M4sMedia) => {
-                        // For M4S, check if we have init segment for media segments
-                        if !self.has_init_segment
-                            && matches!(self.segment_type, Some(SegmentType::M4sMedia))
-                        {
-                            false
-                        } else {
-                            self.buffer.len() >= min_required
-                        }
-                    }
-                    Some(SegmentType::EndMarker) => false,
-                    None => false, // Can't complete if we don't know the type
-                };
-
-                if is_complete {
-                    debug!(
-                        "{} Gathered complete segment ({} items), processing",
-                        self.context.name,
-                        self.buffer.len()
-                    );
-
-                    self.flush_buffer(output)?;
-                    self.is_gathering = false;
-                }
-            }
+            self.flush_buffer(output)?;
+            self.is_gathering = false;
         }
 
         Ok(())
@@ -394,50 +320,25 @@ impl Processor<HlsData> for DefragmentOperator {
             self.buffer.len()
         );
 
-        // Determine minimum requirements based on segment type
-        let min_required = match self.segment_type {
-            Some(SegmentType::Ts) => Self::MIN_TS_TAGS_NUM,
-            Some(SegmentType::M4sInit) | Some(SegmentType::M4sMedia) => Self::MIN_TAGS_NUM,
-            Some(SegmentType::EndMarker) => 0,
-            None => Self::MIN_TAGS_NUM, // Default if type not yet determined
-        };
-
-        // Enhanced segment validation before flushing
-        let is_valid_segment = match self.segment_type {
-            Some(SegmentType::Ts) => true,
-            Some(SegmentType::M4sInit) | Some(SegmentType::M4sMedia) => {
-                self.buffer.len() >= min_required
+        // The buffer only ever holds fMP4 items; flush whatever is gathered rather than
+        // dropping a short final segment (init + trailing media) at stream end.
+        let count = self.buffer.len();
+        for item in self.buffer.drain(..) {
+            if context.token.is_cancelled() {
+                warn!(
+                    "{} Cancellation occurred during flush, some data might be lost.",
+                    self.context.name
+                );
+                return Err(PipelineError::Cancelled);
             }
-            _ => false,
-        };
-
-        if is_valid_segment {
-            let count = self.buffer.len();
-
-            for item in self.buffer.drain(..) {
-                if context.token.is_cancelled() {
-                    warn!(
-                        "{} Cancellation occurred during flush, some data might be lost.",
-                        self.context.name
-                    );
-                    return Err(PipelineError::Cancelled);
-                }
-                output(item)?;
-            }
-            self.reset();
-
-            info!(
-                "{} Flushed complete segment ({} items)",
-                self.context.name, count
-            );
-        } else {
-            warn!(
-                "{} Discarding incomplete segment on flush ({} items)",
-                self.context.name,
-                self.buffer.len()
-            );
-            self.reset();
+            output(item)?;
         }
+        self.reset();
+
+        info!(
+            "{} Flushed buffered segment ({} items)",
+            self.context.name, count
+        );
 
         Ok(())
     }
@@ -714,5 +615,76 @@ mod tests {
         assert_eq!(out.len(), 2);
         assert!(matches!(out[0], HlsData::TsData(_)));
         assert!(matches!(out[1], HlsData::EndMarker(_)));
+    }
+
+    #[test]
+    fn flushes_short_fmp4_buffer_on_playlist_end() {
+        let token = CancellationToken::new();
+        let context = StreamerContext::arc_new(token);
+        let mut operator = DefragmentOperator::new(context.clone());
+
+        let mut out = Vec::new();
+        {
+            let mut output = |item: HlsData| -> Result<(), PipelineError> {
+                out.push(item);
+                Ok(())
+            };
+            // Init + two media items: fewer than MIN_TAGS_NUM, so still buffered.
+            operator
+                .process(&context, make_m4s_init(4), &mut output)
+                .unwrap();
+            operator
+                .process(&context, make_m4s_media(4), &mut output)
+                .unwrap();
+            operator
+                .process(&context, make_m4s_media(4), &mut output)
+                .unwrap();
+        }
+        assert!(out.is_empty());
+
+        {
+            let mut output = |item: HlsData| -> Result<(), PipelineError> {
+                out.push(item);
+                Ok(())
+            };
+            operator
+                .process(&context, HlsData::end_marker(), &mut output)
+                .unwrap();
+        }
+
+        assert_eq!(out.len(), 4);
+        assert!(out[0].is_mp4_init());
+        assert!(out[1..3].iter().all(HlsData::is_mp4_media));
+        assert!(matches!(out[3], HlsData::EndMarker(_)));
+    }
+
+    #[test]
+    fn flushes_short_fmp4_buffer_on_finish() {
+        let token = CancellationToken::new();
+        let context = StreamerContext::arc_new(token);
+        let mut operator = DefragmentOperator::new(context.clone());
+
+        let mut out = Vec::new();
+        let mut output = |item: HlsData| -> Result<(), PipelineError> {
+            out.push(item);
+            Ok(())
+        };
+
+        // Init + two media items: fewer than MIN_TAGS_NUM, so still buffered.
+        operator
+            .process(&context, make_m4s_init(4), &mut output)
+            .unwrap();
+        operator
+            .process(&context, make_m4s_media(4), &mut output)
+            .unwrap();
+        operator
+            .process(&context, make_m4s_media(4), &mut output)
+            .unwrap();
+
+        operator.finish(&context, &mut output).unwrap();
+
+        assert_eq!(out.len(), 3);
+        assert!(out[0].is_mp4_init());
+        assert!(out[1..].iter().all(HlsData::is_mp4_media));
     }
 }

--- a/crates/hls-fix/src/operators/defragment.rs
+++ b/crates/hls-fix/src/operators/defragment.rs
@@ -100,10 +100,11 @@ impl DefragmentOperator {
 
     // Handle cases for FMP4s init segment.
     //
-    // Pre-init policy: media buffered while waiting for an init segment is orphaned once a
-    // real init arrives (it is encoded against an unknown configuration), so any such buffer
-    // is dropped here and gathering restarts from this init. handle_end_of_playlist still
-    // emits pre-init media if the stream ends before an init ever arrives.
+    // Any non-empty buffer is dropped when a new init arrives and gathering restarts
+    // from this init: pre-init media is encoded against an unknown configuration, and
+    // a still-gathering init+media group cut short by a config change loses its
+    // buffered items here too. handle_end_of_playlist still emits pre-init media if
+    // the stream ends before an init ever arrives.
     fn handle_new_header(&mut self, data: HlsData) {
         if !self.buffer.is_empty() {
             warn!(
@@ -270,8 +271,9 @@ impl DefragmentOperator {
             return Ok(());
         }
 
-        // Only fMP4 data reaches here (TS returned above), and gathering starts from
-        // handle_new_header, so an init segment is always present. Emit the init plus its
+        // Only fMP4 data reaches here (TS returned above). Gathering can also start
+        // pre-init with media-only buffers, so the has_init_segment conjunct below is
+        // what guarantees an emitted group opens with its init. Emit the init plus its
         // trailing media once MIN_TAGS_NUM items are buffered.
         if self.is_gathering && self.has_init_segment && self.buffer.len() >= Self::MIN_TAGS_NUM {
             debug!(

--- a/crates/hls-fix/src/operators/segment_limiter.rs
+++ b/crates/hls-fix/src/operators/segment_limiter.rs
@@ -11,7 +11,7 @@ pub struct SegmentLimiterOperator {
     max_size: Option<u64>,
     current_duration: Duration,
     current_size: u64,
-    // Store the first initialization segment we encounter
+    // Most recent initialization segment, re-emitted at the start of each new sequence.
     init_segment: Option<M4sInitSegmentData>,
     // Track if we've output an init segment recently
     init_segment_sent: bool,
@@ -125,10 +125,10 @@ impl Processor<HlsData> for SegmentLimiterOperator {
             }
             SegmentType::M4sInit => {
                 if let HlsData::M4sData(M4sData::InitSegment(init_segment)) = input {
-                    // Store the init segment for later use if it's the first one we've seen
-                    if self.init_segment.is_none() {
-                        self.init_segment = Some(init_segment.clone());
-                    }
+                    // Track the most recent init segment so a later size/duration split re-emits
+                    // the codec configuration the following M4sMedia is encoded against, not a
+                    // stale one from before a SegmentSplitOperator init-CRC switch.
+                    self.init_segment = Some(init_segment.clone());
 
                     // Always output the init segment when we encounter it directly
                     output(HlsData::M4sData(M4sData::InitSegment(init_segment)))?;
@@ -249,5 +249,68 @@ mod tests {
         operator.process(&context, seg, &mut output).unwrap();
         assert_eq!(out.len(), 1);
         assert!(matches!(out[0], HlsData::TsData(_)));
+    }
+
+    #[test]
+    fn reemits_latest_init_after_split() {
+        let token = CancellationToken::new();
+        let context = StreamerContext::arc_new(token);
+        let mut operator = SegmentLimiterOperator::new(None, Some(10));
+
+        let mut out = Vec::new();
+        let mut output = |item: HlsData| -> Result<(), PipelineError> {
+            out.push(item);
+            Ok(())
+        };
+
+        let media = |bytes: &'static [u8]| {
+            HlsData::mp4_segment(
+                MediaSegment {
+                    duration: 1.0,
+                    ..MediaSegment::empty()
+                },
+                Bytes::from_static(bytes),
+            )
+        };
+
+        operator
+            .process(
+                &context,
+                HlsData::mp4_init(MediaSegment::empty(), Bytes::from_static(b"AAAA")),
+                &mut output,
+            )
+            .unwrap();
+        operator
+            .process(&context, media(b"11111111"), &mut output)
+            .unwrap();
+        // Codec change mid-sequence: a new init segment replaces the tracked one.
+        operator
+            .process(
+                &context,
+                HlsData::mp4_init(MediaSegment::empty(), Bytes::from_static(b"BBBB")),
+                &mut output,
+            )
+            .unwrap();
+        // 8 more bytes exceed max_size=10, forcing a split; the new sequence must
+        // restart with the latest init segment, which this media is encoded against.
+        operator
+            .process(&context, media(b"22222222"), &mut output)
+            .unwrap();
+
+        assert_eq!(out.len(), 6);
+        assert!(matches!(
+            out[3],
+            HlsData::EndMarker(Some(SplitReason::SizeLimit))
+        ));
+        match &out[4] {
+            HlsData::M4sData(M4sData::InitSegment(init)) => {
+                assert_eq!(init.data.as_ref(), b"BBBB");
+            }
+            other => panic!("expected re-emitted init segment, got {other:?}"),
+        }
+        assert!(matches!(
+            out[5],
+            HlsData::M4sData(M4sData::Segment(_))
+        ));
     }
 }

--- a/crates/hls-fix/src/operators/segment_split.rs
+++ b/crates/hls-fix/src/operators/segment_split.rs
@@ -144,6 +144,18 @@ impl SegmentSplitOperator {
             return Ok(None);
         }
 
+        // has_psi is set by a PAT alone; an empty programs list means the PMT was absent,
+        // cut across the segment boundary, or failed CRC. Comparing an empty layout against
+        // last_ts_stream_info would emit a spurious StreamStructureChange, so treat it like the
+        // no-PSI case and leave last_ts_stream_info untouched.
+        if analysis.stream_info.programs.is_empty() {
+            debug!(
+                "{} TS segment has PAT but no parsed PMT, skipping structural comparison",
+                self.context.name
+            );
+            return Ok(None);
+        }
+
         let current_stream_info = analysis.stream_info.clone();
         let mut profile = analysis.stream_profile();
         if self.last_resolution.is_some() && !analysis.has_random_access {
@@ -954,5 +966,47 @@ mod tests {
 
         assert_eq!(output_items.len(), 3);
         assert!(matches!(&output_items[1], HlsData::EndMarker(_)));
+    }
+
+    #[test]
+    fn pat_without_pmt_does_not_split() {
+        init_test_tracing!();
+        let token = CancellationToken::new();
+        let context = StreamerContext::arc_new(token);
+        let mut operator = SegmentSplitOperator::new(context.clone());
+        let mut output_items = Vec::new();
+
+        let mut output_fn = |item: HlsData| -> Result<(), PipelineError> {
+            output_items.push(item);
+            Ok(())
+        };
+
+        let seg = |data: Vec<u8>| {
+            HlsData::TsData(
+                hls::TsSegmentData::new(MediaSegment::empty(), Bytes::from(data))
+                    .with_continuity_mode(ts::ContinuityMode::Warn),
+            )
+        };
+
+        // Full PSI: PAT + PMT describing one program.
+        let full = create_ts_data_with_codecs(0x1B, 0x0F, 1);
+        // PAT packet alone: has_psi is true but no program layout gets parsed.
+        let pat_only = full[..188].to_vec();
+
+        operator
+            .process(&context, seg(full.clone()), &mut output_fn)
+            .unwrap();
+        operator
+            .process(&context, seg(pat_only), &mut output_fn)
+            .unwrap();
+        operator.process(&context, seg(full), &mut output_fn).unwrap();
+
+        // Neither the PMT-less segment nor the following full-PSI segment may split.
+        assert_eq!(output_items.len(), 3);
+        assert!(
+            output_items
+                .iter()
+                .all(|i| !matches!(i, HlsData::EndMarker(_)))
+        );
     }
 }

--- a/crates/hls-fix/src/writer_task.rs
+++ b/crates/hls-fix/src/writer_task.rs
@@ -10,7 +10,7 @@ use pipeline_common::{
     WriterError, WriterProgress, WriterState, WriterStats, WriterTask, expand_filename_template,
 };
 
-use tracing::{Span, debug, info};
+use tracing::{Span, debug, info, warn};
 use tracing_indicatif::span_ext::IndicatifSpanExt;
 
 use crate::analyzer::HlsAnalyzer;
@@ -50,6 +50,16 @@ impl HlsFormatStrategy {
         Ok(())
     }
 
+    /// Feed an already-written segment to `HlsAnalyzer::analyze_segment` for stats.
+    /// Validation failures (e.g. AV1 sample checks) are logged and swallowed so a single
+    /// non-conformant segment never aborts `WriterTask::run_from_channel`; the bytes are
+    /// already on disk by the time this runs.
+    fn analyze_written_segment(&mut self, item: &HlsData) {
+        if let Err(err) = self.analyzer.analyze_segment(item) {
+            warn!(error = %err, "HLS segment analysis failed; segment written, continuing");
+        }
+    }
+
     fn update_status(&self, state: &WriterState) {
         // Update the current span with progress information
         let span = Span::current();
@@ -84,19 +94,14 @@ impl FormatStrategy<HlsData> for HlsFormatStrategy {
     ) -> Result<u64, Self::StrategyError> {
         match item {
             HlsData::TsData(ts) => {
-                self.analyzer
-                    .analyze_segment(item)
-                    .map_err(HlsStrategyError::Analyzer)?;
                 let bytes_written = ts.data().len() as u64;
                 writer.write_all(ts.data())?;
                 // Accumulate TS segment duration
                 self.target_duration += ts.segment.duration;
+                self.analyze_written_segment(item);
                 Ok(bytes_written)
             }
             HlsData::M4sData(m4s_data) => {
-                self.analyzer
-                    .analyze_segment(item)
-                    .map_err(HlsStrategyError::Analyzer)?;
                 let bytes_written = match m4s_data {
                     M4sData::InitSegment(init) => {
                         info!("Found init segment, offset: {:?}", self.current_offset);
@@ -112,6 +117,7 @@ impl FormatStrategy<HlsData> for HlsFormatStrategy {
                     }
                 };
                 self.current_offset += bytes_written;
+                self.analyze_written_segment(item);
 
                 Ok(bytes_written)
             }
@@ -400,5 +406,54 @@ mod tests {
             .filter(|entry| entry.path().extension().is_some_and(|e| e == "ts"))
             .count();
         assert_eq!(file_count, 0);
+    }
+
+    #[test]
+    fn av1_validation_failure_does_not_abort_writer() {
+        use mp4::test_support::{make_init_with_video_sample_entry, make_media_segment_for_track};
+
+        let tempdir = tempfile::tempdir().expect("create temp dir");
+
+        let mut writer = HlsWriter::new(HlsWriterConfig {
+            output_dir: tempdir.path().to_path_buf(),
+            base_name: "test-%i".to_string(),
+            extension: "mp4".to_string(),
+            max_file_size: None,
+        });
+
+        let (tx, rx) = tokio::sync::mpsc::channel::<Result<HlsData, PipelineError>>(16);
+        let handle = std::thread::spawn(move || writer.run(rx.into()));
+
+        let init_data = make_init_with_video_sample_entry(1, *b"av01");
+        // OBU_TEMPORAL_DELIMITER with size 0: rejected by HlsAnalyzer's default
+        // Av1SampleValidationMode::StrictShouldNot policy.
+        let invalid_media = make_media_segment_for_track(1, &[0x12, 0x00]);
+        // OBU_FRAME with a one-byte payload: passes validation.
+        let valid_media = make_media_segment_for_track(1, &[0x32, 0x01, 0xAA]);
+        let expected_len = (init_data.len() + invalid_media.len() + valid_media.len()) as u64;
+
+        let media = |data: bytes::Bytes| {
+            Ok(HlsData::mp4_segment(
+                MediaSegment {
+                    duration: 1.0,
+                    ..MediaSegment::empty()
+                },
+                data,
+            ))
+        };
+
+        tx.blocking_send(Ok(HlsData::mp4_init(MediaSegment::empty(), init_data)))
+            .unwrap();
+        tx.blocking_send(media(invalid_media)).unwrap();
+        tx.blocking_send(media(valid_media)).unwrap();
+        drop(tx);
+
+        // The non-conformant media segment must be written and must not end the run.
+        let stats = handle
+            .join()
+            .expect("writer thread join")
+            .expect("writer ok");
+        assert_eq!(stats.files_created, 1);
+        assert_eq!(stats.bytes_written, expected_len);
     }
 }

--- a/crates/hls-fix/src/writer_task.rs
+++ b/crates/hls-fix/src/writer_task.rs
@@ -52,8 +52,8 @@ impl HlsFormatStrategy {
 
     /// Feed an already-written segment to `HlsAnalyzer::analyze_segment` for stats.
     /// Validation failures (e.g. AV1 sample checks) are logged and swallowed so a single
-    /// non-conformant segment never aborts `WriterTask::run_from_channel`; the bytes are
-    /// already on disk by the time this runs.
+    /// non-conformant segment never aborts `WriterTask::run_from_channel`; the bytes have
+    /// already been handed to the buffered file writer by the time this runs.
     fn analyze_written_segment(&mut self, item: &HlsData) {
         if let Err(err) = self.analyzer.analyze_segment(item) {
             warn!(error = %err, "HLS segment analysis failed; segment written, continuing");


### PR DESCRIPTION
## Severity

P1-04

Part of the #713 split series: extracts the "prevent HLS repair data loss" fixes from `fix/deep-review-fixes` into a standalone PR.

## What changed

- `DefragmentOperator::handle_end_of_playlist` and `DefragmentOperator::finish` now flush whatever fMP4 items are buffered instead of discarding buffers shorter than `MIN_TAGS_NUM` (5). TS handling is unchanged in behavior (always passthrough) but inlined; the dead `MIN_TS_TAGS_NUM` paths are gone.
- `SegmentLimiterOperator` tracks the most recent init segment rather than only the first one, so the init re-emitted after a size/duration split matches the codec configuration of the media that follows it.
- `SegmentSplitOperator::handle_ts_segment` skips structural comparison for TS segments whose PAT parsed but whose PMT did not (`stream_info.programs` empty), instead of comparing an empty program layout against `last_ts_stream_info`.
- `HlsFormatStrategy::write_item` writes segment bytes first and runs `HlsAnalyzer::analyze_segment` afterwards, logging and swallowing analysis failures (`analyze_written_segment`) instead of propagating them out of the writer task.

## Why

All four paths could lose or corrupt recordings on live input:

- A recording ending (or hitting a discontinuity) with fewer than 5 buffered fMP4 items silently dropped the final init segment and its media.
- After an init-segment change, a limiter split re-emitted the stale first init, producing a file whose media is undecodable against its init.
- A segment whose PMT was cut across the boundary (or failed CRC) triggered a spurious `StreamStructureChange` split, and poisoned `last_ts_stream_info` so the next healthy segment split again.
- A single non-conformant AV1 sample failed `analyze_segment` before the write, aborting the whole writer task and ending the recording.

## Impact

- Short final fMP4 segments are preserved at stream end, cancellation, and mid-stream discontinuities.
- fMP4 outputs after a split always start with the init segment their media was encoded against.
- No more spurious file splits on PAT-only/truncated-PSI TS segments.
- AV1 validation is diagnostic-only in the writer: bytes land on disk and recording continues.

## Validation

- `cargo test --locked -p hls-fix -p hls` (66 tests pass; new tests: `flushes_short_fmp4_buffer_on_playlist_end`, `flushes_short_fmp4_buffer_on_finish`, `reemits_latest_init_after_split`, `pat_without_pmt_does_not_split`, `av1_validation_failure_does_not_abort_writer`)
- Each headline test verified to fail against the pre-fix logic (temporarily reinstated locally).
- `cargo clippy --locked -p hls-fix -p hls --all-targets -- -D warnings` clean
- `git diff --check` clean

## Deferred (P3 follow-ups, intentionally excluded from this PR)

- Removal of the unused HLS query API (`crates/hls/src/ts.rs`, `crates/hls/src/segment.rs`, `crates/hls/src/resolution.rs` API pruning, `crates/hls/src/lib.rs` re-export change) and the six example binaries under `crates/hls/examples/`.
- All `Cargo.toml`/manifest changes, including the `progress` feature gating of `tracing-indicatif` in `writer_task.rs`.
- `HlsPipelineConfigBuilder` stage-toggle additions in `pipeline.rs` (additive API, no behavior fix).
