### PR TITLE
fix(flv): repair limit splitting, timestamp wrap, and EOS forwarding

### DIFF
--- a/crates/flv-fix/src/operators/gop_sort.rs
+++ b/crates/flv-fix/src/operators/gop_sort.rs
@@ -206,8 +206,11 @@ impl Processor<FlvData> for GopSortOperator {
                 debug!("{} Reset GOP tags...", self.context.name);
             }
             FlvData::EndOfSequence(_) => {
+                // Flush the buffered GOP, then forward the marker so downstream close
+                // handlers (e.g. mesio-cli pipe_flv_strategy) see the segment boundary.
                 self.push_tags(output)?;
                 debug!("{} End of stream...", self.context.name);
+                output(input)?;
             }
             FlvData::Split(_) => {
                 self.push_tags(output)?;
@@ -280,6 +283,44 @@ mod tests {
         }
 
         assert_eq!(output_items.len(), GopSortOperator::MAX_GOP_TAGS + 1);
+    }
+
+    #[test]
+    fn end_of_sequence_is_forwarded_after_flushing_gop() {
+        let context = StreamerContext::arc_new(CancellationToken::new());
+        let mut operator = GopSortOperator::new(Arc::clone(&context));
+        let mut output_items = Vec::new();
+        let mut output_fn = |item: FlvData| -> Result<(), PipelineError> {
+            output_items.push(item);
+            Ok(())
+        };
+
+        operator
+            .process(&context, create_test_header(), &mut output_fn)
+            .unwrap();
+        // Non-keyframe tags stay buffered in gop_tags until a flush point.
+        for timestamp in [0, 33, 66] {
+            operator
+                .process(&context, create_video_tag(timestamp, false), &mut output_fn)
+                .unwrap();
+        }
+        operator
+            .process(
+                &context,
+                FlvData::EndOfSequence(bytes::Bytes::new()),
+                &mut output_fn,
+            )
+            .unwrap();
+
+        let tag_count = output_items
+            .iter()
+            .filter(|item| matches!(item, FlvData::Tag(_)))
+            .count();
+        assert_eq!(tag_count, 3, "buffered GOP must be flushed");
+        assert!(
+            matches!(output_items.last(), Some(FlvData::EndOfSequence(_))),
+            "EndOfSequence must be forwarded downstream after the flushed tags"
+        );
     }
 
     #[test]

--- a/crates/flv-fix/src/operators/limit.rs
+++ b/crates/flv-fix/src/operators/limit.rs
@@ -278,7 +278,9 @@ impl Processor<FlvData> for LimitOperator {
             }
             FlvData::Tag(tag) => {
                 // Account for the tag plus the 4-byte PreviousTagSize field that follows
-                // every tag on disk, so accumulated_size tracks true output file growth.
+                // every tag on disk. accumulated_size still excludes the file header and
+                // the tags split_stream re-injects, so it tracks slightly under the
+                // on-disk size.
                 let tag_size = tag.size() as u64 + PREVIOUS_TAG_SIZE_FIELD as u64;
                 self.state.accumulated_size += tag_size;
 
@@ -327,7 +329,9 @@ impl Processor<FlvData> for LimitOperator {
                 // The `limits_hard_exceeded` fallback forces a split on a non-keyframe once
                 // the segment has grown well past the limit, bounding output for video whose
                 // keyframes never classify via FlvTag::is_key_frame_nalu (filtered/encrypted
-                // payloads, unrecognized codec IDs).
+                // payloads, unrecognized codec IDs). It also fires for streams whose GOP
+                // span exceeds the margin, so such a segment opens mid-GOP and its video
+                // is undecodable until the next keyframe.
                 let has_video = self.state.header.as_ref().is_some_and(|h| h.has_video);
                 let can_split_on_tag = if has_video && self.config.split_at_keyframes_only {
                     tag.is_key_frame_nalu() || self.limits_hard_exceeded()

--- a/crates/flv-fix/src/operators/limit.rs
+++ b/crates/flv-fix/src/operators/limit.rs
@@ -44,6 +44,14 @@ use tracing::{debug, info};
 /// Optional callback for when a stream split occurs
 pub type SplitCallback = Box<dyn Fn(SplitReason, u64, u32) + Send + Sync>;
 
+/// Bytes of the FLV PreviousTagSize field that follows every tag on disk.
+const PREVIOUS_TAG_SIZE_FIELD: u32 = 4;
+
+/// Multiplier applied to a configured limit before `LimitOperator::limits_hard_exceeded`
+/// forces a split on a non-keyframe. Gives a keyframe this much slack past the limit to
+/// appear before output is bounded for streams whose keyframes never classify.
+const HARD_SPLIT_MARGIN: u64 = 2;
+
 /// Configuration options for the limit operator
 pub struct LimitConfig {
     /// Maximum size in bytes before splitting (None = no limit)
@@ -180,6 +188,27 @@ impl LimitOperator {
         false
     }
 
+    /// True when the current segment has grown far enough past a configured limit that a
+    /// split must be forced even on a non-keyframe tag. Mirrors the intent of
+    /// GopSortOperator::MAX_GOP_TAGS: bound output when the preferred boundary never arrives.
+    fn limits_hard_exceeded(&self) -> bool {
+        if let Some(max_size) = self.config.max_size_bytes
+            && self.state.accumulated_size >= max_size.saturating_mul(HARD_SPLIT_MARGIN)
+        {
+            return true;
+        }
+
+        if let Some(max_duration) = self.config.max_duration_ms
+            && self.state.first_content_tag_seen
+            && self.state.current_duration() as u64
+                >= (max_duration as u64).saturating_mul(HARD_SPLIT_MARGIN)
+        {
+            return true;
+        }
+
+        false
+    }
+
     fn split_stream(
         &mut self,
         reason: SplitReason,
@@ -248,8 +277,9 @@ impl Processor<FlvData> for LimitOperator {
                 output(FlvData::Header(header))?;
             }
             FlvData::Tag(tag) => {
-                // Update size counter
-                let tag_size = tag.size() as u64;
+                // Account for the tag plus the 4-byte PreviousTagSize field that follows
+                // every tag on disk, so accumulated_size tracks true output file growth.
+                let tag_size = tag.size() as u64 + PREVIOUS_TAG_SIZE_FIELD as u64;
                 self.state.accumulated_size += tag_size;
 
                 // Track key metadata
@@ -291,12 +321,18 @@ impl Processor<FlvData> for LimitOperator {
                 // Check if any limit is exceeded
                 let should_split = self.check_limits();
 
-                // Inside the process method where split decisions are made
+                // Decide whether this tag is an acceptable split boundary.
+                // `split_at_keyframes_only` restricts video splits to keyframes so the new
+                // segment opens on a decodable frame; when disabled we split on any tag.
+                // The `limits_hard_exceeded` fallback forces a split on a non-keyframe once
+                // the segment has grown well past the limit, bounding output for video whose
+                // keyframes never classify via FlvTag::is_key_frame_nalu (filtered/encrypted
+                // payloads, unrecognized codec IDs).
                 let has_video = self.state.header.as_ref().is_some_and(|h| h.has_video);
-                let can_split_on_tag = if has_video {
-                    tag.is_key_frame_nalu()
+                let can_split_on_tag = if has_video && self.config.split_at_keyframes_only {
+                    tag.is_key_frame_nalu() || self.limits_hard_exceeded()
                 } else {
-                    // For audio-only, we can split on any tag
+                    // Audio-only streams, or keyframe-only splitting disabled: any tag works.
                     true
                 };
 
@@ -1144,6 +1180,249 @@ mod tests {
 
         // Verify the actual duration tracked by the operator
         // (We can't directly access state, but we verified no split occurred which proves it)
+    }
+
+    /// Video tag whose payload never classifies as a keyframe via
+    /// `FlvTag::is_key_frame_nalu`: the tag is marked filtered, so
+    /// `TagClass::from_payload` returns the default class with
+    /// `keyframe_media` unset even though the frame-type nibble says keyframe.
+    fn create_unclassified_keyframe_tag(timestamp: u32, size: usize) -> FlvData {
+        let mut data = vec![0u8; size];
+        data[0] = 0x17; // keyframe + AVC nibbles, ignored for filtered tags
+        data[1] = 1;
+        FlvData::Tag(FlvTag::new(
+            timestamp,
+            0,
+            FlvTagType::Video,
+            true,
+            Bytes::from(data),
+        ))
+    }
+
+    #[test]
+    fn size_limit_forces_split_when_keyframes_never_classify() {
+        let context = StreamerContext::arc_new(CancellationToken::new());
+        let split_sizes = Arc::new(Mutex::new(Vec::new()));
+
+        let config = LimitConfig {
+            max_size_bytes: Some(10 * 1024),
+            max_duration_ms: None,
+            split_at_keyframes_only: true,
+            on_split: Some(Box::new({
+                let split_sizes = Arc::clone(&split_sizes);
+                move |_, size, _| {
+                    split_sizes.lock().unwrap().push(size);
+                }
+            })),
+        };
+
+        let mut operator = LimitOperator::with_config(context.clone(), config);
+        let mut output_items = Vec::new();
+        let mut output_fn = |item: FlvData| -> Result<(), PipelineError> {
+            output_items.push(item);
+            Ok(())
+        };
+
+        operator
+            .process(&context, test_utils::create_test_header(), &mut output_fn)
+            .unwrap();
+
+        // ~30 KiB of tags, none of which classifies as a keyframe. The split must
+        // fire once accumulated_size passes HARD_SPLIT_MARGIN * max_size_bytes.
+        for i in 0..30u32 {
+            operator
+                .process(
+                    &context,
+                    create_unclassified_keyframe_tag(i * 33, 1024),
+                    &mut output_fn,
+                )
+                .unwrap();
+        }
+
+        operator.finish(&context, &mut output_fn).unwrap();
+
+        let sizes = split_sizes.lock().unwrap().clone();
+        assert_eq!(
+            sizes.len(),
+            1,
+            "hard margin should force exactly one split without classified keyframes"
+        );
+        assert!(
+            sizes[0] >= 2 * 10 * 1024,
+            "split should only fire past the hard margin, got {} bytes",
+            sizes[0]
+        );
+    }
+
+    #[test]
+    fn duration_limit_forces_split_when_keyframes_never_classify() {
+        let context = StreamerContext::arc_new(CancellationToken::new());
+        let split_durations = Arc::new(Mutex::new(Vec::new()));
+
+        let config = LimitConfig {
+            max_size_bytes: None,
+            max_duration_ms: Some(500),
+            split_at_keyframes_only: true,
+            on_split: Some(Box::new({
+                let split_durations = Arc::clone(&split_durations);
+                move |_, _, duration| {
+                    split_durations.lock().unwrap().push(duration);
+                }
+            })),
+        };
+
+        let mut operator = LimitOperator::with_config(context.clone(), config);
+        let mut output_items = Vec::new();
+        let mut output_fn = |item: FlvData| -> Result<(), PipelineError> {
+            output_items.push(item);
+            Ok(())
+        };
+
+        operator
+            .process(&context, test_utils::create_test_header(), &mut output_fn)
+            .unwrap();
+
+        // Timestamps run to 1500ms with no classified keyframe; the split must fire
+        // once current_duration passes HARD_SPLIT_MARGIN * max_duration_ms.
+        for ts in (0..=1500u32).step_by(100) {
+            operator
+                .process(
+                    &context,
+                    create_unclassified_keyframe_tag(ts, 64),
+                    &mut output_fn,
+                )
+                .unwrap();
+        }
+
+        operator.finish(&context, &mut output_fn).unwrap();
+
+        let durations = split_durations.lock().unwrap().clone();
+        assert_eq!(
+            durations.len(),
+            1,
+            "hard margin should force exactly one split without classified keyframes"
+        );
+        assert!(
+            durations[0] >= 2 * 500,
+            "split should only fire past the hard margin, got {}ms",
+            durations[0]
+        );
+    }
+
+    #[test]
+    fn video_splits_on_any_tag_when_keyframes_only_disabled() {
+        let context = StreamerContext::arc_new(CancellationToken::new());
+        let split_counter = Arc::new(AtomicUsize::new(0));
+        let split_counter_clone = split_counter.clone();
+
+        let config = LimitConfig {
+            max_size_bytes: Some(1024),
+            max_duration_ms: None,
+            split_at_keyframes_only: false,
+            on_split: Some(Box::new(move |_, _, _| {
+                split_counter.fetch_add(1, Ordering::SeqCst);
+            })),
+        };
+
+        let mut operator = LimitOperator::with_config(context.clone(), config);
+        let mut output_items = Vec::new();
+        let mut output_fn = |item: FlvData| -> Result<(), PipelineError> {
+            output_items.push(item);
+            Ok(())
+        };
+
+        operator
+            .process(&context, test_utils::create_test_header(), &mut output_fn)
+            .unwrap();
+
+        // Only non-keyframe video tags: with split_at_keyframes_only disabled the
+        // split must still fire as soon as the size limit is crossed.
+        for i in 0..3u32 {
+            operator
+                .process(
+                    &context,
+                    test_utils::create_video_tag_with_size(i * 33, false, 500),
+                    &mut output_fn,
+                )
+                .unwrap();
+        }
+
+        operator.finish(&context, &mut output_fn).unwrap();
+
+        assert_eq!(
+            split_counter_clone.load(Ordering::SeqCst),
+            1,
+            "split_at_keyframes_only=false must allow splitting on non-keyframe video tags"
+        );
+        let header_count = output_items
+            .iter()
+            .filter(|item| matches!(item, FlvData::Header(_)))
+            .count();
+        assert_eq!(
+            header_count, 2,
+            "initial header plus one re-injected header"
+        );
+    }
+
+    #[test]
+    fn accumulated_size_counts_previous_tag_size_field() {
+        let context = StreamerContext::arc_new(CancellationToken::new());
+        let split_counter = Arc::new(AtomicUsize::new(0));
+        let split_counter_clone = split_counter.clone();
+
+        let config = LimitConfig {
+            max_size_bytes: Some(1000),
+            max_duration_ms: None,
+            split_at_keyframes_only: false,
+            on_split: Some(Box::new(move |_, _, _| {
+                split_counter.fetch_add(1, Ordering::SeqCst);
+            })),
+        };
+
+        let mut operator = LimitOperator::with_config(context.clone(), config);
+        let mut output_items = Vec::new();
+        let mut output_fn = |item: FlvData| -> Result<(), PipelineError> {
+            output_items.push(item);
+            Ok(())
+        };
+
+        // Audio-only stream: any tag is a valid split boundary, so the split fires on
+        // the exact tag where accumulated_size crosses max_size_bytes.
+        operator
+            .process(
+                &context,
+                FlvData::Header(FlvHeader::new(true, false)),
+                &mut output_fn,
+            )
+            .unwrap();
+
+        // Each tag is 96 bytes (85-byte payload + 11-byte tag header) plus the 4-byte
+        // PreviousTagSize field = 100 bytes on disk. Ten tags reach the 1000-byte
+        // limit only when the PreviousTagSize field is counted (10 * 96 = 960).
+        for i in 0..10u32 {
+            let data = vec![0u8; 85];
+            operator
+                .process(
+                    &context,
+                    FlvData::Tag(FlvTag::new(
+                        i * 23,
+                        0,
+                        FlvTagType::Audio,
+                        false,
+                        Bytes::from(data),
+                    )),
+                    &mut output_fn,
+                )
+                .unwrap();
+        }
+
+        operator.finish(&context, &mut output_fn).unwrap();
+
+        assert_eq!(
+            split_counter_clone.load(Ordering::SeqCst),
+            1,
+            "accumulated_size must include the PreviousTagSize field of each tag"
+        );
     }
 
     #[test]

--- a/crates/flv-fix/src/operators/timing_repair.rs
+++ b/crates/flv-fix/src/operators/timing_repair.rs
@@ -259,25 +259,19 @@ impl TimingState {
 
         if tag.is_audio_tag() {
             if let Some(ref last) = self.last_audio_tag {
-                if last.is_audio_sequence_header() {
-                    expected < last.timestamp_ms
-                } else {
-                    let min_expected = last.timestamp_ms;
-
-                    expected <= min_expected
-                }
+                // Treat equal timestamps as valid: an audio tag sharing the previous
+                // audio tag's timestamp is not a backwards jump, so only a strictly
+                // smaller `expected` is a rebound.
+                expected < last.timestamp_ms
             } else {
                 false
             }
         } else if tag.is_video_tag() {
             if let Some(ref last) = self.last_video_tag {
-                if last.is_video_sequence_header() {
-                    expected < last.timestamp_ms
-                } else {
-                    let min_expected = last.timestamp_ms;
-
-                    expected <= min_expected
-                }
+                // Treat equal timestamps as valid: an enhanced METADATA video packet
+                // (tag type 9) legitimately shares its coded frame's timestamp, so only
+                // a strictly smaller `expected` is a rebound.
+                expected < last.timestamp_ms
             } else {
                 false
             }
@@ -339,18 +333,23 @@ impl TimingState {
         let last_ts = self.last_tag.as_ref().map(|t| t.timestamp_ms).unwrap_or(0);
 
         if let Some(last_video) = self.last_video_tag.as_ref().filter(|_| tag.is_video_tag()) {
-            // Calculate ideal next frame timestamp
-            let ideal_next_ts = last_video.timestamp_ms + self.video_frame_interval;
+            // Calculate ideal next frame timestamp; saturating_add keeps the u32 timeline
+            // from wrapping near u32::MAX after ~49.7 days accumulated in one segment.
+            let ideal_next_ts = last_video
+                .timestamp_ms
+                .saturating_add(self.video_frame_interval);
 
             new_delta = ideal_next_ts as i64 - current as i64;
         } else if let Some(last_audio) = self.last_audio_tag.as_ref().filter(|_| tag.is_audio_tag())
         {
-            let ideal_next_ts = last_audio.timestamp_ms + self.audio_sample_interval;
+            let ideal_next_ts = last_audio
+                .timestamp_ms
+                .saturating_add(self.audio_sample_interval);
             new_delta = ideal_next_ts as i64 - current as i64;
         } else if let Some(last) = &self.last_tag {
             // No type-specific last tag, use generic last tag
             let interval = max(self.video_frame_interval, self.audio_sample_interval);
-            new_delta = (last.timestamp_ms + interval) as i64 - current as i64;
+            new_delta = last.timestamp_ms.saturating_add(interval) as i64 - current as i64;
         }
 
         let expected = Self::apply_delta(current, new_delta);
@@ -360,7 +359,7 @@ impl TimingState {
             // to avoid negative timestamps or rebounding
             // in those cases, we use the last timestamp as a reference to calculate the delta
             if tag.is_video_tag() {
-                let adjusted_ts = last_ts + self.video_frame_interval;
+                let adjusted_ts = last_ts.saturating_add(self.video_frame_interval);
                 new_delta = if adjusted_ts >= current {
                     (adjusted_ts - current) as i64
                 } else {
@@ -368,7 +367,7 @@ impl TimingState {
                 };
             } else if tag.is_audio_tag() {
                 // calculate ideal next audio timestamp
-                let adjusted_ts = last_ts + self.audio_sample_interval;
+                let adjusted_ts = last_ts.saturating_add(self.audio_sample_interval);
                 new_delta = if adjusted_ts >= current {
                     (adjusted_ts - current) as i64
                 } else {
@@ -740,6 +739,90 @@ mod tests {
                 "Rebounded timestamp should be corrected to maintain forward progress"
             );
         }
+    }
+
+    #[test]
+    fn equal_timestamps_are_not_rebounds() {
+        // Consecutive tags of the same type sharing a timestamp (e.g. an enhanced
+        // METADATA video packet emitted alongside its coded frame) must pass through
+        // is_timestamp_rebounded without triggering a delta correction.
+        let input_tags = vec![
+            create_test_header(),
+            create_video_tag(1000, false),
+            create_video_tag(1000, false),
+            create_audio_tag(1005),
+            create_audio_tag(1005),
+        ];
+
+        let results = process_tags_through_operator(TimingRepairConfig::default(), input_tags);
+
+        let timestamps: Vec<u32> = results
+            .iter()
+            .filter_map(|item| match item {
+                FlvData::Tag(tag) => Some(tag.timestamp_ms),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            timestamps,
+            vec![1000, 1000, 1005, 1005],
+            "tags sharing their predecessor's timestamp must pass through unchanged"
+        );
+    }
+
+    #[test]
+    fn video_rebound_near_u32_max_saturates_instead_of_overflowing() {
+        // calculate_delta_correction adds video_frame_interval to the previous video
+        // timestamp; near u32::MAX that sum must saturate rather than wrap (or panic
+        // in debug builds).
+        let input_tags = vec![
+            create_test_header(),
+            create_video_tag(u32::MAX - 10, false),
+            create_video_tag(1000, false),
+        ];
+
+        let results = process_tags_through_operator(TimingRepairConfig::default(), input_tags);
+
+        let timestamps: Vec<u32> = results
+            .iter()
+            .filter_map(|item| match item {
+                FlvData::Tag(tag) => Some(tag.timestamp_ms),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(timestamps[0], u32::MAX - 10);
+        assert!(
+            timestamps[1] >= timestamps[0],
+            "corrected rebound timestamp must not go backwards (got {})",
+            timestamps[1]
+        );
+    }
+
+    #[test]
+    fn audio_rebound_near_u32_max_saturates_instead_of_overflowing() {
+        // Same as the video case, but through the last_audio_tag branch of
+        // calculate_delta_correction and audio_sample_interval.
+        let input_tags = vec![
+            create_test_header(),
+            create_audio_tag(u32::MAX - 5),
+            create_audio_tag(2000),
+        ];
+
+        let results = process_tags_through_operator(TimingRepairConfig::default(), input_tags);
+
+        let timestamps: Vec<u32> = results
+            .iter()
+            .filter_map(|item| match item {
+                FlvData::Tag(tag) => Some(tag.timestamp_ms),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(timestamps[0], u32::MAX - 5);
+        assert!(
+            timestamps[1] >= timestamps[0],
+            "corrected rebound timestamp must not go backwards (got {})",
+            timestamps[1]
+        );
     }
 
     #[test]

--- a/crates/flv/src/parser_async.rs
+++ b/crates/flv/src/parser_async.rs
@@ -273,20 +273,11 @@ impl Decoder for FlvDecoder {
                 "Invalid tag type encountered: {}. Attempting resync.",
                 src[0]
             );
-            // Discard the single invalid byte and try resyncing
-            // src.advance(1);
-            // Now attempt resync on the rest
-            if !self.try_resync(src) {
-                // Resync advanced the buffer. Return None to signal progress
-                // but no complete frame yet from *this* specific call point.
-                // The next call to decode will attempt parsing from the new position.
-                return Ok(None);
-            } else {
-                // Resync cleared the buffer or couldn't find anything.
-                // Need more data. try_resync already reserved space.
-                trace!("Resync failed or cleared buffer, returning None for more data.");
-                return Ok(None);
-            }
+            // try_resync either advances the buffer to the next candidate tag start or
+            // clears it and reserves space for more data; both outcomes yield here so the
+            // next decode call re-parses from the updated position.
+            self.try_resync(src);
+            return Ok(None);
         }
 
         if data_size > MAX_TAG_DATA_SIZE {


### PR DESCRIPTION
## Severity

P1-03

This is P1-03 from the #713 split series: FLV processing correctness fixes that can otherwise lose or corrupt recordings.

## What changed

- `LimitOperator` (`crates/flv-fix/src/operators/limit.rs`):
  - Added a `limits_hard_exceeded` fallback: once a segment grows past `HARD_SPLIT_MARGIN` (2x) of a configured size/duration limit, a split is forced even on a non-keyframe tag.
  - `can_split_on_tag` now honors `LimitConfig::split_at_keyframes_only`; when disabled, video streams split on any tag at the limit.
  - `accumulated_size` now counts each tag's 4-byte PreviousTagSize field, matching on-disk file growth.
- `TimingRepairOperator` (`crates/flv-fix/src/operators/timing_repair.rs`):
  - `is_timestamp_rebounded` uses strict `<` so a tag sharing its predecessor's timestamp (e.g. an enhanced METADATA video packet alongside its coded frame) is no longer "corrected".
  - `calculate_delta_correction` uses `saturating_add` for all interval arithmetic on `u32` timestamps.
- `GopSortOperator` (`crates/flv-fix/src/operators/gop_sort.rs`): the `FlvData::EndOfSequence` marker is forwarded downstream after the buffered GOP is flushed.
- `FlvDecoder::decode` (`crates/flv/src/parser_async.rs`): collapsed the invalid-tag-type resync into a single `try_resync` call (both prior branches returned `Ok(None)`); the comment now describes what `try_resync` actually does.
- Regression tests for each fix (8 new tests; all fail on the pre-fix code).

## Why

- `LimitOperator` only split video streams on `FlvTag::is_key_frame_nalu()`. For streams whose keyframes never classify (filtered/encrypted payloads, unrecognized codec IDs), no tag ever qualified, so size/duration limits were silently ignored and a single segment grew without bound. `split_at_keyframes_only: false` was also ignored for video streams.
- `TimingRepairOperator::is_timestamp_rebounded` used `<=`, so legitimate equal-timestamp tags were flagged as rebounds and shifted forward by one frame/sample interval, corrupting timing on streams that emit same-timestamp packets.
- `calculate_delta_correction` used unchecked `+` on `u32` millisecond timestamps: near `u32::MAX` (~49.7 days accumulated in one segment) it panics in debug builds and wraps in release, driving the repaired timeline back to ~0.
- `GopSortOperator` swallowed `EndOfSequence` after flushing, so nothing downstream of it (limit, writer, `mesio-cli` `PipeFlvStrategy::should_close_pipe`) ever observed stream end through that path.

## Impact

- Recordings with unclassifiable keyframes now respect size/duration limits (at 2x margin) instead of producing one unbounded file.
- Segment size accounting matches actual bytes on disk.
- Equal-timestamp tags pass through untouched; long-running segments cannot wrap or panic the timestamp repair path.
- End-of-stream is propagated through the GOP sorter so downstream close handlers fire.

## Validation

- `cargo test --locked -p flv-fix -p flv` — 68 + 81 unit tests + 4 doctests pass, 0 failed
- Pre-fix check: with only the behavior hunks reverted (tests kept), all 8 new tests fail
- `cargo clippy --locked -p flv-fix -p flv --all-targets -- -D warnings` — clean
- `cargo fmt -p flv-fix -p flv` — applied, no residual diff
- `git diff --check` — clean

## Intentionally excluded from #713 (deferred P3 follow-ups)

- `crates/flv-fix/src/operators/segment_reinject.rs` (new `SegmentInitCache`) and the `SplitOperator`/`LimitOperator` refactor onto it — the bug fixes here are re-authored against each operator's existing cache-and-reinject code.
- All `Cargo.toml` changes: the `progress` feature gating with optional `tracing-indicatif` in `flv-fix`, the `time` workspace-dependency switch, and the `flv` crate's `pipeline-common` -> `media-types` dependency move (plus the matching `data.rs`/`lib.rs` re-export changes).
- The `enable_low_latency` knob removal (`pipeline.rs`, `writer.rs`, `writer_task.rs`) and the related `FlvFormatStrategy::new()`/`Default` signature change.
