### PR TITLE
fix(pipeline): give the terminal-DAG rejection a machine-readable code

### DIFF
--- a/rust-srec/frontend/src/lib/__tests__/api-error.test.ts
+++ b/rust-srec/frontend/src/lib/__tests__/api-error.test.ts
@@ -1,0 +1,81 @@
+import {
+  BackendApiError,
+  DAG_ALREADY_TERMINAL_CODE,
+  hasErrorCode,
+  isDagAlreadyTerminalError,
+  isPasswordChangeRequiredError,
+} from '../api-error';
+
+/**
+ * Server functions rethrow `BackendApiError` across the serialization
+ * boundary as a plain `Error` that keeps `status`/`body` but loses the
+ * subclass prototype, so every matcher has to work on this shape too.
+ */
+function rethrownAcrossBoundary(status: number, body: unknown): Error {
+  const error = new Error('Request failed');
+  return Object.assign(error, { status, body });
+}
+
+describe('hasErrorCode', () => {
+  it('matches the backend code discriminator', () => {
+    expect(hasErrorCode({ code: 'X' }, 'X')).toBe(true);
+    expect(hasErrorCode({ code: 'Y' }, 'X')).toBe(false);
+  });
+
+  it('tolerates bodies that are not objects', () => {
+    for (const body of [null, undefined, 'plain text', 42]) {
+      expect(hasErrorCode(body, 'X')).toBe(false);
+    }
+  });
+});
+
+describe('isDagAlreadyTerminalError', () => {
+  it('matches a BackendApiError carrying the code', () => {
+    const error = new BackendApiError(422, 'Unprocessable Entity', {
+      code: DAG_ALREADY_TERMINAL_CODE,
+      message: 'DAG dag-1 is already in a terminal state',
+    });
+
+    expect(isDagAlreadyTerminalError(error)).toBe(true);
+  });
+
+  it('matches the shape that survives the server-function boundary', () => {
+    const error = rethrownAcrossBoundary(422, {
+      code: DAG_ALREADY_TERMINAL_CODE,
+    });
+
+    expect(error).not.toBeInstanceOf(BackendApiError);
+    expect(isDagAlreadyTerminalError(error)).toBe(true);
+  });
+
+  it('does not match other validation failures', () => {
+    const error = rethrownAcrossBoundary(422, {
+      code: 'VALIDATION_ERROR',
+      // Same status and wording family as the terminal-state rejection used
+      // to have; only the code distinguishes them now.
+      message: 'DAG dag-1 is already in a terminal state',
+    });
+
+    expect(isDagAlreadyTerminalError(error)).toBe(false);
+  });
+
+  it('does not match non-errors', () => {
+    expect(isDagAlreadyTerminalError(undefined)).toBe(false);
+    expect(isDagAlreadyTerminalError({ body: { code: 'X' } })).toBe(false);
+  });
+});
+
+describe('isPasswordChangeRequiredError', () => {
+  it('still requires both the 403 status and the code', () => {
+    expect(
+      isPasswordChangeRequiredError(
+        rethrownAcrossBoundary(403, { code: 'PASSWORD_CHANGE_REQUIRED' }),
+      ),
+    ).toBe(true);
+    expect(
+      isPasswordChangeRequiredError(
+        rethrownAcrossBoundary(422, { code: 'PASSWORD_CHANGE_REQUIRED' }),
+      ),
+    ).toBe(false);
+  });
+});

--- a/rust-srec/frontend/src/lib/api-error.ts
+++ b/rust-srec/frontend/src/lib/api-error.ts
@@ -16,17 +16,22 @@ export class BackendApiError extends Error {
   }
 }
 
+/** True when an error body carries the backend's `code` discriminator. */
+export function hasErrorCode(body: unknown, code: string): boolean {
+  return (
+    typeof body === 'object' &&
+    body !== null &&
+    (body as { code?: unknown }).code === code
+  );
+}
+
 // Body code the backend attaches to 403 responses on every authenticated
 // endpoint while the account's must_change_password flag is set (only
 // /auth/change-password and /auth/logout-all are exempt).
 export const PASSWORD_CHANGE_REQUIRED_CODE = 'PASSWORD_CHANGE_REQUIRED';
 
 export function hasPasswordChangeRequiredCode(body: unknown): boolean {
-  return (
-    typeof body === 'object' &&
-    body !== null &&
-    (body as { code?: unknown }).code === PASSWORD_CHANGE_REQUIRED_CODE
-  );
+  return hasErrorCode(body, PASSWORD_CHANGE_REQUIRED_CODE);
 }
 
 // Server functions rethrow BackendApiError across the serialization boundary
@@ -36,4 +41,22 @@ export function isPasswordChangeRequiredError(error: unknown): boolean {
   if (!(error instanceof Error)) return false;
   const { status, body } = error as Partial<BackendApiError>;
   return status === 403 && hasPasswordChangeRequiredCode(body);
+}
+
+// Body code the backend returns when a cancel or retry targets a DAG that
+// already reached a terminal status. Mirrors DAG_ALREADY_TERMINAL_CODE in
+// `api/error.rs`.
+export const DAG_ALREADY_TERMINAL_CODE = 'DAG_ALREADY_TERMINAL';
+
+/**
+ * True when the backend rejected the action because the DAG had already
+ * finished. Callers treat this as a no-op rather than a failure: a cancel
+ * racing a DAG that completed a moment earlier got the outcome it wanted.
+ *
+ * Shape-matched for the same reason as `isPasswordChangeRequiredError`.
+ */
+export function isDagAlreadyTerminalError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  const { body } = error as Partial<BackendApiError>;
+  return hasErrorCode(body, DAG_ALREADY_TERMINAL_CODE);
 }

--- a/rust-srec/frontend/src/routes/_authed/_dashboard/pipeline/jobs/index.lazy.tsx
+++ b/rust-srec/frontend/src/routes/_authed/_dashboard/pipeline/jobs/index.lazy.tsx
@@ -25,6 +25,7 @@ import { Badge } from '@/components/ui/badge';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
+import { isDagAlreadyTerminalError } from '@/lib/api-error';
 import { FAB_ANCHOR } from '@/components/shared/save-fab';
 import { containerVariants, itemVariants } from '@/lib/animation';
 import {
@@ -233,7 +234,7 @@ function PipelineJobsPage() {
 
   const cancelPipelineMutation = useMutation({
     mutationFn: (pipelineId: string) => cancelPipeline({ data: pipelineId }),
-    onSuccess: (result: any) => {
+    onSuccess: (result) => {
       toast.success(
         i18n._(msg`Cancelled ${result.cancelled_steps} steps in pipeline`),
       );
@@ -242,9 +243,10 @@ function PipelineJobsPage() {
       });
       void queryClient.invalidateQueries({ queryKey: ['pipeline', 'stats'] });
     },
-    onError: (error: any) => {
-      // Handle case where DAG is already in terminal state (completed/failed)
-      if (error?.body?.message?.includes('terminal state')) {
+    onError: (error) => {
+      // A pipeline that finished between render and click is not a failure —
+      // refresh so the card shows its real status.
+      if (isDagAlreadyTerminalError(error)) {
         toast.info(i18n._(msg`Pipeline is already completed or cancelled`));
         void queryClient.invalidateQueries({
           queryKey: ['pipeline', 'pipelines'],
@@ -269,7 +271,7 @@ function PipelineJobsPage() {
 
   const retryAllFailedMutation = useMutation({
     mutationFn: () => retryAllFailedPipelines(),
-    onSuccess: (result: any) => {
+    onSuccess: (result) => {
       toast.success(result.message);
       void queryClient.invalidateQueries({
         queryKey: ['pipeline', 'pipelines'],

--- a/rust-srec/frontend/src/server/functions/pipeline.ts
+++ b/rust-srec/frontend/src/server/functions/pipeline.ts
@@ -24,6 +24,7 @@ import {
 import type {
   BatchDagRequest,
   BatchDeleteOutputsRequest,
+  DagPipelineDefinition,
 } from '../../api/schemas';
 import { z } from 'zod';
 
@@ -183,8 +184,11 @@ export const retryAllFailedPipelines = createServerFn({
     .parse(json);
 });
 
+// Type-only validator, deliberately not `DagPipelineDefinitionSchema.parse`:
+// this endpoint exists to have the backend explain what is wrong with a DAG,
+// so rejecting the payload here would swallow the report the caller wants.
 export const validateDagDefinition = createServerFn({ method: 'POST' })
-  .validator((dag: any) => dag)
+  .validator((dag: DagPipelineDefinition) => dag)
   .handler(async ({ data: dag }) => {
     const json = await fetchBackend('/pipeline/validate', {
       method: 'POST',

--- a/rust-srec/src/api/error.rs
+++ b/rust-srec/src/api/error.rs
@@ -12,6 +12,12 @@ use serde::Serialize;
 use crate::api::auth_service::AuthError;
 use crate::error::Error;
 
+/// Code returned when a cancel or retry targets a DAG that already reached a
+/// terminal status. Clients match on this to treat the race as a no-op rather
+/// than an error; keep it in sync with the frontend's
+/// `DAG_ALREADY_TERMINAL_CODE` in `lib/api-error.ts`.
+pub const DAG_ALREADY_TERMINAL_CODE: &str = "DAG_ALREADY_TERMINAL";
+
 /// API error response body.
 #[derive(Debug, Serialize, utoipa::ToSchema)]
 pub struct ApiErrorResponse {
@@ -106,6 +112,11 @@ impl From<Error> for ApiError {
                 ApiError::not_found(format!("{} with id '{}' not found", entity_type, id))
             }
             Error::Validation(msg) => ApiError::validation(msg),
+            Error::DagAlreadyTerminal { ref dag_id } => ApiError::new(
+                StatusCode::UNPROCESSABLE_ENTITY,
+                DAG_ALREADY_TERMINAL_CODE,
+                format!("DAG {} is already in a terminal state", dag_id),
+            ),
             Error::Configuration(msg) => ApiError::bad_request(msg),
             Error::DatabaseSqlx(e) => {
                 tracing::error!("Database error: {}", e);
@@ -204,6 +215,21 @@ mod tests {
 
         assert_eq!(api_err.status, StatusCode::FORBIDDEN);
         assert_eq!(api_err.code, "PASSWORD_CHANGE_REQUIRED");
+    }
+
+    #[test]
+    fn dag_already_terminal_has_its_own_code() {
+        let api_err = ApiError::from(Error::DagAlreadyTerminal {
+            dag_id: "dag-1".to_string(),
+        });
+
+        // The frontend branches its cancel UX on this code. A plain
+        // `Error::Validation` would collapse it into VALIDATION_ERROR and
+        // leave callers matching on message text.
+        assert_eq!(api_err.status, StatusCode::UNPROCESSABLE_ENTITY);
+        assert_eq!(api_err.code, DAG_ALREADY_TERMINAL_CODE);
+        assert_ne!(api_err.code, ApiError::validation("x").code);
+        assert!(api_err.message.contains("dag-1"));
     }
 
     #[test]

--- a/rust-srec/src/error.rs
+++ b/rust-srec/src/error.rs
@@ -27,6 +27,17 @@ pub enum Error {
     #[error("Validation error: {0}")]
     Validation(String),
 
+    /// A DAG operation that only applies to a live execution was attempted on
+    /// one that already reached a terminal status.
+    ///
+    /// Distinct from [`Error::Validation`] so `From<Error> for ApiError` can
+    /// give it a dedicated code: callers branch their UI on this condition
+    /// (a cancel racing a DAG that just finished is expected, not a failure
+    /// to report), and a shared `VALIDATION_ERROR` code leaves them matching
+    /// on message text.
+    #[error("DAG {dag_id} is already in a terminal state")]
+    DagAlreadyTerminal { dag_id: String },
+
     #[error("Configuration error: {0}")]
     Configuration(String),
 

--- a/rust-srec/src/pipeline/dag_scheduler.rs
+++ b/rust-srec/src/pipeline/dag_scheduler.rs
@@ -655,10 +655,9 @@ impl DagScheduler {
         let dag = self.dag_repository.get_dag(dag_id).await?;
 
         if dag.get_status().map(|s| s.is_terminal()).unwrap_or(false) {
-            return Err(Error::Validation(format!(
-                "DAG {} is already in terminal state",
-                dag_id
-            )));
+            return Err(Error::DagAlreadyTerminal {
+                dag_id: dag_id.to_string(),
+            });
         }
 
         let cancelled = self


### PR DESCRIPTION
## What changed?

Follow-up from reviewing #800. Two findings there were inherited rather than introduced by that PR (`git blame` puts them in #333 and #765), so they are fixed here instead.

**The message-text coupling.** `PipelineJobsPage`'s cancel handler branched its UX on an English substring:

```ts
if (error?.body?.message?.includes('terminal state')) { /* "already completed" notice */ }
```

The string it matched is built in `dag_scheduler.rs:659`, where cancelling a finished DAG returned `Error::Validation(...)`. That maps to the shared `VALIDATION_ERROR` code, so the message was the *only* thing distinguishing "this pipeline already finished" from any other 422. Rewording it — or translating it — would have silently downgraded the notice to a generic "Failed to cancel pipeline" toast, with nothing failing to signal the breakage.

- New `Error::DagAlreadyTerminal { dag_id }`, mapped in `From<Error> for ApiError` to a dedicated `DAG_ALREADY_TERMINAL` code (still 422).
- `hasErrorCode(body, code)` in `lib/api-error.ts`, with `isDagAlreadyTerminalError` built on it; `hasPasswordChangeRequiredCode` now shares it rather than repeating the shape check.
- Shape-matched, not `instanceof` — server functions rethrow `BackendApiError` across the serialization boundary as a plain `Error` that keeps `status`/`body` but loses the prototype, as `api-error.ts:32` documents. The tests cover both shapes.

The batch endpoint added in #800 already forwards `api_error.code` per item, so batch cancel over a mixed selection now reports a machine-readable reason per pipeline for free.

**The untyped boundaries.** `validateDagDefinition`'s validator was `(dag: any) => dag`, and two `onSuccess: (result: any)` annotations discarded the return types their zod-parsed server functions already produce. Now typed.

Worth noting on the validator: I kept it type-only (`(dag: DagPipelineDefinition) => dag`) rather than switching to `DagPipelineDefinitionSchema.parse`. That endpoint exists to have the backend explain what is wrong with a DAG, so parsing the payload client-side would swallow the very report the caller asked for. Type-only pass-through is also the dominant convention here (17 of ~88 validators parse).

## Scope

- Affected components: backend, frontend
- Breaking change: no. The wire status stays 422 and only the `code` narrows from `VALIDATION_ERROR` to `DAG_ALREADY_TERMINAL`; the message wording changed slightly ("in a terminal state"), which nothing matches on any more.
- No release-notes entry: behaviour is unchanged for users today — this removes the way it could silently break tomorrow.

## Verification

Ran a server against a seeded DAG row in `COMPLETED` status:

```
DELETE /api/pipeline/dag/dag-terminal-1
  422 {"code":"DAG_ALREADY_TERMINAL","message":"DAG dag-terminal-1 is already in a terminal state"}

POST /api/pipeline/dags/batch  {"action":{"type":"cancel"}}
  200 {"failed":1,"results":[{"id":"dag-terminal-1","success":false,"code":"DAG_ALREADY_TERMINAL",...}]}
```

Neighbouring rejections keep their own codes, so the new one is genuinely specific rather than swallowing siblings:

```
POST .../retry   400 {"code":"BAD_REQUEST","message":"DAG is not in FAILED or CANCELLED status"}
DELETE .../nope  404 {"code":"NOT_FOUND",...}
```

`cargo fmt --check` and `cargo clippy --workspace --all-targets` clean; 1661 Rust tests pass, including a new one asserting the code is distinct from `ApiError::validation`'s. 197 frontend tests pass — 7 new for the matchers, one of which feeds in an error carrying `VALIDATION_ERROR` *and the old message wording* to prove the text coupling is gone. `pnpm lint`, `fmt:check`, `typecheck` clean.