### PR TITLE
chore(toolchain): bump Rust to 1.98.0

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.97.1"
+channel = "1.98.0"
 profile = "minimal"
 components = ["clippy", "rustfmt"]


### PR DESCRIPTION
Bumps the pinned toolchain in `rust-toolchain.toml` from 1.97.1 to 1.98.0 (current stable, released 2026-08-20).

The workspace MSRV is unchanged — `rust-version = "1.95"` in `Cargo.toml`, the `ARG RUST_VERSION` in both Dockerfiles, and the getting-started docs all still say 1.95, so building from source on older stable releases keeps working. This only moves the toolchain that local dev and CI resolve to.