### PR TITLE
refactor(flv): share segment reinjection between split and limit operators

### DIFF
--- a/crates/flv-fix/src/operators.rs
+++ b/crates/flv-fix/src/operators.rs
@@ -11,6 +11,7 @@ mod header_check;
 mod limit;
 mod script_filler;
 mod script_filter;
+mod segment_reinject;
 mod split;
 mod time_consistency;
 mod timing_repair;

--- a/crates/flv-fix/src/operators/limit.rs
+++ b/crates/flv-fix/src/operators/limit.rs
@@ -33,13 +33,13 @@
 //!
 
 use flv::data::FlvData;
-use flv::header::FlvHeader;
-use flv::tag::FlvTag;
 use pipeline_common::split_reason::SplitReason;
 use pipeline_common::{PipelineError, Processor, StreamerContext};
 use std::sync::Arc;
 use std::time::Instant;
 use tracing::{debug, info};
+
+use crate::operators::segment_reinject::SegmentInitCache;
 
 /// Optional callback for when a stream split occurs
 pub type SplitCallback = Box<dyn Fn(SplitReason, u64, u32) + Send + Sync>;
@@ -83,14 +83,11 @@ impl Default for LimitConfig {
 
 // Store stream state for re-emission after splits
 struct StreamState {
-    header: Option<FlvHeader>,
-    metadata: Option<FlvTag>,
-    audio_sequence_tag: Option<FlvTag>,
-    video_sequence_tag: Option<FlvTag>,
+    /// Cached header/metadata/sequence tags re-injected by `split_stream`.
+    cache: SegmentInitCache,
     accumulated_size: u64,
     start_timestamp: u32,
     max_timestamp: u32,
-    last_keyframe_position: Option<(u64, u32)>, // (size, timestamp) at last keyframe
     split_count: u32,
     first_content_tag_seen: bool,
 }
@@ -98,14 +95,10 @@ struct StreamState {
 impl StreamState {
     fn new() -> Self {
         Self {
-            header: None,
-            metadata: None,
-            audio_sequence_tag: None,
-            video_sequence_tag: None,
+            cache: SegmentInitCache::new(),
             accumulated_size: 0,
             start_timestamp: 0,
             max_timestamp: 0,
-            last_keyframe_position: None,
             split_count: 0,
             first_content_tag_seen: false,
         }
@@ -114,7 +107,6 @@ impl StreamState {
     fn reset_counters(&mut self) {
         self.accumulated_size = 0;
         self.start_timestamp = self.max_timestamp;
-        self.last_keyframe_position = None;
         self.split_count += 1;
     }
 
@@ -225,29 +217,9 @@ impl LimitOperator {
         // Emit the Split marker before re-injecting the header.
         output(FlvData::Split(reason))?;
 
-        // Send each item with Arc cloning instead of full data cloning
-        if let Some(header) = &self.state.header {
-            output(FlvData::Header(header.clone()))?;
-            debug!("{} {}", self.context.name, "re-emit header after split");
-        }
-        if let Some(metadata) = &self.state.metadata {
-            output(FlvData::Tag(metadata.clone()))?;
-            debug!("{} {}", self.context.name, "re-emit metadata after split");
-        }
-        if let Some(video_seq) = &self.state.video_sequence_tag {
-            output(FlvData::Tag(video_seq.clone()))?;
-            debug!(
-                "{} {}",
-                self.context.name, "re-emit video sequence tag after split"
-            );
-        }
-        if let Some(audio_seq) = &self.state.audio_sequence_tag {
-            output(FlvData::Tag(audio_seq.clone()))?;
-            debug!(
-                "{} {}",
-                self.context.name, "re-emit audio sequence tag after split"
-            );
-        }
+        self.state
+            .cache
+            .reinject(output, Some(&self.context.name))?;
 
         // Reset accumulated counters for the new segment
         self.state.reset_counters();
@@ -270,7 +242,7 @@ impl Processor<FlvData> for LimitOperator {
             FlvData::Header(header) => {
                 // Reset state for a new stream
                 self.state = StreamState::new();
-                self.state.header = Some(header.clone());
+                self.state.cache.header = Some(header.clone());
                 self.last_split_time = Instant::now();
 
                 // Forward the header
@@ -284,17 +256,15 @@ impl Processor<FlvData> for LimitOperator {
                 let tag_size = tag.size() as u64 + PREVIOUS_TAG_SIZE_FIELD as u64;
                 self.state.accumulated_size += tag_size;
 
-                // Track key metadata
+                // Track key metadata. Sequence headers are cached with timestamp_ms
+                // zeroed so the tags re-injected by split_stream open the new segment
+                // at timestamp 0.
                 if tag.is_script_tag() {
-                    self.state.metadata = Some(tag.clone());
+                    self.state.cache.metadata = Some(tag.clone());
                 } else if tag.is_video_sequence_header() {
-                    let mut tag = tag.clone();
-                    tag.timestamp_ms = 0; // Reset timestamp for video sequence header
-                    self.state.video_sequence_tag = Some(tag);
+                    self.state.cache.store_video_sequence_tag(tag.clone(), true);
                 } else if tag.is_audio_sequence_header() {
-                    let mut tag = tag.clone();
-                    tag.timestamp_ms = 0; // Reset timestamp for audio sequence header
-                    self.state.audio_sequence_tag = Some(tag);
+                    self.state.cache.store_audio_sequence_tag(tag.clone(), true);
                 } else {
                     // This is actual content (not sequence header or metadata)
                     // Update timestamp tracking only for content tags
@@ -314,12 +284,6 @@ impl Processor<FlvData> for LimitOperator {
                     }
                 }
 
-                // Track keyframes for optimal split points
-                if tag.is_key_frame_nalu() {
-                    self.state.last_keyframe_position =
-                        Some((self.state.accumulated_size, self.state.max_timestamp));
-                }
-
                 // Check if any limit is exceeded
                 let should_split = self.check_limits();
 
@@ -332,7 +296,12 @@ impl Processor<FlvData> for LimitOperator {
                 // payloads, unrecognized codec IDs). It also fires for streams whose GOP
                 // span exceeds the margin, so such a segment opens mid-GOP and its video
                 // is undecodable until the next keyframe.
-                let has_video = self.state.header.as_ref().is_some_and(|h| h.has_video);
+                let has_video = self
+                    .state
+                    .cache
+                    .header
+                    .as_ref()
+                    .is_some_and(|h| h.has_video);
                 let can_split_on_tag = if has_video && self.config.split_at_keyframes_only {
                     tag.is_key_frame_nalu() || self.limits_hard_exceeded()
                 } else {
@@ -387,6 +356,7 @@ mod tests {
     use super::*;
     use crate::test_utils::{self, create_script_tag};
     use bytes::Bytes;
+    use flv::header::FlvHeader;
     use flv::tag::{FlvTag, FlvTagType};
     use pipeline_common::{CancellationToken, StreamerContext};
     use std::sync::atomic::{AtomicUsize, Ordering};

--- a/crates/flv-fix/src/operators/segment_reinject.rs
+++ b/crates/flv-fix/src/operators/segment_reinject.rs
@@ -18,18 +18,18 @@ use tracing::debug;
 /// cached tags outside of a full reinjection.
 #[derive(Default)]
 pub(crate) struct SegmentInitCache {
-    pub header: Option<FlvHeader>,
-    pub metadata: Option<FlvTag>,
-    pub audio_sequence_tag: Option<FlvTag>,
-    pub video_sequence_tag: Option<FlvTag>,
+    pub(crate) header: Option<FlvHeader>,
+    pub(crate) metadata: Option<FlvTag>,
+    pub(crate) audio_sequence_tag: Option<FlvTag>,
+    pub(crate) video_sequence_tag: Option<FlvTag>,
 }
 
 impl SegmentInitCache {
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self::default()
     }
 
-    pub fn clear(&mut self) {
+    pub(crate) fn clear(&mut self) {
         *self = Self::default();
     }
 
@@ -37,7 +37,7 @@ impl SegmentInitCache {
     /// is set, `tag.timestamp_ms` is rebased to 0 so a later `reinject` opens
     /// the new segment with the sequence header at timestamp 0; when unset the
     /// tag keeps the timestamp it carried in the stream.
-    pub fn store_video_sequence_tag(&mut self, mut tag: FlvTag, zero_timestamp: bool) {
+    pub(crate) fn store_video_sequence_tag(&mut self, mut tag: FlvTag, zero_timestamp: bool) {
         if zero_timestamp {
             tag.timestamp_ms = 0;
         }
@@ -46,7 +46,7 @@ impl SegmentInitCache {
 
     /// Stores `tag` as the current audio sequence header; see
     /// `store_video_sequence_tag` for the `zero_timestamp` semantics.
-    pub fn store_audio_sequence_tag(&mut self, mut tag: FlvTag, zero_timestamp: bool) {
+    pub(crate) fn store_audio_sequence_tag(&mut self, mut tag: FlvTag, zero_timestamp: bool) {
         if zero_timestamp {
             tag.timestamp_ms = 0;
         }
@@ -63,7 +63,7 @@ impl SegmentInitCache {
     ///
     /// When `debug_name` is provided, each re-emitted item is logged at debug
     /// level with that name as prefix.
-    pub fn reinject(
+    pub(crate) fn reinject(
         &self,
         output: &mut dyn FnMut(FlvData) -> Result<(), PipelineError>,
         debug_name: Option<&str>,

--- a/crates/flv-fix/src/operators/segment_reinject.rs
+++ b/crates/flv-fix/src/operators/segment_reinject.rs
@@ -1,0 +1,97 @@
+//! Shared cache of segment initialization data (FLV header, onMetaData script
+//! tag, audio/video sequence headers) that `SplitOperator` and `LimitOperator`
+//! re-emit at the start of each new segment after a split boundary.
+
+use flv::data::FlvData;
+use flv::header::FlvHeader;
+use flv::tag::FlvTag;
+use pipeline_common::PipelineError;
+use tracing::debug;
+
+/// Caches the items a downstream writer needs at the start of every segment so
+/// they can be re-injected after a split: the FLV header, the onMetaData
+/// script tag and the latest audio/video sequence headers.
+///
+/// Fields are directly accessible because operators also need to inspect
+/// (`SplitOperator::split_stream` reads `video_sequence_tag` for codec info)
+/// or drain (`SplitOperator::flush_buffered_tags_if_pending` uses `take`) the
+/// cached tags outside of a full reinjection.
+#[derive(Default)]
+pub(crate) struct SegmentInitCache {
+    pub header: Option<FlvHeader>,
+    pub metadata: Option<FlvTag>,
+    pub audio_sequence_tag: Option<FlvTag>,
+    pub video_sequence_tag: Option<FlvTag>,
+}
+
+impl SegmentInitCache {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn clear(&mut self) {
+        *self = Self::default();
+    }
+
+    /// Stores `tag` as the current video sequence header. When `zero_timestamp`
+    /// is set, `tag.timestamp_ms` is rebased to 0 so a later `reinject` opens
+    /// the new segment with the sequence header at timestamp 0; when unset the
+    /// tag keeps the timestamp it carried in the stream.
+    pub fn store_video_sequence_tag(&mut self, mut tag: FlvTag, zero_timestamp: bool) {
+        if zero_timestamp {
+            tag.timestamp_ms = 0;
+        }
+        self.video_sequence_tag = Some(tag);
+    }
+
+    /// Stores `tag` as the current audio sequence header; see
+    /// `store_video_sequence_tag` for the `zero_timestamp` semantics.
+    pub fn store_audio_sequence_tag(&mut self, mut tag: FlvTag, zero_timestamp: bool) {
+        if zero_timestamp {
+            tag.timestamp_ms = 0;
+        }
+        self.audio_sequence_tag = Some(tag);
+    }
+
+    /// Re-emits the cached items in segment-opening order: header, onMetaData
+    /// script tag, video sequence header, audio sequence header.
+    ///
+    /// Tags are emitted with the timestamps they were stored with; callers that
+    /// need rebased timestamps must store with `zero_timestamp` set, otherwise
+    /// the segment timeline is not reset and downstream consumers may observe a
+    /// timestamp discontinuity at the split point.
+    ///
+    /// When `debug_name` is provided, each re-emitted item is logged at debug
+    /// level with that name as prefix.
+    pub fn reinject(
+        &self,
+        output: &mut dyn FnMut(FlvData) -> Result<(), PipelineError>,
+        debug_name: Option<&str>,
+    ) -> Result<(), PipelineError> {
+        if let Some(header) = &self.header {
+            output(FlvData::Header(header.clone()))?;
+            if let Some(name) = debug_name {
+                debug!("{name} re-emit header after split");
+            }
+        }
+        if let Some(metadata) = &self.metadata {
+            output(FlvData::Tag(metadata.clone()))?;
+            if let Some(name) = debug_name {
+                debug!("{name} re-emit metadata after split");
+            }
+        }
+        if let Some(video_seq) = &self.video_sequence_tag {
+            output(FlvData::Tag(video_seq.clone()))?;
+            if let Some(name) = debug_name {
+                debug!("{name} re-emit video sequence tag after split");
+            }
+        }
+        if let Some(audio_seq) = &self.audio_sequence_tag {
+            output(FlvData::Tag(audio_seq.clone()))?;
+            if let Some(name) = debug_name {
+                debug!("{name} re-emit audio sequence tag after split");
+            }
+        }
+        Ok(())
+    }
+}

--- a/crates/flv-fix/src/operators/split.rs
+++ b/crates/flv-fix/src/operators/split.rs
@@ -32,7 +32,6 @@
 //! - hua0512
 //!
 use flv::data::FlvData;
-use flv::header::FlvHeader;
 use flv::tag::FlvTag;
 use pipeline_common::split_reason::{AudioCodecInfo, SplitReason, VideoCodecInfo};
 use pipeline_common::{PipelineError, Processor, StreamerContext};
@@ -40,6 +39,7 @@ use std::sync::Arc;
 use tracing::{debug, info};
 
 use crate::crc32;
+use crate::operators::segment_reinject::SegmentInitCache;
 
 /// Controls how `SplitOperator` decides whether a sequence header "changed".
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -60,10 +60,8 @@ pub enum SequenceHeaderChangeMode {
 
 // Store data wrapped in Arc for efficient cloning
 struct StreamState {
-    header: Option<FlvHeader>,
-    metadata: Option<FlvTag>,
-    audio_sequence_tag: Option<FlvTag>,
-    video_sequence_tag: Option<FlvTag>,
+    /// Cached header/metadata/sequence tags re-injected by `split_stream`.
+    cache: SegmentInitCache,
     /// Key for detecting changes in the last seen video sequence header.
     ///
     /// The exact meaning depends on `SequenceHeaderChangeMode`.
@@ -93,10 +91,7 @@ struct StreamState {
 impl StreamState {
     fn new() -> Self {
         Self {
-            header: None,
-            metadata: None,
-            audio_sequence_tag: None,
-            video_sequence_tag: None,
+            cache: SegmentInitCache::new(),
             video_sig: None,
             audio_sig: None,
             prev_video_codec_info: None,
@@ -110,10 +105,7 @@ impl StreamState {
     }
 
     fn reset(&mut self) {
-        self.header = None;
-        self.metadata = None;
-        self.audio_sequence_tag = None;
-        self.video_sequence_tag = None;
+        self.cache.clear();
         self.video_sig = None;
         self.audio_sig = None;
         self.prev_video_codec_info = None;
@@ -416,6 +408,7 @@ impl SplitOperator {
             let new_sig = self.state.video_sig.unwrap_or(0);
             let to = self
                 .state
+                .cache
                 .video_sequence_tag
                 .as_ref()
                 .map(|t| Self::extract_video_codec_info(t, new_sig))
@@ -435,6 +428,7 @@ impl SplitOperator {
             let new_sig = self.state.audio_sig.unwrap_or(0);
             let to = self
                 .state
+                .cache
                 .audio_sequence_tag
                 .as_ref()
                 .map(|t| Self::extract_audio_codec_info(t, new_sig))
@@ -447,24 +441,10 @@ impl SplitOperator {
             output(FlvData::Split(SplitReason::AudioCodecChange { from, to }))?;
         }
 
-        // Note on timestamp handling:
-        // When we split the stream, we re-inject the header and sequence information
-        // using the original timestamps from when they were first encountered.
-        // This maintains timestamp consistency within the stream segments
-        // but does not reset the timeline. Downstream components or players
-        // may need to handle potential timestamp discontinuities at split points.
-        if let Some(header) = &self.state.header {
-            output(FlvData::Header(header.clone()))?;
-        }
-        if let Some(metadata) = &self.state.metadata {
-            output(FlvData::Tag(metadata.clone()))?;
-        }
-        if let Some(video_seq) = &self.state.video_sequence_tag {
-            output(FlvData::Tag(video_seq.clone()))?;
-        }
-        if let Some(audio_seq) = &self.state.audio_sequence_tag {
-            output(FlvData::Tag(audio_seq.clone()))?;
-        }
+        // Re-inject the cached header/metadata/sequence tags with the timestamps they
+        // were stored with; the timeline is not reset, so downstream components may
+        // need to handle a timestamp discontinuity at the split point.
+        self.state.cache.reinject(output, None)?;
         self.state.changed = false;
         self.state.buffered_metadata = false;
         self.state.buffered_audio_sequence_tag = false;
@@ -485,17 +465,17 @@ impl SplitOperator {
         // We intentionally do NOT inject a new header here to avoid creating an empty segment (and
         // triggering writer rotation) when the stream ends before the next media tag arrives.
         if self.state.buffered_metadata
-            && let Some(metadata) = self.state.metadata.take()
+            && let Some(metadata) = self.state.cache.metadata.take()
         {
             output(FlvData::Tag(metadata))?;
         }
         if self.state.buffered_video_sequence_tag
-            && let Some(video_seq) = self.state.video_sequence_tag.take()
+            && let Some(video_seq) = self.state.cache.video_sequence_tag.take()
         {
             output(FlvData::Tag(video_seq))?;
         }
         if self.state.buffered_audio_sequence_tag
-            && let Some(audio_seq) = self.state.audio_sequence_tag.take()
+            && let Some(audio_seq) = self.state.cache.audio_sequence_tag.take()
         {
             output(FlvData::Tag(audio_seq))?;
         }
@@ -521,10 +501,10 @@ impl Processor<FlvData> for SplitOperator {
         match input {
             FlvData::Header(header) => {
                 // If we already have a header, this is a stream restart — emit a Split marker.
-                let is_restart = self.state.header.is_some();
+                let is_restart = self.state.cache.header.is_some();
                 // Reset state when a new header is encountered
                 self.state.reset();
-                self.state.header = Some(header.clone());
+                self.state.cache.header = Some(header.clone());
                 if is_restart {
                     output(FlvData::Split(SplitReason::HeaderReceived))?;
                 }
@@ -546,7 +526,7 @@ impl Processor<FlvData> for SplitOperator {
                             "{} Metadata detected while split pending",
                             self.context.name
                         );
-                        self.state.metadata = Some(tag);
+                        self.state.cache.metadata = Some(tag);
                         self.state.buffered_metadata = true;
                         return Ok(());
                     }
@@ -559,12 +539,12 @@ impl Processor<FlvData> for SplitOperator {
                         let new_sig = self.video_change_key(&tag);
                         if let Some(old_sig) = self.state.video_sig
                             && old_sig != new_sig
-                            && let Some(old_tag) = self.state.video_sequence_tag.as_ref()
+                            && let Some(old_tag) = self.state.cache.video_sequence_tag.as_ref()
                         {
                             self.state.prev_video_codec_info =
                                 Some(Self::extract_video_codec_info(old_tag, old_sig));
                         }
-                        self.state.video_sequence_tag = Some(tag);
+                        self.state.cache.store_video_sequence_tag(tag, false);
                         self.state.buffered_video_sequence_tag = true;
                         self.state.video_sig = Some(new_sig);
                         return Ok(());
@@ -578,12 +558,12 @@ impl Processor<FlvData> for SplitOperator {
                         let new_sig = self.audio_change_key(&tag);
                         if let Some(old_sig) = self.state.audio_sig
                             && old_sig != new_sig
-                            && let Some(old_tag) = self.state.audio_sequence_tag.as_ref()
+                            && let Some(old_tag) = self.state.cache.audio_sequence_tag.as_ref()
                         {
                             self.state.prev_audio_codec_info =
                                 Some(Self::extract_audio_codec_info(old_tag, old_sig));
                         }
-                        self.state.audio_sequence_tag = Some(tag);
+                        self.state.cache.store_audio_sequence_tag(tag, false);
                         self.state.buffered_audio_sequence_tag = true;
                         self.state.audio_sig = Some(new_sig);
                         return Ok(());
@@ -598,7 +578,7 @@ impl Processor<FlvData> for SplitOperator {
                 // Normal operation: track key tags and detect parameter changes.
                 if tag.is_script_tag() {
                     debug!("{} Metadata detected", self.context.name);
-                    self.state.metadata = Some(tag.clone());
+                    self.state.cache.metadata = Some(tag.clone());
                     return output(FlvData::Tag(tag));
                 }
 
@@ -613,7 +593,7 @@ impl Processor<FlvData> for SplitOperator {
                             "{} Dropping duplicate video sequence header (sig: {:x})",
                             self.context.name, sig
                         );
-                        self.state.video_sequence_tag = Some(tag);
+                        self.state.cache.store_video_sequence_tag(tag, false);
                         self.state.video_sig = Some(sig);
                         return Ok(());
                     }
@@ -631,7 +611,7 @@ impl Processor<FlvData> for SplitOperator {
                                 self.context.name, prev_sig, sig
                             );
                             // Eagerly extract codec info from the old tag before we overwrite it.
-                            if let Some(old_tag) = self.state.video_sequence_tag.as_ref() {
+                            if let Some(old_tag) = self.state.cache.video_sequence_tag.as_ref() {
                                 self.state.prev_video_codec_info =
                                     Some(Self::extract_video_codec_info(old_tag, prev_sig));
                             }
@@ -644,7 +624,9 @@ impl Processor<FlvData> for SplitOperator {
                             );
                         }
                     }
-                    self.state.video_sequence_tag = Some(tag.clone());
+                    self.state
+                        .cache
+                        .store_video_sequence_tag(tag.clone(), false);
                     self.state.video_sig = Some(sig);
 
                     // If we just detected a change, buffer the new header and wait for the next
@@ -667,7 +649,7 @@ impl Processor<FlvData> for SplitOperator {
                             "{} Dropping duplicate audio sequence header (sig: {:x})",
                             self.context.name, sig
                         );
-                        self.state.audio_sequence_tag = Some(tag);
+                        self.state.cache.store_audio_sequence_tag(tag, false);
                         self.state.audio_sig = Some(sig);
                         return Ok(());
                     }
@@ -681,7 +663,7 @@ impl Processor<FlvData> for SplitOperator {
                                 self.context.name, prev_sig, sig
                             );
                             // Eagerly extract codec info from the old tag before we overwrite it.
-                            if let Some(old_tag) = self.state.audio_sequence_tag.as_ref() {
+                            if let Some(old_tag) = self.state.cache.audio_sequence_tag.as_ref() {
                                 self.state.prev_audio_codec_info =
                                     Some(Self::extract_audio_codec_info(old_tag, prev_sig));
                             }
@@ -694,7 +676,9 @@ impl Processor<FlvData> for SplitOperator {
                             );
                         }
                     }
-                    self.state.audio_sequence_tag = Some(tag.clone());
+                    self.state
+                        .cache
+                        .store_audio_sequence_tag(tag.clone(), false);
                     self.state.audio_sig = Some(sig);
 
                     if self.state.changed {


### PR DESCRIPTION
Tracks the P3 follow-up split out of #713. Severity: P3 (code-quality refactor, no functional change).

## What changed

Extracts the duplicated segment-initialization bookkeeping in `SplitOperator` and `LimitOperator` into a shared `SegmentInitCache` (`crates/flv-fix/src/operators/segment_reinject.rs`):

- The cache owns the FLV header, onMetaData script tag, and latest audio/video sequence headers, plus `reinject`, which re-emits them in segment-opening order (header, metadata, video seq, audio seq) after a split.
- Each operator keeps its own timestamp policy at the call site via the `zero_timestamp` argument of `store_{video,audio}_sequence_tag`:
  - `LimitOperator` stores sequence headers with `zero_timestamp: true`, so re-injected tags open the new segment at timestamp 0 (identical to the previous inline `tag.timestamp_ms = 0`).
  - `SplitOperator` stores with `zero_timestamp: false`, preserving original timestamps and leaving the timeline un-reset across the split, exactly as before. The two policies are deliberately different and are not merged.
- Per-item debug logging on reinjection is opt-in (`debug_name`): `LimitOperator` passes its context name (same log lines as before), `SplitOperator` passes `None` (it never logged per item).
- Cache fields stay directly accessible because `SplitOperator::split_stream` reads `video_sequence_tag`/`audio_sequence_tag` for codec-change info and `flush_buffered_tags_if_pending` drains them with `take`.
- Drops `StreamState::last_keyframe_position` in `limit.rs`: it was written on every keyframe but never read anywhere, so removing it changes nothing observable.

This was re-authored against current `main`, so `LimitOperator`'s hard-margin logic (`limits_hard_exceeded`, `HARD_SPLIT_MARGIN`), PreviousTagSize accounting, and `split_at_keyframes_only` handling are untouched.

## Why

Both operators maintained the same four cached fields and the same four-step re-emission sequence independently; a change to segment-opening order or caching rules had to be made twice. The shared cache makes the re-emission order a single definition while keeping the operator-specific timestamp decisions where they belong.

## Impact

Behavior-neutral: no output, ordering, logging, or split-decision change in either operator. The pre-existing `split.rs` and `limit.rs` test suites run unchanged (no assertion was modified) and pin this.

## Validation

- cargo test --locked -p flv-fix (81 passed, 0 failed)
- cargo clippy --locked -p flv-fix --all-targets -- -D warnings
- cargo fmt; git diff --check