### PR TITLE
fix(desktop): prevent sqlite lock during startup

### DIFF
--- a/rust-srec/src-tauri/src/lib.rs
+++ b/rust-srec/src-tauri/src/lib.rs
@@ -326,11 +326,10 @@ async fn run_desktop_backend_init(
     let logging_future =
         tokio::task::spawn_blocking(move || backend::init_logging(&log_dir_str_clone));
 
-    let pool_future = backend::init_pool(&database_url);
-    let write_pool_future = backend::init_write_pool(&database_url);
+    let database_pools_future = backend::init_database_pools(&database_url);
 
-    let (logging_result, pool_result, write_pool_result) =
-        tokio::join!(logging_future, pool_future, write_pool_future);
+    let (logging_result, database_pools_result) =
+        tokio::join!(logging_future, database_pools_future);
 
     // Handle logging result
     let (logging_config, log_guard) = match logging_result {
@@ -351,23 +350,10 @@ async fn run_desktop_backend_init(
     let log_and_pool_ms = log_and_pool_start.elapsed().as_millis();
     log::info!("Desktop init: logging + db pool took {}ms", log_and_pool_ms);
 
-    // Handle database pool result
-    let pool = match pool_result {
-        Ok(p) => p,
+    let (pool, write_pool) = match database_pools_result {
+        Ok(pools) => pools,
         Err(e) => {
             show_boot_error_window(&app_handle, &format!("Failed to open database: {e}")).await;
-            return;
-        }
-    };
-
-    let write_pool = match write_pool_result {
-        Ok(p) => p,
-        Err(e) => {
-            show_boot_error_window(
-                &app_handle,
-                &format!("Failed to open write database pool: {e}"),
-            )
-            .await;
             return;
         }
     };

--- a/rust-srec/src/backend.rs
+++ b/rust-srec/src/backend.rs
@@ -5,7 +5,7 @@
 //! services, and infrastructure do not expand the crate's public API.
 
 pub use crate::api::server::ApiServerConfig;
-pub use crate::database::{init_pool, init_write_pool, run_migrations};
+pub use crate::database::{init_database_pools, init_pool, init_write_pool, run_migrations};
 pub use crate::downloader::DownloadManagerConfig;
 pub use crate::logging::init_logging;
 pub use crate::notification::{NotificationEvent, NotificationPriority};

--- a/rust-srec/src/database.rs
+++ b/rust-srec/src/database.rs
@@ -14,10 +14,11 @@ pub mod time;
 pub use batching::{BatchWriter, BatchWriterConfig, JobStatusUpdate, StatsUpdate};
 pub use maintenance::{MaintenanceConfig, MaintenanceScheduler};
 
-use sqlx::sqlite::{SqliteConnectOptions, SqliteJournalMode, SqlitePoolOptions, SqliteSynchronous};
-use sqlx::{Pool, Row, Sqlite};
 use std::str::FromStr;
 use std::time::Duration;
+
+use sqlx::sqlite::{SqliteConnectOptions, SqliteJournalMode, SqlitePoolOptions, SqliteSynchronous};
+use sqlx::{Connection, Pool, Row, Sqlite};
 
 /// Database connection pool type alias.
 pub type DbPool = Pool<Sqlite>;
@@ -100,6 +101,20 @@ async fn ensure_wal_mode(pool: &DbPool, pool_name: &str) -> Result<(), sqlx::Err
     Ok(())
 }
 
+fn sqlite_connect_options(database_url: &str) -> Result<SqliteConnectOptions, sqlx::Error> {
+    Ok(SqliteConnectOptions::from_str(database_url)?
+        .synchronous(SqliteSynchronous::Normal)
+        .busy_timeout(Duration::from_millis(DEFAULT_BUSY_TIMEOUT_MS))
+        .foreign_keys(true)
+        .create_if_missing(true))
+}
+
+async fn establish_wal_mode(database_url: &str) -> Result<(), sqlx::Error> {
+    let options = sqlite_connect_options(database_url)?.journal_mode(SqliteJournalMode::Wal);
+    let connection = sqlx::SqliteConnection::connect_with(&options).await?;
+    connection.close().await
+}
+
 /// Compute a sensible default read pool size based on available CPU cores.
 ///
 /// SQLite readers don't benefit much beyond ~10 connections, and on low-core
@@ -111,29 +126,11 @@ pub fn default_read_pool_size() -> u32 {
     (cores * 2).min(DEFAULT_POOL_SIZE)
 }
 
-/// Initialize the database connection pool with WAL mode and performance optimizations.
-///
-/// # Arguments
-/// * `database_url` - SQLite database URL (e.g., "sqlite:srec.db?mode=rwc")
-/// * `max_connections` - Maximum number of connections in the pool
-///
-/// # Returns
-/// A configured SQLite connection pool.
-pub async fn init_pool_with_size(
+async fn open_pool_with_size(
     database_url: &str,
     max_connections: u32,
 ) -> Result<DbPool, sqlx::Error> {
-    let connect_options = SqliteConnectOptions::from_str(database_url)?
-        // Enable WAL mode for concurrent reads during writes
-        .journal_mode(SqliteJournalMode::Wal)
-        // NORMAL synchronous mode - balance between safety and performance
-        .synchronous(SqliteSynchronous::Normal)
-        // Set busy timeout to wait for locks
-        .busy_timeout(Duration::from_millis(DEFAULT_BUSY_TIMEOUT_MS))
-        // Enable foreign key constraints
-        .foreign_keys(true)
-        // Create database if it doesn't exist
-        .create_if_missing(true);
+    let connect_options = sqlite_connect_options(database_url)?;
 
     let pool = SqlitePoolOptions::new()
         .max_connections(max_connections)
@@ -152,6 +149,22 @@ pub async fn init_pool_with_size(
     );
 
     Ok(pool)
+}
+
+/// Initialize the database connection pool with WAL mode and performance optimizations.
+///
+/// # Arguments
+/// * `database_url` - SQLite database URL (e.g., "sqlite:srec.db?mode=rwc")
+/// * `max_connections` - Maximum number of connections in the pool
+///
+/// # Returns
+/// A configured SQLite connection pool.
+pub async fn init_pool_with_size(
+    database_url: &str,
+    max_connections: u32,
+) -> Result<DbPool, sqlx::Error> {
+    establish_wal_mode(database_url).await?;
+    open_pool_with_size(database_url, max_connections).await
 }
 
 /// Initialize the database connection pool with default size.
@@ -176,12 +189,12 @@ pub async fn init_pool(database_url: &str) -> Result<DbPool, sqlx::Error> {
 /// # Returns
 /// A configured SQLite connection pool with a single connection.
 pub async fn init_write_pool(database_url: &str) -> Result<WritePool, sqlx::Error> {
-    let connect_options = SqliteConnectOptions::from_str(database_url)?
-        .journal_mode(SqliteJournalMode::Wal)
-        .synchronous(SqliteSynchronous::Normal)
-        .busy_timeout(Duration::from_millis(DEFAULT_BUSY_TIMEOUT_MS))
-        .foreign_keys(true)
-        .create_if_missing(true);
+    establish_wal_mode(database_url).await?;
+    open_write_pool(database_url).await
+}
+
+async fn open_write_pool(database_url: &str) -> Result<WritePool, sqlx::Error> {
+    let connect_options = sqlite_connect_options(database_url)?;
 
     let pool = SqlitePoolOptions::new()
         .max_connections(1)
@@ -212,6 +225,23 @@ pub async fn init_write_pool(database_url: &str) -> Result<WritePool, sqlx::Erro
     tracing::info!("Write pool initialized with 1 max connection (serialized writes)");
 
     Ok(pool)
+}
+
+/// Initialize the read and write pools in the order required by SQLite.
+///
+/// Entering WAL mode requires an exclusive lock that SQLite's busy timeout cannot wait for.
+/// A short-lived connection establishes the persistent mode before either pool opens the database.
+pub async fn init_database_pools(database_url: &str) -> Result<(DbPool, WritePool), sqlx::Error> {
+    establish_wal_mode(database_url).await?;
+    let pool = open_pool_with_size(database_url, default_read_pool_size()).await?;
+    let write_pool = match open_write_pool(database_url).await {
+        Ok(pool) => pool,
+        Err(error) => {
+            pool.close().await;
+            return Err(error);
+        }
+    };
+    Ok((pool, write_pool))
 }
 
 pub async fn run_migrations(pool: &DbPool) -> Result<(), sqlx::Error> {
@@ -267,6 +297,32 @@ mod tests {
         // In-memory databases use "memory" journal mode, not WAL
         // For file-based databases, this would be "wal"
         assert!(result.0 == "memory" || result.0 == "wal");
+    }
+
+    #[tokio::test]
+    async fn fresh_file_database_pools_initialize_reliably() {
+        let directory = tempfile::tempdir().unwrap();
+
+        for attempt in 0..32 {
+            let path = directory.path().join(format!("fresh-{attempt}.db"));
+            let url = format!("sqlite:{}?mode=rwc", path.to_string_lossy());
+            let (pool, write_pool) = init_database_pools(&url).await.unwrap();
+
+            let read_mode: String = sqlx::query_scalar("PRAGMA journal_mode")
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+            let write_mode: String = sqlx::query_scalar("PRAGMA journal_mode")
+                .fetch_one(&write_pool)
+                .await
+                .unwrap();
+
+            assert_eq!(read_mode, "wal");
+            assert_eq!(write_mode, "wal");
+
+            pool.close().await;
+            write_pool.close().await;
+        }
     }
 
     #[tokio::test]

--- a/rust-srec/src/main.rs
+++ b/rust-srec/src/main.rs
@@ -6,8 +6,8 @@
 use std::sync::Arc;
 
 use rust_srec::backend::{
-    NotificationEvent, ServiceContainer, init_logging, init_pool, init_write_pool,
-    install_panic_hook, install_rustls_provider, run_migrations,
+    NotificationEvent, ServiceContainer, init_database_pools, init_logging, install_panic_hook,
+    install_rustls_provider, run_migrations,
 };
 use tracing::{error, info, warn};
 
@@ -40,8 +40,7 @@ async fn main() -> anyhow::Result<()> {
         std::env::var("DATABASE_URL").unwrap_or_else(|_| "sqlite:srec.db?mode=rwc".to_string());
 
     info!("Connecting to database: {}", database_url);
-    let pool = init_pool(&database_url).await?;
-    let write_pool = init_write_pool(&database_url).await?;
+    let (pool, write_pool) = init_database_pools(&database_url).await?;
 
     // Run migrations
     info!("Running database migrations...");


### PR DESCRIPTION
## Summary

- establish SQLite WAL mode through a dedicated bootstrap connection before opening pools
- keep the persistent journal mode out of reusable pool connection options
- use the shared ordered pool initializer from both server and desktop startup
- cover repeated first-run initialization against fresh database files

## Root cause

Desktop startup initialized the read and write pools concurrently. Both SQLx connection options issued `PRAGMA journal_mode=WAL`, but changing SQLite journal mode requires an exclusive lock that the busy timeout cannot wait for. One pool could therefore fail with `SQLITE_BUSY` while opening a new database. A later launch succeeded because WAL mode had already persisted.

## Impact

The Windows portable build can initialize its database reliably on first launch. Pool growth also no longer repeats the lock-sensitive journal-mode pragma.

## Validation

- `cargo test --locked -p rust-srec --lib -j 1 database::tests::`
- `cargo clippy --locked -p rust-srec -p rust-srec-desktop --all-targets -j 1 -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
