### PR TITLE
refactor: drop the dead enable_low_latency knob

### DIFF
--- a/crates/flv-fix/src/pipeline.rs
+++ b/crates/flv-fix/src/pipeline.rs
@@ -69,9 +69,6 @@ pub struct FlvPipelineConfig {
     /// Configuration for keyframe index injection
     pub keyframe_index_config: Option<ScriptFillerConfig>,
 
-    /// Retained for configuration compatibility; metadata patching is always layout-stable.
-    pub enable_low_latency: bool,
-
     pub pipe_mode: bool,
 }
 
@@ -85,7 +82,6 @@ impl Default for FlvPipelineConfig {
             repair_strategy: RepairStrategy::Relaxed,
             continuity_mode: ContinuityMode::Reset,
             keyframe_index_config: Some(ScriptFillerConfig::default()),
-            enable_low_latency: true,
             pipe_mode: false,
         }
     }
@@ -160,11 +156,6 @@ impl FlvPipelineConfigBuilder {
         keyframe_index_config: Option<ScriptFillerConfig>,
     ) -> Self {
         self.config.keyframe_index_config = keyframe_index_config;
-        self
-    }
-
-    pub fn enable_low_latency(mut self, enable_low_latency: bool) -> Self {
-        self.config.enable_low_latency = enable_low_latency;
         self
     }
 
@@ -430,7 +421,6 @@ mod test {
             let mut writer_task = FlvWriter::new(FlvWriterConfig {
                 output_dir,
                 base_name,
-                enable_low_latency: true,
             });
 
             let stats = writer_task.run(output_rx.into())?;

--- a/crates/flv-fix/src/writer.rs
+++ b/crates/flv-fix/src/writer.rs
@@ -15,7 +15,7 @@ impl FlvWriter {
     pub fn new(config: FlvWriterConfig) -> Self {
         let writer_config =
             WriterConfig::new(config.output_dir, config.base_name, "flv".to_string());
-        let strategy = FlvFormatStrategy::new(config.enable_low_latency);
+        let strategy = FlvFormatStrategy::new();
         let writer_task = WriterTask::new(writer_config, strategy);
         Self { writer_task }
     }

--- a/crates/flv-fix/src/writer_task.rs
+++ b/crates/flv-fix/src/writer_task.rs
@@ -40,8 +40,6 @@ pub enum FlvStrategyError {
 pub struct FlvWriterConfig {
     pub output_dir: PathBuf,
     pub base_name: String,
-    /// Retained for configuration compatibility; metadata patching is always layout-stable.
-    pub enable_low_latency: bool,
 }
 
 /// FLV-specific format strategy implementation
@@ -67,8 +65,14 @@ struct MetadataPatch {
     include_keyframes: bool,
 }
 
+impl Default for FlvFormatStrategy {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl FlvFormatStrategy {
-    pub fn new(_enable_low_latency: bool) -> Self {
+    pub fn new() -> Self {
         Self {
             analyzer: FlvAnalyzer::default(),
             pending_header: None,
@@ -420,7 +424,6 @@ mod tests {
         let mut writer = RecordingWriter::new(FlvWriterConfig {
             output_dir: tempdir.path().to_path_buf(),
             base_name: "segment-%i".to_string(),
-            enable_low_latency: true,
         });
         let opened_path = Arc::new(Mutex::new(None));
         let callback_path = Arc::clone(&opened_path);
@@ -475,7 +478,6 @@ mod tests {
         let mut writer = RecordingWriter::new(FlvWriterConfig {
             output_dir: tempdir.path().to_path_buf(),
             base_name: "segment-%i".to_string(),
-            enable_low_latency: true,
         });
         let opened_path = Arc::new(Mutex::new(None));
         let callback_path = Arc::clone(&opened_path);
@@ -526,7 +528,6 @@ mod tests {
         let mut writer = RecordingWriter::new(FlvWriterConfig {
             output_dir: tempdir.path().to_path_buf(),
             base_name: "segment-%i".to_string(),
-            enable_low_latency: true,
         });
         let opened_path = Arc::new(Mutex::new(None));
         let callback_path = Arc::clone(&opened_path);

--- a/mesio-cli/README.md
+++ b/mesio-cli/README.md
@@ -95,7 +95,6 @@ OPTIONS:
 
 ```text
   -k, --keyframe-index                Inject keyframe index in metadata for better seeking [default: true]
-      --low-latency-fix <BOOLEAN>     Legacy compatibility option. FLV metadata updates are always fixed-size and in-place. Requires --fix flag to be enabled [default: true]
 ```
 
 ### HLS Options

--- a/mesio-cli/src/cli.rs
+++ b/mesio-cli/src/cli.rs
@@ -92,16 +92,6 @@ pub struct CliArgs {
     )]
     pub enable_fix: bool,
 
-    /// Legacy compatibility switch for FLV metadata modification
-    #[arg(
-        long,
-        action = clap::ArgAction::Set,
-        default_value = "true",
-        help = "Legacy compatibility option. FLV metadata updates are always fixed-size and in-place.",
-        requires = "enable_fix",
-    )]
-    pub low_latency_fix: bool,
-
     /// Channel size for processing channels
     #[arg(
         short = 'b',

--- a/mesio-cli/src/main.rs
+++ b/mesio-cli/src/main.rs
@@ -196,7 +196,6 @@ async fn bootstrap() -> Result<(), AppError> {
         } else {
             None
         })
-        .enable_low_latency(args.low_latency_fix)
         .pipe_mode(is_pipe_mode)
         .build();
 

--- a/mesio-cli/src/processor/flv.rs
+++ b/mesio-cli/src/processor/flv.rs
@@ -32,7 +32,6 @@ async fn process_raw_stream(
     let mut writer = FlvWriter::new(FlvWriterConfig {
         output_dir: output_dir.to_path_buf(),
         base_name: base_name.to_string(),
-        enable_low_latency: false,
     });
 
     // Capture the current span to propagate to the blocking task
@@ -159,7 +158,6 @@ pub async fn process_file(
                 FlvWriter::new(FlvWriterConfig {
                     output_dir: output_dir.to_path_buf(),
                     base_name: base_name.to_string(),
-                    enable_low_latency: config.flv_pipeline_config.enable_low_latency,
                 })
             },
             token.clone(),
@@ -300,7 +298,6 @@ pub async fn process_flv_stream(
                 FlvWriter::new(FlvWriterConfig {
                     output_dir: output_dir.to_path_buf(),
                     base_name: base_name.clone(),
-                    enable_low_latency: config.flv_pipeline_config.enable_low_latency,
                 })
             },
             token.clone(),

--- a/rust-srec/src/downloader/engine/mesio/config.rs
+++ b/rust-srec/src/downloader/engine/mesio/config.rs
@@ -728,10 +728,6 @@ mod tests {
             flv_pipeline_config.duplicate_tag_filtering,
             default_config.duplicate_tag_filtering
         );
-        assert_eq!(
-            flv_pipeline_config.enable_low_latency,
-            default_config.enable_low_latency
-        );
         assert_eq!(flv_pipeline_config.pipe_mode, default_config.pipe_mode);
     }
 
@@ -790,7 +786,6 @@ mod tests {
         config.flv_pipeline_config = Some(
             FlvPipelineConfig::builder()
                 .duplicate_tag_filtering(false)
-                .enable_low_latency(false)
                 .pipe_mode(true)
                 .build(),
         );
@@ -798,7 +793,6 @@ mod tests {
         let flv_pipeline_config = build_flv_pipeline_config(&config);
 
         assert!(!flv_pipeline_config.duplicate_tag_filtering);
-        assert!(!flv_pipeline_config.enable_low_latency);
         assert!(flv_pipeline_config.pipe_mode);
     }
 

--- a/rust-srec/src/downloader/engine/mesio/flv_downloader.rs
+++ b/rust-srec/src/downloader/engine/mesio/flv_downloader.rs
@@ -172,7 +172,6 @@ impl FlvDownloader {
         let mut writer = FlvWriter::new(FlvWriterConfig {
             output_dir,
             base_name,
-            enable_low_latency: true,
         });
 
         helpers::setup_writer_callbacks(&mut writer, &self.event_tx);
@@ -252,7 +251,6 @@ impl FlvDownloader {
         let mut writer = FlvWriter::new(FlvWriterConfig {
             output_dir,
             base_name,
-            enable_low_latency: true,
         });
 
         helpers::setup_writer_callbacks(&mut writer, &self.event_tx);


### PR DESCRIPTION
## Severity

P3 (cleanup follow-up from the #713 split)

## What changed

Removed the `enable_low_latency` flag end to end: `FlvWriterConfig` field, the ignored `FlvFormatStrategy::new` argument (now `new()` + `Default`), the `FlvPipelineConfig` builder knob, and the mesio-cli / downloader-engine call sites that threaded a constant through.

## Why

`FlvFormatStrategy::new(_enable_low_latency: bool)` ignored its argument and the field's own doc said it was retained only for configuration compatibility; metadata patching is always layout-stable. Every caller passed a constant.

## Impact

No behavior change; identical output. One less no-op knob threaded through four layers.

## Validation

- `cargo test --locked -p flv-fix` (81 passed)
- `cargo check --locked -p mesio`
- `cargo test --locked -p rust-srec --lib downloader::` (175 passed)
- `cargo clippy --locked -p flv-fix -p mesio -p rust-srec --lib -- -D warnings`
- `git diff --check`

Note: this touches `crates/flv-fix/src/writer_task.rs` in different hunks than the sibling progress-feature PR; whichever merges second may need a trivial rebase.
