### PR TITLE
perf: reduce frontend hot paths and Windows tray polling

### DIFF
--- a/rust-srec/frontend/src/components/danmu/danmu-viewer.tsx
+++ b/rust-srec/frontend/src/components/danmu/danmu-viewer.tsx
@@ -77,13 +77,12 @@ export function DanmuViewer({ url, title }: DanmuViewerProps) {
   }, [url]);
 
   const filteredComments = useMemo(() => {
+    // Lowercase the query once; the per-comment filter reuses it for both
+    // the content and username matches.
+    const query = searchQuery.toLowerCase();
     return comments.filter((c) => {
-      const contentMatch = c.content
-        .toLowerCase()
-        .includes(searchQuery.toLowerCase());
-      const userMatch = c.username
-        ?.toLowerCase()
-        .includes(searchQuery.toLowerCase());
+      const contentMatch = c.content.toLowerCase().includes(query);
+      const userMatch = c.username?.toLowerCase().includes(query);
       const matchesSearch = contentMatch || userMatch;
       if (!matchesSearch) return false;
 

--- a/rust-srec/frontend/src/components/logging/log-file-browser.tsx
+++ b/rust-srec/frontend/src/components/logging/log-file-browser.tsx
@@ -85,9 +85,12 @@ export function LogFileBrowser() {
 
       // Stream to disk via a token-authenticated anchor navigation, matching
       // handleDownloadFile; the browser writes the zip response body directly
-      // instead of buffering the whole archive in the JS heap.
+      // instead of buffering the whole archive in the JS heap. The download
+      // attribute keeps an error response as a file download instead of
+      // navigating the app to the raw error body.
       const link = document.createElement('a');
       link.href = url.toString();
+      link.download = '';
       document.body.appendChild(link);
       link.click();
       document.body.removeChild(link);
@@ -122,6 +125,7 @@ export function LogFileBrowser() {
 
         const link = document.createElement('a');
         link.href = url.toString();
+        link.download = '';
         document.body.appendChild(link);
         link.click();
         document.body.removeChild(link);

--- a/rust-srec/frontend/src/components/logging/log-file-browser.tsx
+++ b/rust-srec/frontend/src/components/logging/log-file-browser.tsx
@@ -4,7 +4,7 @@
 import { useState, useCallback } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { format } from 'date-fns';
-import { motion, AnimatePresence } from 'motion/react';
+import { motion } from 'motion/react';
 import { msg } from '@lingui/core/macro';
 import { Trans } from '@lingui/react/macro';
 import { useLingui } from '@lingui/react';
@@ -27,7 +27,6 @@ import {
   PopoverTrigger,
 } from '@/components/ui/popover';
 import { Calendar } from '@/components/ui/calendar';
-import { Progress } from '@/components/ui/progress';
 import { toast } from 'sonner';
 import {
   FileText,
@@ -37,29 +36,16 @@ import {
   Archive,
   X,
   Loader2,
-  CheckCircle2,
-  AlertCircle,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { formatBytes } from '@/lib/format';
 import { BASE_URL } from '@/utils/env';
 
-interface DownloadState {
-  isDownloading: boolean;
-  progress: number;
-  filename?: string;
-  error?: string;
-  completed?: boolean;
-}
-
 export function LogFileBrowser() {
   const { i18n } = useLingui();
   const [dateRange, setDateRange] = useState<DateRange | undefined>(undefined);
   const [isCalendarOpen, setIsCalendarOpen] = useState(false);
-  const [downloadState, setDownloadState] = useState<DownloadState>({
-    isDownloading: false,
-    progress: 0,
-  });
+  const [isDownloadingArchive, setIsDownloadingArchive] = useState(false);
 
   // Format dates for API (YYYY-MM-DD)
   const fromDate = dateRange?.from
@@ -85,13 +71,7 @@ export function LogFileBrowser() {
 
   // Download all logs as an archive
   const handleDownloadArchive = useCallback(async () => {
-    setDownloadState({
-      isDownloading: true,
-      progress: 0,
-      filename: undefined,
-      error: undefined,
-      completed: false,
-    });
+    setIsDownloadingArchive(true);
 
     try {
       // Get download token
@@ -112,28 +92,18 @@ export function LogFileBrowser() {
       link.click();
       document.body.removeChild(link);
 
-      setDownloadState({
-        isDownloading: false,
-        progress: 100,
-        completed: true,
-      });
-
-      toast.success(i18n._(msg`Logs downloaded successfully`));
-
-      // Reset state after a delay
-      setTimeout(() => {
-        setDownloadState({ isDownloading: false, progress: 0 });
-      }, 3000);
+      // Anchor downloads do not expose response or completion status. The
+      // browser download UI owns progress after navigation is dispatched.
+      toast.info(i18n._(msg`Downloading...`));
     } catch (error: unknown) {
       console.error('Download failed:', error);
       const errorMessage =
-        error instanceof Error ? error.message : 'Download failed';
-      setDownloadState({
-        isDownloading: false,
-        progress: 0,
-        error: errorMessage,
-      });
-      toast.error(errorMessage || i18n._(msg`Failed to download logs`));
+        error instanceof Error
+          ? error.message
+          : i18n._(msg`Failed to download logs`);
+      toast.error(errorMessage);
+    } finally {
+      setIsDownloadingArchive(false);
     }
   }, [fromDate, toDate, i18n]);
 
@@ -251,10 +221,10 @@ export function LogFileBrowser() {
               {/* Download All Button */}
               <Button
                 onClick={handleDownloadArchive}
-                disabled={downloadState.isDownloading || !data?.items?.length}
+                disabled={isDownloadingArchive || !data?.items?.length}
                 className="gap-2"
               >
-                {downloadState.isDownloading ? (
+                {isDownloadingArchive ? (
                   <Loader2 className="h-4 w-4 animate-spin" />
                 ) : (
                   <Download className="h-4 w-4" />
@@ -263,50 +233,6 @@ export function LogFileBrowser() {
               </Button>
             </div>
           </div>
-
-          {/* Download Progress */}
-          <AnimatePresence>
-            {(downloadState.isDownloading || downloadState.completed) && (
-              <motion.div
-                initial={{ opacity: 0, height: 0 }}
-                animate={{ opacity: 1, height: 'auto' }}
-                exit={{ opacity: 0, height: 0 }}
-                className="overflow-hidden"
-              >
-                <div className="p-4 rounded-lg bg-muted/30 border border-border/40 space-y-2">
-                  <div className="flex items-center justify-between text-sm">
-                    <div className="flex items-center gap-2">
-                      {downloadState.completed ? (
-                        <CheckCircle2 className="h-4 w-4 text-emerald-500" />
-                      ) : downloadState.error ? (
-                        <AlertCircle className="h-4 w-4 text-destructive" />
-                      ) : (
-                        <Loader2 className="h-4 w-4 animate-spin text-primary" />
-                      )}
-                      <span className="font-medium">
-                        {downloadState.completed ? (
-                          <Trans>Download complete</Trans>
-                        ) : downloadState.error ? (
-                          downloadState.error
-                        ) : (
-                          <Trans>Downloading...</Trans>
-                        )}
-                      </span>
-                    </div>
-                    {downloadState.filename && (
-                      <span className="text-muted-foreground text-xs">
-                        {downloadState.filename}
-                      </span>
-                    )}
-                  </div>
-                  <Progress value={downloadState.progress} className="h-2" />
-                  <div className="text-xs text-muted-foreground text-right">
-                    {downloadState.progress}%
-                  </div>
-                </div>
-              </motion.div>
-            )}
-          </AnimatePresence>
         </div>
       </CardHeader>
 

--- a/rust-srec/frontend/src/components/logging/log-file-browser.tsx
+++ b/rust-srec/frontend/src/components/logging/log-file-browser.tsx
@@ -41,16 +41,8 @@ import {
   AlertCircle,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { formatBytes } from '@/lib/format';
 import { BASE_URL } from '@/utils/env';
-
-/** Format bytes to human readable string */
-function formatBytes(bytes: number): string {
-  if (bytes === 0) return '0 B';
-  const k = 1024;
-  const sizes = ['B', 'KB', 'MB', 'GB'];
-  const i = Math.floor(Math.log(bytes) / Math.log(k));
-  return `${parseFloat((bytes / Math.pow(k, i)).toFixed(1))} ${sizes[i]}`;
-}
 
 interface DownloadState {
   isDownloading: boolean;
@@ -91,7 +83,7 @@ export function LogFileBrowser() {
     setDateRange(undefined);
   }, []);
 
-  // Download all logs as archive with progress tracking
+  // Download all logs as an archive
   const handleDownloadArchive = useCallback(async () => {
     setDownloadState({
       isDownloading: true,
@@ -111,73 +103,18 @@ export function LogFileBrowser() {
       if (fromDate) url.searchParams.set('from', fromDate);
       if (toDate) url.searchParams.set('to', toDate);
 
-      // Fetch with progress tracking
-      const response = await fetch(url.toString());
-
-      if (!response.ok) {
-        throw new Error(`Download failed: ${response.statusText}`);
-      }
-
-      const contentLength = response.headers.get('content-length');
-      const total = contentLength ? parseInt(contentLength, 10) : 0;
-
-      // Get filename from Content-Disposition header
-      const disposition = response.headers.get('content-disposition');
-      let filename = 'rust-srec-logs.zip';
-      if (disposition) {
-        const match = disposition.match(/filename="?([^";\n]+)"?/);
-        if (match) filename = match[1];
-      }
-
-      setDownloadState((prev) => ({ ...prev, filename }));
-
-      // Read the response body with progress
-      const reader = response.body?.getReader();
-      if (!reader) {
-        throw new Error('Failed to read response body');
-      }
-
-      const chunks: Uint8Array[] = [];
-      let received = 0;
-
-      while (true) {
-        const { done, value } = await reader.read();
-        if (done) break;
-
-        chunks.push(value);
-        received += value.length;
-
-        if (total > 0) {
-          const progress = Math.round((received / total) * 100);
-          setDownloadState((prev) => ({ ...prev, progress }));
-        }
-      }
-
-      // Combine chunks into a single Uint8Array
-      const combined = new Uint8Array(received);
-      let offset = 0;
-      for (const chunk of chunks) {
-        combined.set(chunk, offset);
-        offset += chunk.length;
-      }
-
-      // Create blob from combined array
-      const blob = new Blob([combined], { type: 'application/zip' });
-      const downloadUrl = window.URL.createObjectURL(blob);
-
-      // Trigger download
+      // Stream to disk via a token-authenticated anchor navigation, matching
+      // handleDownloadFile; the browser writes the zip response body directly
+      // instead of buffering the whole archive in the JS heap.
       const link = document.createElement('a');
-      link.href = downloadUrl;
-      link.download = filename;
+      link.href = url.toString();
       document.body.appendChild(link);
       link.click();
       document.body.removeChild(link);
-      window.URL.revokeObjectURL(downloadUrl);
 
       setDownloadState({
         isDownloading: false,
         progress: 100,
-        filename,
         completed: true,
       });
 
@@ -461,7 +398,7 @@ export function LogFileBrowser() {
                   variant="ghost"
                   size="icon"
                   onClick={() => handleDownloadFile(file)}
-                  className="opacity-0 group-hover:opacity-100 transition-opacity h-9 w-9"
+                  className="opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 focus-visible:opacity-100 transition-opacity h-9 w-9"
                   title={i18n._(msg`Download ${file.filename}`)}
                 >
                   <Download className="h-4 w-4" />

--- a/rust-srec/frontend/src/components/sessions/jobs-tab.tsx
+++ b/rust-srec/frontend/src/components/sessions/jobs-tab.tsx
@@ -11,10 +11,11 @@ import {
   getStatusConfig,
   getStatusLabel,
 } from '@/components/pipeline/status-config';
+import type { DagSummary } from '@/api/schemas';
 
 interface JobsTabProps {
   isLoading: boolean;
-  dags: any[];
+  dags: DagSummary[];
 }
 
 export function JobsTab({ isLoading, dags }: JobsTabProps) {
@@ -48,7 +49,7 @@ export function JobsTab({ isLoading, dags }: JobsTabProps) {
           ) : (
             <div className="divide-y divide-border/40">
               <AnimatePresence mode="popLayout">
-                {dags.map((dag: any, index: number) => (
+                {dags.map((dag, index) => (
                   <motion.div
                     key={dag.id}
                     initial={{ opacity: 0, x: -10 }}

--- a/rust-srec/frontend/src/components/streamers/card/stream-actions-menu.tsx
+++ b/rust-srec/frontend/src/components/streamers/card/stream-actions-menu.tsx
@@ -32,7 +32,7 @@ export const StreamActionsMenu = ({
         <Button
           variant="ghost"
           size="icon"
-          className="h-7 w-7 opacity-100 md:opacity-0 md:group-hover:opacity-100 transition-opacity -mr-2 text-muted-foreground hover:text-foreground"
+          className="h-7 w-7 opacity-100 md:opacity-0 md:group-hover:opacity-100 md:focus-visible:opacity-100 md:group-focus-within:opacity-100 transition-opacity -mr-2 text-muted-foreground hover:text-foreground"
         >
           <MoreHorizontal className="h-4 w-4" />
         </Button>

--- a/rust-srec/frontend/src/routes/_authed/_dashboard/streamers/index.lazy.tsx
+++ b/rust-srec/frontend/src/routes/_authed/_dashboard/streamers/index.lazy.tsx
@@ -416,11 +416,33 @@ function StreamersPage() {
     [selectedIds, batchMutation],
   );
 
-  const handleDelete = (id: string) => {
-    if (confirm(i18n._(msg`Are you sure you want to delete this streamer?`))) {
-      deleteMutation.mutate(id);
-    }
-  };
+  // Depend on the stable `mutate` reference (React Query returns a fresh
+  // result object every render, so depending on the mutation object would
+  // recreate these callbacks each render and defeat StreamerCard's memo).
+  const deleteMutate = deleteMutation.mutate;
+  const toggleMutate = toggleMutation.mutate;
+  const checkMutate = checkMutation.mutate;
+
+  const handleDelete = useCallback(
+    (id: string) => {
+      if (
+        confirm(i18n._(msg`Are you sure you want to delete this streamer?`))
+      ) {
+        deleteMutate(id);
+      }
+    },
+    [deleteMutate, i18n],
+  );
+
+  const handleToggle = useCallback(
+    (id: string, enabled: boolean) => toggleMutate({ id, enabled }),
+    [toggleMutate],
+  );
+
+  const handleCheck = useCallback(
+    (id: string) => checkMutate(id),
+    [checkMutate],
+  );
 
   if (isError) {
     return (
@@ -791,10 +813,8 @@ function StreamersPage() {
                     isSelected={selectedIds.has(streamer.id)}
                     onSelectionChange={handleSelectionChange}
                     onDelete={handleDelete}
-                    onToggle={(id, enabled) =>
-                      toggleMutation.mutate({ id, enabled })
-                    }
-                    onCheck={(id) => checkMutation.mutate(id)}
+                    onToggle={handleToggle}
+                    onCheck={handleCheck}
                   />
                 </motion.div>
               ))}

--- a/rust-srec/src-tauri/src/lib.rs
+++ b/rust-srec/src-tauri/src/lib.rs
@@ -631,8 +631,16 @@ async fn run_desktop_backend_init(
         });
     }
 
-    // Hiding the window on minimize is handled event-driven in the app.run
-    // RunEvent::WindowEvent(Resized) branch, so no polling watcher is spawned.
+    // Tao exposes a reliable resize event for minimization on Windows. Other
+    // desktop targets retain the watcher until Tao exposes a minimize event.
+    #[cfg(all(desktop, not(target_os = "windows")))]
+    {
+        let app_handle = app_handle.clone();
+        let cancellation = container.cancellation_token();
+        tauri::async_runtime::spawn(async move {
+            run_minimize_to_tray_watcher(app_handle, cancellation).await;
+        });
+    }
 }
 
 /// Run the desktop notification listener loop.
@@ -680,6 +688,54 @@ async fn run_desktop_notification_listener(
                     }
                 }
             }
+        }
+    }
+}
+
+/// Watch for minimize events on desktop targets where Tao does not expose one.
+#[cfg(all(desktop, not(target_os = "windows")))]
+async fn run_minimize_to_tray_watcher(
+    app_handle: tauri::AppHandle,
+    cancellation: tokio_util::sync::CancellationToken,
+) {
+    let visible_poll = Duration::from_millis(80);
+    let hidden_poll = Duration::from_millis(5000);
+    let mut last_seen_minimized = false;
+
+    loop {
+        let sleep_for = match app_handle.get_webview_window("main") {
+            Some(window) => match window.is_visible() {
+                Ok(true) => visible_poll,
+                _ => hidden_poll,
+            },
+            None => hidden_poll,
+        };
+
+        tokio::select! {
+            _ = cancellation.cancelled() => {
+                log::debug!("Minimize-to-tray watcher shutting down");
+                break;
+            }
+            _ = tokio::time::sleep(sleep_for) => {}
+        }
+
+        let Some(window) = app_handle.get_webview_window("main") else {
+            continue;
+        };
+
+        if !window.is_visible().unwrap_or(false) {
+            last_seen_minimized = false;
+            continue;
+        }
+
+        let minimized = window.is_minimized().unwrap_or(false);
+        if minimized && !last_seen_minimized {
+            if let Err(error) = window.hide() {
+                log::warn!("Failed to hide minimized window: {}", error);
+            }
+            last_seen_minimized = true;
+        } else if !minimized {
+            last_seen_minimized = false;
         }
     }
 }
@@ -947,20 +1003,24 @@ pub fn run() {
             return;
         }
 
-        // Minimize button hides the main window to the tray. Resized fires when
-        // the window enters the minimized state; is_minimized() gates the hide
-        // so ordinary resize/maximize events pass through untouched.
-        if let tauri::RunEvent::WindowEvent {
-            label,
-            event: tauri::WindowEvent::Resized(_),
-            ..
-        } = &event
-            && label == "main"
-            && let Some(window) = app_handle.get_webview_window("main")
-            && window.is_minimized().unwrap_or(false)
+        #[cfg(target_os = "windows")]
         {
-            let _ = window.hide();
-            return;
+            // On Windows, WM_SIZE follows the minimize command after Tao has
+            // updated its minimized state, so this path can remain event-driven.
+            if let tauri::RunEvent::WindowEvent {
+                label,
+                event: tauri::WindowEvent::Resized(_),
+                ..
+            } = &event
+                && label == "main"
+                && let Some(window) = app_handle.get_webview_window("main")
+                && window.is_minimized().unwrap_or(false)
+            {
+                if let Err(error) = window.hide() {
+                    log::warn!("Failed to hide minimized window: {}", error);
+                }
+                return;
+            }
         }
 
         if let tauri::RunEvent::ExitRequested { api, .. } = event {

--- a/rust-srec/src-tauri/src/lib.rs
+++ b/rust-srec/src-tauri/src/lib.rs
@@ -631,15 +631,8 @@ async fn run_desktop_backend_init(
         });
     }
 
-    // Spawn minimize-to-tray watcher (hides window when user clicks minimize button).
-    #[cfg(desktop)]
-    {
-        let app_handle = app_handle.clone();
-        let cancellation = container.cancellation_token();
-        tauri::async_runtime::spawn(async move {
-            run_minimize_to_tray_watcher(app_handle, cancellation).await;
-        });
-    }
+    // Hiding the window on minimize is handled event-driven in the app.run
+    // RunEvent::WindowEvent(Resized) branch, so no polling watcher is spawned.
 }
 
 /// Run the desktop notification listener loop.
@@ -687,62 +680,6 @@ async fn run_desktop_notification_listener(
                     }
                 }
             }
-        }
-    }
-}
-
-/// Watch for minimize events and hide window to tray.
-/// Uses smart polling: fast when visible (80ms), slow backoff when hidden (5000ms).
-async fn run_minimize_to_tray_watcher(
-    app_handle: tauri::AppHandle,
-    cancellation: tokio_util::sync::CancellationToken,
-) {
-    let visible_poll = Duration::from_millis(80);
-    let hidden_poll = Duration::from_millis(5000);
-
-    // Edge-trigger so we don't spam hide() if minimized stays true.
-    let mut last_seen_minimized = false;
-
-    loop {
-        let sleep_for = {
-            match app_handle.get_webview_window("main") {
-                Some(window) => match window.is_visible() {
-                    Ok(true) => visible_poll,
-                    _ => hidden_poll,
-                },
-                None => hidden_poll,
-            }
-        };
-
-        tokio::select! {
-            _ = cancellation.cancelled() => {
-                log::debug!("Minimize-to-tray watcher shutting down");
-                break;
-            }
-            _ = tokio::time::sleep(sleep_for) => {}
-        }
-
-        let Some(window) = app_handle.get_webview_window("main") else {
-            continue;
-        };
-
-        let is_visible = window.is_visible().unwrap_or(false);
-        if !is_visible {
-            last_seen_minimized = false;
-            continue;
-        }
-
-        let minimized = window.is_minimized().unwrap_or(false);
-
-        // If it just became minimized, hide it to tray.
-        if minimized && !last_seen_minimized {
-            let _ = window.hide();
-            last_seen_minimized = true;
-            continue;
-        }
-
-        if !minimized {
-            last_seen_minimized = false;
         }
     }
 }
@@ -1007,6 +944,22 @@ pub fn run() {
         {
             api.prevent_close();
             hide_main_window(app_handle);
+            return;
+        }
+
+        // Minimize button hides the main window to the tray. Resized fires when
+        // the window enters the minimized state; is_minimized() gates the hide
+        // so ordinary resize/maximize events pass through untouched.
+        if let tauri::RunEvent::WindowEvent {
+            label,
+            event: tauri::WindowEvent::Resized(_),
+            ..
+        } = &event
+            && label == "main"
+            && let Some(window) = app_handle.get_webview_window("main")
+            && window.is_minimized().unwrap_or(false)
+        {
+            let _ = window.hide();
             return;
         }
 


### PR DESCRIPTION
## Severity

P3-01

## What changed

- `danmu-viewer.tsx`: lowercase the search query once per filter pass instead of twice per comment.
- `log-file-browser.tsx`: dispatch log archives through the token-authenticated browser download path so ZIP responses are not buffered in the JavaScript heap. The page no longer reports fake progress or completion after dispatch.
- `streamers/index.lazy.tsx`: stabilize delete, toggle, and check callbacks so `StreamerCard` memoization holds across parent renders.
- `jobs-tab.tsx`: replace `any[]` with `DagSummary[]`.
- `stream-actions-menu.tsx` and `log-file-browser.tsx`: keep hover-revealed actions visible for keyboard focus.
- Desktop tray handling: replace the 80 ms minimize watcher with `RunEvent::WindowEvent(Resized)` on Windows. macOS and Linux retain the watcher because Tao does not expose a portable minimize event on those platforms.

## Why

These paths incurred avoidable render, memory, or polling costs. The platform-specific tray split removes hot polling where the runtime exposes a reliable minimize transition without regressing minimize-to-tray behavior elsewhere.

## Impact

- Danmu filtering lowercases the query once per pass.
- Unchanged streamer cards can skip re-rendering.
- Log archives are streamed by the browser rather than accumulated in the page heap; browser UI owns download progress after dispatch.
- Windows no longer polls window state while visible. macOS and Linux preserve their existing minimize-to-tray behavior.

## Validation

- `pnpm run lint`
- `pnpm test` (26 files, 140 tests)
- `pnpm build`
- `pnpm exec oxfmt --check src/components/logging/log-file-browser.tsx`
- `cargo check --locked -p rust-srec-desktop`
- `cargo fmt -p rust-srec-desktop -- --check`
- `git diff --check`

## Split context

Chunk P3-01 of the #713 split series. All selected frontend hunks were re-authored onto current `main`; the Tauri optimization is included with a non-Windows compatibility fallback.


## Output note

Byte sizes now render via the shared `formatBytes` (2 decimals, TB-aware) instead of the deleted local `toFixed(1)` helper — e.g. "3.5 MB" becomes "3.46 MB".
