### PR TITLE
fix(auth): harden password hashing and token tracing

### DIFF
--- a/rust-srec/src/api/auth_service.rs
+++ b/rust-srec/src/api/auth_service.rs
@@ -344,6 +344,24 @@ impl AuthService {
             .is_ok())
     }
 
+    /// Run `verify_password` on a blocking thread so the Argon2id work
+    /// (m=19456, t=2) never occupies a tokio async worker.
+    async fn verify_password_blocking(password: &str, hash: &str) -> Result<bool, AuthError> {
+        let password = password.to_owned();
+        let hash = hash.to_owned();
+        tokio::task::spawn_blocking(move || Self::verify_password(&password, &hash))
+            .await
+            .map_err(|e| AuthError::Internal(format!("Password verification task failed: {}", e)))?
+    }
+
+    /// Run `hash_password` on a blocking thread; see `verify_password_blocking`.
+    async fn hash_password_blocking(password: &str) -> Result<String, AuthError> {
+        let password = password.to_owned();
+        tokio::task::spawn_blocking(move || Self::hash_password(&password))
+            .await
+            .map_err(|e| AuthError::Internal(format!("Password hashing task failed: {}", e)))?
+    }
+
     /// Generate a cryptographically secure refresh token (256 bits).
     fn generate_refresh_token() -> String {
         use rand::RngExt;
@@ -421,7 +439,7 @@ impl AuthService {
         }
 
         // Verify password
-        if !Self::verify_password(password, &user.password_hash)? {
+        if !Self::verify_password_blocking(password, &user.password_hash).await? {
             warn!(user_id = %user.id, username = %username, "Login failed: invalid credentials");
             return Err(AuthError::InvalidCredentials);
         }
@@ -661,7 +679,7 @@ impl AuthService {
             .ok_or(AuthError::UserNotFound)?;
 
         // Verify current password
-        if !Self::verify_password(current_password, &user.password_hash)? {
+        if !Self::verify_password_blocking(current_password, &user.password_hash).await? {
             warn!(user_id = %user_id, "Password change failed: incorrect current password");
             return Err(AuthError::IncorrectCurrentPassword);
         }
@@ -677,7 +695,7 @@ impl AuthService {
         self.validate_password_strength(new_password)?;
 
         // Hash new password
-        let new_hash = Self::hash_password(new_password)?;
+        let new_hash = Self::hash_password_blocking(new_password).await?;
 
         // Update password and clear must_change_password flag
         self.user_repo

--- a/rust-srec/src/api/server.rs
+++ b/rust-srec/src/api/server.rs
@@ -235,8 +235,8 @@ impl ApiServer {
                         return Span::none();
                     }
                     // Routes that carry a JWT/access token or upstream auth
-                    // headers in the query string (stream_proxy/media/downloads
-                    // read `?token=`/`?headers=`). Record only method + path so
+                    // headers in the query string (stream_proxy/media/downloads/
+                    // logging read `?token=`/`?headers=`). Record only method + path so
                     // those secrets never enter the span's `uri` field and thus
                     // never reach on_response/on_failure lines or the retained
                     // rust-srec.log files. The `tower_http::trace::make_span`

--- a/rust-srec/src/api/server.rs
+++ b/rust-srec/src/api/server.rs
@@ -230,14 +230,41 @@ impl ApiServer {
         router = router.layer(
             TraceLayer::new_for_http()
                 .make_span_with(|req: &Request| {
-                    if req.uri().path().starts_with("/api/health") {
-                        Span::none()
-                    } else {
-                        let mut make_span =
-                            tower_http::trace::DefaultMakeSpan::new().level(tracing::Level::INFO);
-                        use tower_http::trace::MakeSpan;
-                        make_span.make_span(req)
+                    let path = req.uri().path();
+                    if path.starts_with("/api/health") {
+                        return Span::none();
                     }
+                    // Routes that carry a JWT/access token or upstream auth
+                    // headers in the query string (stream_proxy/media/downloads
+                    // read `?token=`/`?headers=`). Record only method + path so
+                    // those secrets never enter the span's `uri` field and thus
+                    // never reach on_response/on_failure lines or the retained
+                    // rust-srec.log files. The `tower_http::trace::make_span`
+                    // target keeps the span under the `tower_http` filter so
+                    // DefaultOnResponse/DefaultOnFailure still attach to it.
+                    const TOKEN_QUERY_ROUTES: [&str; 4] = [
+                        "/api/stream-proxy",
+                        "/api/media",
+                        "/api/downloads",
+                        "/api/logging",
+                    ];
+                    if TOKEN_QUERY_ROUTES
+                        .iter()
+                        .any(|prefix| path.starts_with(prefix))
+                    {
+                        return tracing::span!(
+                            target: "tower_http::trace::make_span",
+                            tracing::Level::INFO,
+                            "request",
+                            method = %req.method(),
+                            uri = %path,
+                            version = ?req.version(),
+                        );
+                    }
+                    let mut make_span =
+                        tower_http::trace::DefaultMakeSpan::new().level(tracing::Level::INFO);
+                    use tower_http::trace::MakeSpan;
+                    make_span.make_span(req)
                 })
                 .on_request(|req: &Request, span: &Span| {
                     if span.is_disabled() || req.uri().path().starts_with("/api/health") {


### PR DESCRIPTION
## Severity

P1-10

## What changed

- `AuthService::verify_password` and `hash_password` now run through `spawn_blocking` wrappers (`verify_password_blocking`, `hash_password_blocking`) at the login and password-change call sites, so the Argon2id work (m=19456, t=2) never occupies a tokio async worker.
- The HTTP trace layer's `make_span` records only method + path (not the full URI) for `/api/stream-proxy`, `/api/media`, `/api/downloads`, and `/api/logging` requests, whose query strings carry JWT access tokens or upstream auth headers (`?token=` / `?headers=`). The span keeps the `tower_http::trace::make_span` target so `DefaultOnResponse`/`DefaultOnFailure` still attach.

## Why

A handful of concurrent logins could stall async workers for the duration of the Argon2id derivations, delaying every other request on those workers. Separately, the default `MakeSpan` records the full request URI, so access tokens in query strings reached span fields, on-response/on-failure log lines, and the retained `rust-srec.log` files.

## Impact

Password hashing no longer blocks the async runtime, and bearer tokens passed via query string never enter tracing output or log retention.

## Validation

- `cargo test --locked -p rust-srec --lib api::` (157 passed)
- `cargo clippy --locked -p rust-srec --lib -- -D warnings`
- `rustfmt --edition 2024 --check` on both files
- `git diff --check`

This is P1-10 from the #713 split series, scoped to the backend items. The frontend `SESSION_SECRET` fail-closed change originally listed under this chunk already shipped in #728, and the platform cookie-logging removals landed with #726, so this PR covers the remaining two items.
