### PR TITLE
fix(frontend): stabilize concurrent upload status pill

### DIFF
--- a/rust-srec/frontend/src/components/streamers/card/upload-indicator.test.tsx
+++ b/rust-srec/frontend/src/components/streamers/card/upload-indicator.test.tsx
@@ -1,32 +1,53 @@
 import { setupI18n } from '@lingui/core';
 import { I18nProvider } from '@lingui/react';
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 
 import { UploadIndicator } from './upload-indicator';
+import type { UploadView } from '@/store/uploads';
+
+function renderIndicator(uploads: UploadView[]) {
+  const i18n = setupI18n({ locale: 'en', messages: { en: {} } });
+
+  return render(
+    <I18nProvider i18n={i18n}>
+      <UploadIndicator uploads={uploads} />
+    </I18nProvider>,
+  );
+}
+
+function createUpload(overrides: Partial<UploadView> = {}): UploadView {
+  return {
+    jobId: 'job-1',
+    streamerId: 'streamer-1',
+    sessionId: 'session-1',
+    uploader: 'rclone',
+    filesTotal: 2,
+    startedAtMs: 1n,
+    percent: 50,
+    lastEventAtMs: 1,
+    ...overrides,
+  };
+}
 
 describe('UploadIndicator', () => {
   it('uses the activated provider locale for plural messages', () => {
-    const i18n = setupI18n({ locale: 'en', messages: { en: {} } });
+    expect(() => renderIndicator([createUpload()])).not.toThrow();
+  });
 
-    expect(() =>
-      render(
-        <I18nProvider i18n={i18n}>
-          <UploadIndicator
-            uploads={[
-              {
-                jobId: 'job-1',
-                streamerId: 'streamer-1',
-                sessionId: 'session-1',
-                uploader: 'rclone',
-                filesTotal: 2,
-                startedAtMs: 1n,
-                percent: 50,
-                lastEventAtMs: Date.now(),
-              },
-            ]}
-          />
-        </I18nProvider>,
-      ),
-    ).not.toThrow();
+  it('shows progress for a single upload', () => {
+    renderIndicator([createUpload({ percent: 26.3 })]);
+
+    expect(screen.getByText('26%')).toBeInTheDocument();
+  });
+
+  it('shows the upload count when several uploads are active', () => {
+    renderIndicator([
+      createUpload({ percent: 26.3 }),
+      createUpload({ jobId: 'job-2', percent: 100, lastEventAtMs: 2 }),
+    ]);
+
+    expect(screen.getByText('2')).toBeInTheDocument();
+    expect(screen.queryByText('26%')).not.toBeInTheDocument();
+    expect(screen.queryByText('100%')).not.toBeInTheDocument();
   });
 });

--- a/rust-srec/frontend/src/components/streamers/card/upload-indicator.tsx
+++ b/rust-srec/frontend/src/components/streamers/card/upload-indicator.tsx
@@ -22,22 +22,22 @@ export function UploadIndicator({ uploads }: { uploads: UploadView[] }) {
 
   if (uploads.length === 0) return null;
 
-  // With several concurrent upload jobs, surface the one with the most
-  // recent progress in the compact percent label.
-  const latest = uploads.reduce((a, b) =>
-    b.lastEventAtMs > a.lastEventAtMs ? b : a,
-  );
+  const singleUpload = uploads.length === 1 ? uploads[0] : undefined;
 
   return (
     <Tooltip>
       <TooltipTrigger asChild>
         <div className="flex h-6 items-center gap-1 rounded-full border border-sky-500/20 bg-sky-500/10 px-2 text-sky-600 dark:text-sky-400">
           <CloudUpload className="h-3 w-3 animate-pulse" />
-          {latest.percent != null && (
+          {singleUpload?.percent != null ? (
             <span className="font-mono text-[10px] font-semibold tabular-nums">
-              {Math.min(latest.percent, 100).toFixed(0)}%
+              {Math.min(singleUpload.percent, 100).toFixed(0)}%
             </span>
-          )}
+          ) : uploads.length > 1 ? (
+            <span className="font-mono text-[10px] font-semibold tabular-nums">
+              {uploads.length}
+            </span>
+          ) : null}
         </div>
       </TooltipTrigger>
       <TooltipContent className="space-y-1.5">


### PR DESCRIPTION
## Summary

- show upload progress when exactly one upload is active
- show the active upload count when several uploads run concurrently
- keep individual upload percentages and transfer details in the tooltip

## Root cause

The compact status pill displayed the percentage from whichever upload emitted the latest progress event. Concurrent uploads emitted alternating events, causing the pill to switch repeatedly between unrelated percentages.

## Impact

The streamer card now provides a stable concurrent-upload indicator without presenting a misleading combined percentage.

## Validation

- `pnpm test -- src/components/streamers/card/upload-indicator.test.tsx`
- `pnpm run lint`
- `pnpm run build`
