### PR TITLE
docs: reword split-reason shim and danmu runner comments

### DIFF
--- a/crates/pipeline-common/src/split_reason.rs
+++ b/crates/pipeline-common/src/split_reason.rs
@@ -1,3 +1,3 @@
-//! Re-exports the split-reason types, which now live in the `media-types`
-//! crate, so pipeline consumers can keep importing them via `pipeline_common`.
+//! Re-exports the split-reason types from the `media-types` crate so pipeline
+//! consumers can keep importing them via `pipeline_common`.
 pub use media_types::split_reason::{AudioCodecInfo, SplitReason, VideoCodecInfo};

--- a/rust-srec/src/danmu/runner.rs
+++ b/rust-srec/src/danmu/runner.rs
@@ -192,7 +192,6 @@ impl CollectionRunner {
     }
 
     /// Sleep until `deadline`, or wait forever when no idle back-off is pending.
-    /// Mirrors the `Option`-guarded timer idiom so a disabled back-off never fires.
     async fn wait_until(deadline: Option<tokio::time::Instant>) {
         match deadline {
             Some(instant) => tokio::time::sleep_until(instant).await,
@@ -332,8 +331,8 @@ impl CollectionRunner {
 
     /// Handle the result of receiving a message from the provider.
     ///
-    /// `Ok(None)` maps to `ReceiveOutcome::Idle` so the caller arms the idle
-    /// back-off instead of blocking the run loop with an inline sleep.
+    /// `Ok(None)` maps to `ReceiveOutcome::Idle`; the caller owns the idle
+    /// back-off, so this function never sleeps.
     async fn handle_receive_result(
         &mut self,
         result: platforms_parser::danmaku::error::Result<Option<DanmuItem>>,


### PR DESCRIPTION
Comment-only follow-up to #739 and #741: the split-reason shim doc referenced the relocation history and the danmu runner docs narrated the removed inline sleep; both now state only the current contract, per the project comment rules. Validated with `cargo check --locked -p pipeline-common -p rust-srec --lib` and rustfmt.