### PR TITLE
perf(pipeline): make the pending-job indexes match the claim order

### DIFF
--- a/rust-srec/migrations/20260831020000_make_pending_job_claims_fifo.sql
+++ b/rust-srec/migrations/20260831020000_make_pending_job_claims_fifo.sql
@@ -1,0 +1,15 @@
+-- SqlxJobRepository::claim_next_pending_job selects the next PENDING job with
+-- ORDER BY priority DESC, created_at ASC, id ASC. The previous partial indexes
+-- sorted created_at DESC, so the planner had to sort the whole pending set on
+-- every claim. Match the claim order exactly, with id as the final tiebreak,
+-- so the claim is an index walk to the first row.
+DROP INDEX IF EXISTS idx_job_pending_priority_created_at;
+DROP INDEX IF EXISTS idx_job_pending_type_priority_created_at;
+
+CREATE INDEX idx_job_pending_priority_created_at
+    ON job(priority DESC, created_at ASC, id ASC)
+    WHERE status = 'PENDING';
+
+CREATE INDEX idx_job_pending_type_priority_created_at
+    ON job(job_type, priority DESC, created_at ASC, id ASC)
+    WHERE status = 'PENDING';


### PR DESCRIPTION
## What changed?

Reworked from the first version of this PR. The nine `20260831*` migrations it originally carried were leftovers of a branch lost in an Aug 31 reset: never in main, never in any release tag (newest is rust-srec-v0.5.1 from Aug 4, built by CI), and the Rust code they were written for does not exist. No production database has run them, so they are deleted rather than shipped, along with the two repair migrations that only existed to make them safe. Only local dev databases built from that working tree will notice, and those can be recreated.

One piece was worth keeping on its own merits. `SqlxJobRepository::claim_next_pending_job` orders by `priority DESC, created_at ASC, id ASC`, but the two partial indexes on pending jobs sort `created_at DESC`, so the planner sorts the whole pending set on every claim. This migration recreates both partial indexes in the claim order with `id` as the final tiebreak.

## Scope

- Affected components: backend (one SQLite migration)
- Breaking change: no. Same two index names, same partial predicate, only the column order changes.

## How to test

```
cargo test -p rust-srec --lib database::repositories::job
```

Or apply `rust-srec/migrations/*.sql` to an empty SQLite database, insert some pending jobs, run `ANALYZE`, and `EXPLAIN QUERY PLAN` the claim query above.

## Verification

Measured on a scratch SQLite database with 60k job rows, 6k of them PENDING, 200 claims each:

| | plan | per claim |
|---|---|---|
| Before, with statistics | temp B-tree sort over the pending set | ~4 ms |
| After, with statistics | covering index walk to the first row | ~9 µs |
| Either, without statistics | temp B-tree sort | ~4 ms |

Statistics come from the `PRAGMA optimize` pass `MaintenanceService::run_optimize` runs on `optimize_interval` (7 days), so deployed databases pick up the new plan on their next pass. Without statistics the planner ignores both the old and new partial indexes alike, so the change is never worse than today.

`cargo test -p rust-srec --lib database::repositories::job`: 2 passed. Earlier full runs of the library and integration suites passed with this file present. No Rust source changed.

## Checklist

- [x] I ran formatting (`cargo fmt --all`) if Rust code changed (no Rust code changed)
- [x] I ran lint (`cargo clippy ...`) if Rust code changed (no Rust code changed)
- [x] I ran tests (`cargo test` or `cargo nextest run`) if feasible
- [x] I updated docs/config examples if behavior changed (none needed)
- [x] I avoided logging secrets and redacted sensitive info in screenshots/logs

## Related issues

None.
