### PR TITLE
fix(platforms): correct live/offline classification across extractors

### DIFF
--- a/crates/platforms/src/extractor/platforms/acfun/builder.rs
+++ b/crates/platforms/src/extractor/platforms/acfun/builder.rs
@@ -70,19 +70,30 @@ impl PlatformExtractor for Acfun {
             .await?;
 
         if response.result != 0 {
+            let detail = response
+                .error_msg
+                .unwrap_or_else(|| response.result.to_string());
             return Err(ExtractorError::ValidationError(format!(
-                "Failed to login: {}",
-                response.result
+                "Failed to login: {detail}"
             )));
         }
+
+        let user_id = response.user_id.ok_or_else(|| {
+            ExtractorError::ValidationError("Visitor login response missing userId".to_string())
+        })?;
+        let visitor_st = response.visitor_st.ok_or_else(|| {
+            ExtractorError::ValidationError(
+                "Visitor login response missing acfun.api.visitor_st".to_string(),
+            )
+        })?;
 
         let params = [
             ("subBiz", "mainApp".to_string()),
             ("kpn", "ACFUN_APP".to_string()),
             ("kpf", "PC_WEB".to_string()),
-            ("userId", response.user_id.to_string()),
+            ("userId", user_id.to_string()),
             ("did", did),
-            ("acfun.api.visitor_st", response.visitor_st),
+            ("acfun.api.visitor_st", visitor_st),
         ];
         let start_play_response = self
             .extractor
@@ -142,6 +153,25 @@ impl PlatformExtractor for Acfun {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_visitor_login_error_payload_parses_without_user_fields() {
+        let json = r#"{"result":100,"error_msg":"rate limited"}"#;
+        let response: VisitorLoginResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(response.result, 100);
+        assert_eq!(response.error_msg.as_deref(), Some("rate limited"));
+        assert!(response.user_id.is_none());
+        assert!(response.visitor_st.is_none());
+    }
+
+    #[test]
+    fn test_visitor_login_success_payload_parses_user_fields() {
+        let json = r#"{"result":0,"userId":123456,"acfun.api.visitor_st":"st-token"}"#;
+        let response: VisitorLoginResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(response.result, 0);
+        assert_eq!(response.user_id, Some(123456));
+        assert_eq!(response.visitor_st.as_deref(), Some("st-token"));
+    }
 
     #[tokio::test]
     #[ignore]

--- a/crates/platforms/src/extractor/platforms/acfun/models.rs
+++ b/crates/platforms/src/extractor/platforms/acfun/models.rs
@@ -8,7 +8,6 @@ use serde::Deserialize;
 #[derive(Debug, Deserialize)]
 pub struct VisitorLoginResponse {
     pub result: i32,
-    #[serde(rename = "error_msg")]
     pub error_msg: Option<String>,
     // Present only when result == 0; error payloads omit these, so they must be
     // Option for deserialization to reach the result check in Acfun::extract.

--- a/crates/platforms/src/extractor/platforms/acfun/models.rs
+++ b/crates/platforms/src/extractor/platforms/acfun/models.rs
@@ -8,10 +8,14 @@ use serde::Deserialize;
 #[derive(Debug, Deserialize)]
 pub struct VisitorLoginResponse {
     pub result: i32,
+    #[serde(rename = "error_msg")]
+    pub error_msg: Option<String>,
+    // Present only when result == 0; error payloads omit these, so they must be
+    // Option for deserialization to reach the result check in Acfun::extract.
     #[serde(rename = "userId")]
-    pub user_id: i64,
+    pub user_id: Option<i64>,
     #[serde(rename = "acfun.api.visitor_st")]
-    pub visitor_st: String,
+    pub visitor_st: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/crates/platforms/src/extractor/platforms/bilibili/builder.rs
+++ b/crates/platforms/src/extractor/platforms/bilibili/builder.rs
@@ -202,8 +202,11 @@ impl Bilibili {
             return Err(ExtractorError::ValidationError(json.message));
         }
 
-        let data = json.data;
-        let playurl_info = data.playurl_info;
+        // `code == 0` with no `data`/`playurl_info` means the room went offline between
+        // `fetch_room_info` and here; surface it as an empty stream list rather than a decode error.
+        let Some(playurl_info) = json.data.and_then(|data| data.playurl_info) else {
+            return Ok(Vec::new());
+        };
 
         let mut quality_map = FxHashMap::default();
         quality_map.reserve(playurl_info.playurl.g_qn_desc.len());
@@ -335,6 +338,12 @@ impl PlatformExtractor for Bilibili {
     }
 
     async fn get_url(&self, stream_info: &mut StreamInfo) -> Result<(), ExtractorError> {
+        // Nothing to resolve when the URL is already populated; check before reading extras so a
+        // ready stream with missing/malformed extras is not rejected.
+        if !stream_info.url.is_empty() {
+            return Ok(());
+        }
+
         let extras = stream_info.extras.as_ref().ok_or_else(|| {
             ExtractorError::ValidationError("Stream extras not found".to_string())
         })?;
@@ -348,11 +357,6 @@ impl PlatformExtractor for Bilibili {
         })?;
 
         let cdn = extras.get("cdn").and_then(|c| c.as_str());
-
-        // skip extraction if url is already present
-        if !stream_info.url.is_empty() {
-            return Ok(());
-        }
 
         // 协议格式，0: http_stream(flv), 1: http_hls
         let protocol = match stream_info.stream_format {
@@ -388,7 +392,10 @@ impl PlatformExtractor for Bilibili {
             return Err(ExtractorError::ValidationError(json.message));
         }
 
-        let playurl_info = json.data.playurl_info;
+        let playurl_info = json
+            .data
+            .and_then(|data| data.playurl_info)
+            .ok_or(ExtractorError::NoStreamsFound)?;
         let stream = playurl_info
             .playurl
             .stream
@@ -455,9 +462,48 @@ mod tests {
     use tracing::Level;
 
     use crate::extractor::{
-        default::default_client, platform_extractor::PlatformExtractor,
-        platforms::bilibili::Bilibili,
+        default::default_client,
+        platform_extractor::PlatformExtractor,
+        platforms::bilibili::{Bilibili, models::RoomPlayInfo},
     };
+
+    #[test]
+    fn test_room_play_info_parses_offline_room_with_null_playurl_info() {
+        let json = r#"{
+            "code": 0,
+            "message": "0",
+            "ttl": 1,
+            "data": {
+                "room_id": 6,
+                "short_id": 6,
+                "uid": 1,
+                "is_hidden": false,
+                "is_locked": false,
+                "is_portrait": false,
+                "live_status": 0,
+                "hidden_till": 0,
+                "lock_till": 0,
+                "encrypted": false,
+                "pwd_verified": false,
+                "live_time": -1,
+                "room_shield": 0,
+                "playurl_info": null
+            }
+        }"#;
+        let info: RoomPlayInfo = serde_json::from_str(json).unwrap();
+        assert_eq!(info.code, 0);
+        let data = info.data.unwrap();
+        assert_eq!(data.live_status, 0);
+        assert!(data.playurl_info.is_none());
+    }
+
+    #[test]
+    fn test_room_play_info_parses_error_response_without_data() {
+        let json = r#"{"code": -400, "message": "参数错误", "ttl": 1, "data": null}"#;
+        let info: RoomPlayInfo = serde_json::from_str(json).unwrap();
+        assert_eq!(info.code, -400);
+        assert!(info.data.is_none());
+    }
 
     #[tokio::test]
     #[ignore]

--- a/crates/platforms/src/extractor/platforms/bilibili/models.rs
+++ b/crates/platforms/src/extractor/platforms/bilibili/models.rs
@@ -50,7 +50,8 @@ pub struct RoomPlayInfo {
     pub code: i32,
     pub message: String,
     pub ttl: i32,
-    pub data: RoomPlayInfoData,
+    // Absent when `code != 0`; callers must check `code` before unwrapping `data`.
+    pub data: Option<RoomPlayInfoData>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -69,7 +70,8 @@ pub struct RoomPlayInfoData {
     pub live_time: i64,
     pub room_shield: i32,
     // pub all_special_types: Vec<i32>,
-    pub playurl_info: PlayUrlInfo,
+    // Null while the room is offline (`live_status == 0`) even though `code == 0`.
+    pub playurl_info: Option<PlayUrlInfo>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/crates/platforms/src/extractor/platforms/douyu/builder.rs
+++ b/crates/platforms/src/extractor/platforms/douyu/builder.rs
@@ -60,10 +60,6 @@ fn is_douyu_auth_failed(status: StatusCode, body: &str) -> bool {
     normalized.contains("鉴权失败")
 }
 
-fn is_douyu_room_unavailable_message(message: &str) -> bool {
-    message.contains("error -3") || message.contains("error -4") || message.contains("error -5")
-}
-
 pub struct Douyu {
     pub extractor: Extractor,
     pub cdn: String,
@@ -101,8 +97,11 @@ impl Douyu {
             .or_else(|| extras_get_bool(extras.as_ref(), "onlyAudio"))
             .unwrap_or(false);
 
+        // Clamp to at least 1 so the `for attempt in 0..self.request_retries` loop in
+        // `get_betard_room_info` runs; 0 would make every betard fetch return the generic
+        // "Failed to get betard room info" error and silently disable VIP detection.
         let request_retries = extras_get_u64(extras.as_ref(), "request_retries")
-            .map(|v| v as u32)
+            .map(|v| (v as u32).max(1))
             .unwrap_or(Self::DEFAULT_RETRIES);
 
         let mut extractor = Extractor::new("Douyu", url, client);
@@ -646,10 +645,14 @@ impl Douyu {
                 // Handle specific Douyu error codes
                 match resp.error {
                     -5..=-3 => {
-                        return Err(ExtractorError::ValidationError(format!(
-                            "Room is unavailable / streamer is not live (error {}): {}",
+                        // Codes -3/-4/-5 mean the room is unavailable / streamer is offline;
+                        // `parse_web_response` matches on `NoStreamsFound` to recover the
+                        // went-offline race without inspecting message text.
+                        debug!(
+                            "getH5PlayV1 reports room unavailable (error {}): {}",
                             resp.error, resp.msg
-                        )));
+                        );
+                        return Err(ExtractorError::NoStreamsFound);
                     }
                     -9 => {
                         // Timestamp mismatch — retryable since each attempt generates a fresh timestamp
@@ -918,11 +921,9 @@ impl Douyu {
         // streamer is live
         let streams = match self.get_streams_with_stable_auth(rid, is_vip).await {
             Ok(streams) => streams,
-            Err(ExtractorError::ValidationError(msg))
-                if is_douyu_room_unavailable_message(&msg) =>
-            {
+            Err(ExtractorError::NoStreamsFound) => {
                 // Room went offline between status check and stream fetch
-                debug!("Room went offline during stream fetch: {}", msg);
+                debug!("Room went offline during stream fetch (rid {})", rid);
                 return Ok(self.create_media_info(
                     &title,
                     &artist,
@@ -1223,11 +1224,17 @@ mod tests {
     }
 
     #[test]
-    fn test_h5play_unavailable_error_message_matches_all_offline_codes() {
-        for code in -5..=-3 {
-            let message = format!("Room is unavailable / streamer is not live (error {code}): msg");
-            assert!(super::is_douyu_room_unavailable_message(&message));
-        }
+    fn test_request_retries_extras_zero_clamped_to_one() {
+        let extractor = Douyu::new(
+            "https://www.douyu.com/309763".to_string(),
+            default_client(),
+            None,
+            Some(json!({
+                "request_retries": 0
+            })),
+        );
+
+        assert_eq!(extractor.request_retries, 1);
     }
 
     #[test]

--- a/crates/platforms/src/extractor/platforms/huya/builder.rs
+++ b/crates/platforms/src/extractor/platforms/huya/builder.rs
@@ -254,10 +254,12 @@ impl PlatformExtractor for Huya {
     }
 
     async fn get_url(&self, stream_info: &mut StreamInfo) -> Result<(), ExtractorError> {
-        // `get_anticode_url` re-signs via getCdnTokenInfo using the `flv_url`/`ua` extras that only
-        // `parse_living_info_streams` (WUP mode) emits. `parse_streams` for Web/MP already produce a
-        // fully signed `stream_info.url`, so when the `flv_url` extra is absent leave that URL as-is
-        // rather than calling getCdnTokenInfoEx with an empty `flv_url` and failing on the token.
+        // `get_anticode_url` re-signs via getCdnTokenInfo using the `flv_url`/`ua` extras that
+        // only `parse_living_info_streams` (WUP mode) emits; without them there is nothing to
+        // feed the token call, so the URL from `parse_streams` is used as-is. Known limitation:
+        // when `force_origin_quality` strips `-imgplus` from the stream name, that URL's
+        // anti-code still signs the original name; covering that path needs a local re-sign
+        // via `build_stream_query`.
         let Some(extras) = stream_info.extras.as_ref() else {
             return Ok(());
         };

--- a/crates/platforms/src/extractor/platforms/huya/builder.rs
+++ b/crates/platforms/src/extractor/platforms/huya/builder.rs
@@ -254,20 +254,22 @@ impl PlatformExtractor for Huya {
     }
 
     async fn get_url(&self, stream_info: &mut StreamInfo) -> Result<(), ExtractorError> {
-        // MP based api requires no extra anticode computation
-        if self.api_mode == HuyaApiMode::Mp && !self.force_origin_quality {
+        // `get_anticode_url` re-signs via getCdnTokenInfo using the `flv_url`/`ua` extras that only
+        // `parse_living_info_streams` (WUP mode) emits. `parse_streams` for Web/MP already produce a
+        // fully signed `stream_info.url`, so when the `flv_url` extra is absent leave that URL as-is
+        // rather than calling getCdnTokenInfoEx with an empty `flv_url` and failing on the token.
+        let Some(extras) = stream_info.extras.as_ref() else {
+            return Ok(());
+        };
+
+        let flv_url = Self::extract_flv_url_from_extras(extras);
+        if flv_url.is_empty() {
             return Ok(());
         }
 
         debug!("Getting WUP URL for stream: {}", stream_info.url);
 
-        // Extract WUP request parameters from stream extras
-        let extras = stream_info.extras.as_ref().ok_or_else(|| {
-            ExtractorError::ValidationError("Stream extras not found for WUP request".to_string())
-        })?;
-
         // Compute anticode
-        let flv_url = Self::extract_flv_url_from_extras(extras);
         let stream_name = Self::extract_stream_name_from_extras(extras)?;
         let presenter_uid = Self::extract_presenter_uid_from_extras(extras);
         let ua = crate::extractor::utils::extras_get_str(Some(extras), "ua")
@@ -292,6 +294,43 @@ mod tests {
         d.push("src/extractor/tests/test_data/huya/");
         d.push(file_name);
         std::fs::read_to_string(d).unwrap()
+    }
+
+    #[tokio::test]
+    async fn test_get_url_keeps_signed_url_when_extras_absent() {
+        let extractor = Huya::new(
+            "https://www.huya.com/660000".to_string(),
+            default_client(),
+            None,
+            None,
+        );
+        let signed_url = "https://al.flv.huya.com/src/stream.flv?wsSecret=abc&wsTime=123";
+        let mut stream_info =
+            StreamInfo::builder(signed_url.to_string(), StreamFormat::Flv, MediaFormat::Flv)
+                .build();
+
+        extractor.get_url(&mut stream_info).await.unwrap();
+
+        assert_eq!(stream_info.url, signed_url);
+    }
+
+    #[tokio::test]
+    async fn test_get_url_keeps_signed_url_when_flv_url_extra_missing() {
+        let extractor = Huya::new(
+            "https://www.huya.com/660000".to_string(),
+            default_client(),
+            None,
+            None,
+        );
+        let signed_url = "https://al.flv.huya.com/src/stream.flv?wsSecret=abc&wsTime=123";
+        let mut stream_info =
+            StreamInfo::builder(signed_url.to_string(), StreamFormat::Flv, MediaFormat::Flv)
+                .extras(serde_json::json!({ "stream_name": "some-stream" }))
+                .build();
+
+        extractor.get_url(&mut stream_info).await.unwrap();
+
+        assert_eq!(stream_info.url, signed_url);
     }
 
     #[test]

--- a/crates/platforms/src/extractor/platforms/huya/builder.rs
+++ b/crates/platforms/src/extractor/platforms/huya/builder.rs
@@ -254,20 +254,22 @@ impl PlatformExtractor for Huya {
     }
 
     async fn get_url(&self, stream_info: &mut StreamInfo) -> Result<(), ExtractorError> {
-        // `get_anticode_url` re-signs via getCdnTokenInfo using the `flv_url`/`ua` extras that
-        // only `parse_living_info_streams` (WUP mode) emits; without them there is nothing to
-        // feed the token call, so the URL from `parse_streams` is used as-is. Known limitation:
-        // when `force_origin_quality` strips `-imgplus` from the stream name, that URL's
-        // anti-code still signs the original name; covering that path needs a local re-sign
-        // via `build_stream_query`.
+        // MP api-mode URLs are CDN-usable as parsed. Every other path — WUP, Web,
+        // and MP with force_origin_quality — must re-sign through
+        // `get_anticode_url`/getCdnTokenInfo (the `flv_url`/`ua` extras it reads
+        // are empty outside WUP mode, which the token call accepts): the web
+        // page's anti-code is rejected by Huya's CDN as-is.
+        if self.api_mode == HuyaApiMode::Mp && !self.force_origin_quality {
+            return Ok(());
+        }
+
+        // Without extras there is nothing to feed getCdnTokenInfo; keep the
+        // parsed URL instead of failing the candidate.
         let Some(extras) = stream_info.extras.as_ref() else {
             return Ok(());
         };
 
         let flv_url = Self::extract_flv_url_from_extras(extras);
-        if flv_url.is_empty() {
-            return Ok(());
-        }
 
         debug!("Getting WUP URL for stream: {}", stream_info.url);
 
@@ -317,12 +319,12 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_get_url_keeps_signed_url_when_flv_url_extra_missing() {
+    async fn test_get_url_keeps_mp_url_without_force_origin() {
         let extractor = Huya::new(
             "https://www.huya.com/660000".to_string(),
             default_client(),
             None,
-            None,
+            Some(serde_json::json!({ "api_mode": "MP" })),
         );
         let signed_url = "https://al.flv.huya.com/src/stream.flv?wsSecret=abc&wsTime=123";
         let mut stream_info =

--- a/crates/platforms/src/extractor/platforms/pandatv/builder.rs
+++ b/crates/platforms/src/extractor/platforms/pandatv/builder.rs
@@ -127,14 +127,27 @@ impl PandaTV {
 
         let live_info = self.get_live_info(&media.user_id, pwd).await?;
 
-        let category =
-            (!live_info.media.category.is_empty()).then(|| vec![live_info.media.category.clone()]);
-        let live_start_time = live_info.media.start_time.parse::<i64>().ok();
+        // get_live_info only returns Ok when result == true, so the success
+        // payload (media/PlayList/chat_server) is present; surface a clear
+        // ValidationError if the API ever diverges from that contract.
+        let live_media = live_info.media.ok_or(ExtractorError::ValidationError(
+            "Live media field is missing".to_string(),
+        ))?;
+        let play_list = live_info.play_list.ok_or(ExtractorError::ValidationError(
+            "PlayList field is missing".to_string(),
+        ))?;
+        let chat_server = live_info
+            .chat_server
+            .ok_or(ExtractorError::ValidationError(
+                "Chat server field is missing".to_string(),
+            ))?;
+
+        let category = (!live_media.category.is_empty()).then(|| vec![live_media.category.clone()]);
+        let live_start_time = live_media.start_time.parse::<i64>().ok();
 
         // debug!("Live info: {:?}", live_info);
 
-        let hls_url = live_info
-            .play_list
+        let hls_url = play_list
             .hls
             .first()
             .ok_or(ExtractorError::ValidationError(
@@ -147,8 +160,8 @@ impl PandaTV {
         // Keep the historical meaning of "token" (chat server token). The live token is still
         // available in the response model if needed.
         // extras.insert("chat_server".to_string(), live_info.chat_server.url);
-        extras.insert("t".to_string(), live_info.chat_server.t.to_string());
-        extras.insert("token".to_string(), live_info.chat_server.token);
+        extras.insert("t".to_string(), chat_server.t.to_string());
+        extras.insert("token".to_string(), chat_server.token);
         extras.insert("rid".to_string(), bj_info.id.to_string());
         // extras.extend(self.extractor.get_platform_headers_map());
 
@@ -196,7 +209,10 @@ impl PandaTV {
             .await?;
 
         if !response.result {
-            return Err(ExtractorError::ValidationError(response.message));
+            let msg = response
+                .message
+                .unwrap_or_else(|| "Unknown error".to_string());
+            return Err(ExtractorError::ValidationError(msg));
         }
 
         Ok(response)
@@ -229,11 +245,31 @@ mod tests {
     use tracing::{Level, debug};
 
     use crate::extractor::{
-        default::default_client, platform_extractor::PlatformExtractor,
-        platforms::pandatv::builder::PandaTV,
+        default::default_client,
+        platform_extractor::PlatformExtractor,
+        platforms::pandatv::{builder::PandaTV, models::PandaTvLiveResponse},
     };
 
     const TEST_URL: &str = "https://www.pandalive.co.kr/play/codud23";
+
+    #[test]
+    fn test_live_response_error_payload_parses_without_success_fields() {
+        let json = r#"{"result": false, "message": "castEnd"}"#;
+        let response: PandaTvLiveResponse = serde_json::from_str(json).unwrap();
+        assert!(!response.result);
+        assert_eq!(response.message.as_deref(), Some("castEnd"));
+        assert!(response.media.is_none());
+        assert!(response.play_list.is_none());
+        assert!(response.chat_server.is_none());
+    }
+
+    #[test]
+    fn test_live_response_error_payload_parses_without_message() {
+        let json = r#"{"result": false}"#;
+        let response: PandaTvLiveResponse = serde_json::from_str(json).unwrap();
+        assert!(!response.result);
+        assert!(response.message.is_none());
+    }
 
     #[tokio::test]
     #[ignore]

--- a/crates/platforms/src/extractor/platforms/pandatv/models.rs
+++ b/crates/platforms/src/extractor/platforms/pandatv/models.rs
@@ -61,32 +61,36 @@ pub struct PandaTvPlayTime {
     pub total: String,
 }
 
+/// Only `result` is guaranteed on every `/v1/live/play` reply. Error responses
+/// (e.g. `castEnd`, region blocks, wrong password) carry `result == false` and
+/// `message` but omit the success payload, so every other field is `Option` to
+/// keep the `result`/`message` check in `PandaTV::get_live_info` reachable.
 #[derive(Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct PandaTvLiveResponse {
     // pub room_blind_info: PandaTvLiveRoomBlindInfo,
     // pub room_freeze_info: PandaTvLiveRoomFreezeInfo,
-    pub token: String,
-    pub enter_chat: Vec<serde_json::Value>,
-    pub html5: bool,
-    pub channel: String,
-    pub media: PandaTvLiveMedia,
-    pub mode: String,
-    pub chat_mode: String,
-    pub play_mode: String,
+    pub token: Option<String>,
+    pub enter_chat: Option<Vec<serde_json::Value>>,
+    pub html5: Option<bool>,
+    pub channel: Option<String>,
+    pub media: Option<PandaTvLiveMedia>,
+    pub mode: Option<String>,
+    pub chat_mode: Option<String>,
+    pub play_mode: Option<String>,
     #[serde(rename = "PlayList")]
-    pub play_list: PandaTvLivePlayList,
-    pub ie_play_mode: String,
-    pub is_bookmark: bool,
-    pub adult_out: bool,
-    pub chat_server: PandaTvLiveChatServer,
-    pub room_info: String,
-    pub ranking: i32,
-    pub chat_message: PandaTvLiveChatMessage,
-    pub vip_deco: i32,
+    pub play_list: Option<PandaTvLivePlayList>,
+    pub ie_play_mode: Option<String>,
+    pub is_bookmark: Option<bool>,
+    pub adult_out: Option<bool>,
+    pub chat_server: Option<PandaTvLiveChatServer>,
+    pub room_info: Option<String>,
+    pub ranking: Option<i32>,
+    pub chat_message: Option<PandaTvLiveChatMessage>,
+    pub vip_deco: Option<i32>,
     pub result: bool,
-    pub message: String,
-    pub login_info: PandaTvLiveLoginInfo,
+    pub message: Option<String>,
+    pub login_info: Option<PandaTvLiveLoginInfo>,
     // pub user_ip: String,
 }
 

--- a/crates/platforms/src/extractor/platforms/picarto/builder.rs
+++ b/crates/platforms/src/extractor/platforms/picarto/builder.rs
@@ -12,6 +12,7 @@ use crate::{
         hls_extractor::HlsExtractor,
         platform_extractor::{Extractor, PlatformExtractor},
         platforms::picarto::models::PicartoResponse,
+        utils::capture_group_1_or_invalid_url,
     },
     media::{MediaFormat, MediaInfo, StreamFormat, StreamInfo},
 };
@@ -43,15 +44,8 @@ impl Picarto {
         Self { extractor }
     }
 
-    pub fn extract_room_id(&self) -> Result<String, ExtractorError> {
-        // Extract the room ID from the URL
-        let url = self.extractor.url.clone();
-        let room_id = url
-            .split('/')
-            .next_back()
-            .ok_or_else(|| ExtractorError::ValidationError("Room ID not found in URL".to_string()))?
-            .to_string();
-        Ok(room_id)
+    pub fn extract_room_id(&self) -> Result<&str, ExtractorError> {
+        capture_group_1_or_invalid_url(&URL_REGEX, &self.extractor.url)
     }
 
     pub async fn get_live_info(&self, rid: &str) -> Result<MediaInfo, ExtractorError> {
@@ -142,7 +136,7 @@ impl PlatformExtractor for Picarto {
         let room_id = self.extract_room_id()?;
         debug!("Extracted room ID: {}", room_id);
 
-        let media_info = self.get_live_info(&room_id).await?;
+        let media_info = self.get_live_info(room_id).await?;
         Ok(media_info)
     }
 }
@@ -155,6 +149,23 @@ mod tests {
     use crate::extractor::{
         default::default_client, platform_extractor::PlatformExtractor, platforms::picarto::Picarto,
     };
+
+    #[test]
+    fn test_extract_room_id_ignores_trailing_slash_and_query() {
+        for url in [
+            "https://picarto.tv/RaptorARTStudios",
+            "https://picarto.tv/RaptorARTStudios/",
+            "https://picarto.tv/RaptorARTStudios?tab=about",
+            "https://www.picarto.tv/RaptorARTStudios/videos",
+        ] {
+            let picarto = Picarto::new(url.to_string(), default_client(), None, None);
+            assert_eq!(
+                picarto.extract_room_id().unwrap(),
+                "RaptorARTStudios",
+                "url: {url}"
+            );
+        }
+    }
 
     #[tokio::test]
     #[ignore]

--- a/crates/platforms/src/extractor/platforms/redbook/builder.rs
+++ b/crates/platforms/src/extractor/platforms/redbook/builder.rs
@@ -17,6 +17,12 @@ pub static URL_REGEX: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"^(?:https?://)?xhslink\.com/m/[a-zA-Z0-9_-]+").unwrap());
 static SCRIPT_DATA_REGEX: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"<script>window.__INITIAL_STATE__=(.*?)</script>").unwrap());
+/// Matches a bare JavaScript `undefined` value only where a JSON value can
+/// appear — immediately after `:`, `,` or `[`. Anchoring on the preceding
+/// delimiter leaves `undefined` substrings inside string values (nicknames,
+/// titles like "xundefinedy") untouched.
+static UNDEFINED_VALUE_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"([:,\[])undefined\b").unwrap());
 
 // Constants for common strings and values
 const DEFAULT_QUALITY: &str = "原画";
@@ -145,13 +151,27 @@ impl RedBook {
         SCRIPT_DATA_REGEX
             .captures(body)
             .and_then(|captures| captures.get(1))
-            .map(|m| m.as_str().replace("undefined", "null"))
+            .map(|m| {
+                UNDEFINED_VALUE_REGEX
+                    .replace_all(m.as_str(), "${1}null")
+                    .into_owned()
+            })
             .filter(|data| !data.is_empty())
             .ok_or_else(|| {
                 ExtractorError::ValidationError(
                     "Failed to extract script_data from the body".into(),
                 )
             })
+    }
+
+    /// Prefer the server-provided `room_info.room_title`: the 回放 replay
+    /// marker only appears there, and the replay guard in `get_live_info`
+    /// must see it rather than the synthesized "{artist} 的直播" fallback.
+    fn resolve_title(room_title: Option<&str>, artist: &str) -> String {
+        room_title
+            .filter(|t| !t.is_empty())
+            .map(ToString::to_string)
+            .unwrap_or_else(|| format!("{artist} 的直播"))
     }
 
     fn deeplink_param(deeplink: &str, key: &str) -> Option<String> {
@@ -228,7 +248,7 @@ impl RedBook {
         let artist = &room_data.host_info.nick_name;
         let avatar_url = Some(room_data.host_info.avatar.to_string());
         let site_url = self.extractor.url.clone();
-        let title = format!("{artist} 的直播");
+        let title = Self::resolve_title(room_data.room_info.room_title.as_deref(), artist);
         let is_live = live_stream.live_status == SUCCESS_STATUS;
 
         // Validate live status
@@ -351,6 +371,34 @@ mod tests {
         assert!(super::URL_REGEX.is_match("https://xhslink.com/m/844vKmW30jz"));
 
         assert!(!super::URL_REGEX.as_str().contains("xiaohongshu"));
+    }
+
+    #[test]
+    fn test_extract_script_data_replaces_only_bare_undefined_values() {
+        let body = r#"<script>window.__INITIAL_STATE__={"a":undefined,"name":"xundefinedy","list":[undefined,1],"b":2}</script>"#;
+        let data = super::RedBook::extract_script_data(body).unwrap();
+        let value: serde_json::Value = serde_json::from_str(&data).unwrap();
+        assert!(value["a"].is_null());
+        assert_eq!(value["name"], "xundefinedy");
+        assert!(value["list"][0].is_null());
+        assert_eq!(value["list"][1], 1);
+        assert_eq!(value["b"], 2);
+    }
+
+    #[test]
+    fn test_resolve_title_prefers_room_title() {
+        assert_eq!(
+            super::RedBook::resolve_title(Some("小红书直播回放"), "artist"),
+            "小红书直播回放"
+        );
+        assert_eq!(
+            super::RedBook::resolve_title(Some(""), "artist"),
+            "artist 的直播"
+        );
+        assert_eq!(
+            super::RedBook::resolve_title(None, "artist"),
+            "artist 的直播"
+        );
     }
 
     #[test]

--- a/crates/platforms/src/extractor/platforms/redbook/builder.rs
+++ b/crates/platforms/src/extractor/platforms/redbook/builder.rs
@@ -19,8 +19,10 @@ static SCRIPT_DATA_REGEX: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"<script>window.__INITIAL_STATE__=(.*?)</script>").unwrap());
 /// Matches a bare JavaScript `undefined` value only where a JSON value can
 /// appear — immediately after `:`, `,` or `[`. Anchoring on the preceding
-/// delimiter leaves `undefined` substrings inside string values (nicknames,
-/// titles like "xundefinedy") untouched.
+/// delimiter leaves most `undefined` substrings inside string values
+/// (nicknames, titles like "xundefinedy") untouched; a quoted value that
+/// itself contains a delimiter directly before `undefined` (e.g. "a,undefined!")
+/// is still rewritten, since the regex cannot see string boundaries.
 static UNDEFINED_VALUE_REGEX: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"([:,\[])undefined\b").unwrap());
 

--- a/crates/platforms/src/extractor/platforms/twitcasting/builder.rs
+++ b/crates/platforms/src/extractor/platforms/twitcasting/builder.rs
@@ -14,6 +14,7 @@ use regex::Regex;
 use reqwest::Client;
 use rustc_hash::FxHashMap;
 use std::sync::LazyLock;
+use tracing::warn;
 use url::Url;
 
 // Constants
@@ -121,6 +122,7 @@ impl Twitcasting {
     ) -> Result<Vec<StreamInfo>, ExtractorError> {
         let streams = &stream_container.streams;
         let mut stream_info = Vec::new();
+        let mut last_error = None;
 
         // Define stream qualities and their corresponding URLs
         let stream_configs = [
@@ -131,7 +133,10 @@ impl Twitcasting {
 
         for (url, quality) in stream_configs {
             if let Some(stream_url) = url {
-                let info = self
+                // A single stale variant playlist (e.g. a 404 on `low`) must not
+                // discard the higher-quality variants already collected, so log
+                // and skip rather than propagating the per-variant error.
+                match self
                     .extract_hls_stream(
                         &self.extractor.client,
                         None,
@@ -139,9 +144,25 @@ impl Twitcasting {
                         Some(quality),
                         None,
                     )
-                    .await?;
-                stream_info.extend(info);
+                    .await
+                {
+                    Ok(info) => stream_info.extend(info),
+                    Err(e) => {
+                        warn!(quality, error = %e, "twitcasting variant playlist fetch failed; skipping");
+                        last_error = Some(e);
+                    }
+                }
             }
+        }
+
+        // `fetch_live_data` already reported `movie.live == true`, so ending up
+        // with no streams because every variant fetch failed is a transient
+        // fetch failure, not an offline stream; propagate it so `get_live_info`
+        // callers retry instead of receiving a live MediaInfo with no streams.
+        if stream_info.is_empty()
+            && let Some(e) = last_error
+        {
+            return Err(e);
         }
 
         Ok(stream_info)
@@ -190,9 +211,86 @@ mod tests {
     use tracing::Level;
 
     use crate::extractor::{
-        default::default_client, platform_extractor::PlatformExtractor,
-        platforms::twitcasting::Twitcasting,
+        default::default_client,
+        platform_extractor::PlatformExtractor,
+        platforms::twitcasting::{Twitcasting, models::StreamContainer},
     };
+
+    fn test_extractor() -> Twitcasting {
+        Twitcasting::new(
+            "https://twitcasting.tv/nodasori2525".to_string(),
+            default_client(),
+            None,
+            None,
+        )
+    }
+
+    fn container(high: Option<&str>, medium: Option<&str>, low: Option<&str>) -> StreamContainer {
+        serde_json::from_value(serde_json::json!({
+            "streams": {
+                "high": high,
+                "medium": medium,
+                "low": low,
+            }
+        }))
+        .unwrap()
+    }
+
+    /// Serves one HTTP request with a minimal HLS media playlist, returning the URL to fetch.
+    async fn serve_media_playlist_once() -> String {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            if let Ok((mut socket, _)) = listener.accept().await {
+                let mut buf = [0u8; 4096];
+                let _ = socket.read(&mut buf).await;
+                let body =
+                    "#EXTM3U\n#EXT-X-VERSION:3\n#EXT-X-TARGETDURATION:2\n#EXTINF:2.0,\nseg0.ts\n";
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\ncontent-type: application/vnd.apple.mpegurl\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",
+                    body.len(),
+                );
+                let _ = socket.write_all(response.as_bytes()).await;
+                let _ = socket.shutdown().await;
+            }
+        });
+        format!("http://{addr}/playlist.m3u8")
+    }
+
+    #[tokio::test]
+    async fn test_extract_all_hls_streams_errors_when_every_variant_fails() {
+        let extractor = test_extractor();
+        // Invalid URLs make `extract_hls_stream` fail at `Url::parse` without network access.
+        let container = container(Some("not a url"), Some("also not a url"), None);
+
+        let result = extractor.extract_all_hls_streams(&container).await;
+
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_extract_all_hls_streams_keeps_successful_variant_when_another_fails() {
+        let extractor = test_extractor();
+        let good_url = serve_media_playlist_once().await;
+        let container = container(Some("not a url"), Some(&good_url), None);
+
+        let streams = extractor.extract_all_hls_streams(&container).await.unwrap();
+
+        assert_eq!(streams.len(), 1);
+        assert_eq!(streams[0].url, good_url);
+    }
+
+    #[tokio::test]
+    async fn test_extract_all_hls_streams_empty_when_no_variants_present() {
+        let extractor = test_extractor();
+        let container = container(None, None, None);
+
+        let streams = extractor.extract_all_hls_streams(&container).await.unwrap();
+
+        assert!(streams.is_empty());
+    }
 
     #[tokio::test]
     #[ignore]


### PR DESCRIPTION
## Severity

P1-09

Part of the #713 split series: monitoring correctness — wrong live/offline classification across platform extractors.

## What changed

- **AcFun**: visitor-login error payloads omit `userId` / `acfun.api.visitor_st`; the model now makes them `Option` (plus `error_msg`) so deserialization reaches the `result` check and reports the platform's error message instead of failing with a decode error.
- **Bilibili**: `getRoomPlayInfo` returns `code == 0` with `data`/`playurl_info` null while a room is offline. `process_streams` now treats that as an empty stream list (went-offline race) and `get_url` maps it to `NoStreamsFound`, instead of both failing with a decode error. `get_url` also short-circuits on an already-populated URL before validating extras, so a ready stream with missing extras is not rejected.
- **Douyu**: `getH5PlayV1` codes -3/-4/-5 (room unavailable / streamer offline) now surface as typed `ExtractorError::NoStreamsFound`; `parse_web_response` matches on the variant to classify the went-offline race as offline, replacing fragile error-message-text sniffing. `request_retries` extras of 0 are clamped to 1 so betard room-info fetches (VIP detection) still run.
- **Huya**: `get_url` now leaves already-signed Web/MP stream URLs untouched when the `flv_url` extra is absent, instead of entering the WUP re-sign path with empty parameters and failing the check.
- **PandaTV**: `/v1/live/play` error replies (`castEnd`, region block, wrong password) carry only `result`/`message`; the success payload fields are now `Option` so the `result == false` branch is reachable and produces a clear `ValidationError` instead of a decode failure.
- **Picarto**: channel name is extracted via the URL regex capture group instead of the last path segment, which grabbed query strings, sub-pages, or empty trailing segments and misclassified the channel as not found.
- **RedBook**: bare JS `undefined` is replaced with `null` only in JSON value position, so titles/nicknames containing the substring no longer corrupt the payload; the title now uses the server-provided `room_info.room_title`, which is where the 回放 replay marker appears, so replays are correctly classified as not live.
- **Twitcasting** (deviates from #713 — see below): a failed variant playlist fetch is logged and skipped so it no longer discards the other variants; when **every** variant fetch fails, the extractor now returns the error.

### Deviation from #713

#713's Twitcasting patch swallowed per-variant errors unconditionally, so a check where every variant playlist fetch failed produced a silent empty-variants success. Per the split plan, this PR instead propagates the last error when all attempted variants fail, so the monitor treats it as a failed check (retry/backoff) rather than offline.

### Excluded from this PR (deferred as P3 / other chunks)

- `tiktok/builder.rs`: removal of the no-op `if !is_live { streams.clear(); }` (dead code, no behavior change).
- `redbook/builder.rs`: H265 stream priority offset fix (`streams.len()` instead of `h265.len()`) — stream-priority ordering, not live/offline classification.
- `bilibili/danmu.rs` and `bilibili/wbi.rs` hardening: already landed on main via #718 in equivalent or stronger form; nothing to port.
- No `Cargo.toml` / `lib.rs` changes (rquickjs disabling is a separate deferred cleanup).

## Why

Monitoring decisions key off extractor results: a decode error where the platform actually said "offline" turns a clean offline transition into a failed check, and an empty-success where the request actually failed turns a transient network error into a false offline. Both misdrive `monitor` retry/backoff and session state.

## Impact

- Offline transitions on Bilibili/Douyu (room goes offline between the status check and the stream fetch) resolve as clean offline instead of errors.
- AcFun/PandaTV API error replies produce actionable error messages instead of serde decode failures.
- Picarto URLs with query strings/sub-pages/trailing slashes are monitored correctly.
- RedBook replays are no longer recorded as live, and payloads containing the literal string "undefined" parse correctly.
- Twitcasting transient CDN failures no longer end sessions as offline; a single stale variant no longer aborts extraction.

## Validation

- `cargo test --locked -p platforms-parser --lib` — 227 passed, 0 failed (new tests: AcFun login payloads, Bilibili offline/error `RoomPlayInfo` payloads, Douyu retries clamp, Huya `get_url` pass-through, PandaTV error payloads, Picarto room-id extraction, RedBook `undefined` replacement + title resolution, Twitcasting all-variants-fail → error / partial failure → partial success / no variants → empty).
- `cargo clippy --locked -p platforms-parser --all-targets -- -D warnings` — clean.
- `git diff --check` — clean.


## Huya anti-code verification (live-tested)

The initial extraction skipped `get_anticode_url` whenever the `flv_url` extra was absent (all Web/MP streams). Live testing against `https://www.huya.com/660000` showed the web page's raw anti-code is rejected by Huya's CDN with HTTP 403, which would have broken the default `api_mode=WEB` entirely. The final version restores the original routing: only MP without `force_origin_quality` keeps its parsed URL; WUP, Web, and MP+force re-sign through `get_anticode_url`/getCdnTokenInfo (which accepts the empty `flv_url`/`ua` extras outside WUP mode).

Live results on the fixed code:
- Default WEB mode: re-signed URL sustained a 200-second FLV download (128.8 MB, no errors).
- WEB + `force_origin_quality`: resolved URL carries the `-imgplus`-stripped stream name with a token minted for that name; 45-second start check downloaded 59 MB with no 403.
- Raw (un-re-signed) page URL as a control: immediate HTTP 403, confirming the re-sign is load-bearing.
