### PR TITLE
perf(pipeline): index the job and session list orders and the stats aggregate

### DIFF
--- a/rust-srec/migrations/20260902000000_add_job_list_and_stats_indexes.sql
+++ b/rust-srec/migrations/20260902000000_add_job_list_and_stats_indexes.sql
@@ -1,0 +1,19 @@
+-- SqlxJobRepository::list_jobs_filtered orders every page by
+-- priority DESC, created_at DESC. With a status filter the only usable index
+-- was idx_job_status_created_at, so the planner sorted the whole status
+-- partition (most of the table once jobs are COMPLETED) for each page.
+CREATE INDEX idx_job_status_priority_created_at
+    ON job(status, priority DESC, created_at DESC);
+
+-- SqlxJobRepository::get_avg_processing_time reads duration_secs,
+-- started_at and completed_at for every COMPLETED job. Covering those columns
+-- keeps the aggregate inside the index instead of fetching each row; the
+-- query is polled with the pipeline stats.
+CREATE INDEX idx_job_status_duration
+    ON job(status, duration_secs, started_at, completed_at);
+
+-- SqlxSessionRepository::list_sessions_filtered orders by start_time DESC.
+-- Without a streamer filter no index matched that order, so each page sorted
+-- all sessions.
+CREATE INDEX idx_live_sessions_start_time
+    ON live_sessions(start_time DESC);

--- a/rust-srec/src/database/repositories/job.rs
+++ b/rust-srec/src/database/repositories/job.rs
@@ -921,33 +921,29 @@ impl JobRepository for SqlxJobRepository {
     }
 
     async fn get_job_counts_by_status(&self) -> Result<JobCounts> {
-        // Use a single query with CASE statements for efficiency
-        let row: (i64, i64, i64, i64, i64) = sqlx::query_as(
-            r#"
-            SELECT
-                COALESCE(SUM(CASE WHEN status = ? THEN 1 ELSE 0 END), 0) as pending,
-                COALESCE(SUM(CASE WHEN status = ? THEN 1 ELSE 0 END), 0) as processing,
-                COALESCE(SUM(CASE WHEN status = ? THEN 1 ELSE 0 END), 0) as completed,
-                COALESCE(SUM(CASE WHEN status = ? THEN 1 ELSE 0 END), 0) as failed,
-                COALESCE(SUM(CASE WHEN status = ? THEN 1 ELSE 0 END), 0) as cancelled
-            FROM job
-            "#,
-        )
-        .bind(JobStatus::Pending.as_str())
-        .bind(JobStatus::Processing.as_str())
-        .bind(JobStatus::Completed.as_str())
-        .bind(JobStatus::Failed.as_str())
-        .bind(JobStatus::Cancelled.as_str())
-        .fetch_one(&self.pool)
-        .await?;
+        // GROUP BY walks idx_job_status_created_at in status order and emits one
+        // count per run, so each index entry is visited once with no per-row
+        // comparison against every status value.
+        let rows: Vec<(String, i64)> =
+            sqlx::query_as("SELECT status, COUNT(*) FROM job GROUP BY status")
+                .fetch_all(&self.pool)
+                .await?;
 
-        Ok(JobCounts {
-            pending: row.0 as u64,
-            processing: row.1 as u64,
-            completed: row.2 as u64,
-            failed: row.3 as u64,
-            cancelled: row.4 as u64,
-        })
+        let mut counts = JobCounts::default();
+        for (status, count) in rows {
+            let count = count as u64;
+            match JobStatus::parse(&status) {
+                Some(JobStatus::Pending) => counts.pending = count,
+                Some(JobStatus::Processing) => counts.processing = count,
+                Some(JobStatus::Completed) => counts.completed = count,
+                Some(JobStatus::Failed) => counts.failed = count,
+                Some(JobStatus::Cancelled) => counts.cancelled = count,
+                // The status CHECK constraint on job admits only the values above.
+                None => {}
+            }
+        }
+
+        Ok(counts)
     }
 
     async fn get_avg_processing_time(&self) -> Result<Option<f64>> {


### PR DESCRIPTION
## What changed?

Follow-up to #803. I ran `EXPLAIN QUERY PLAN` over every SQL statement in `rust-srec/src` against the migrated schema populated with realistic data (60k jobs, 85% COMPLETED; 20k sessions), with `ANALYZE` statistics, and flagged plans that sort or scan. Most hits were on tiny tables or per-parent lookups. Four were on polled or paginated paths and are fixed here.

- **Jobs list with a status filter.** `list_jobs_filtered` orders by `priority DESC, created_at DESC`. With `status = ?` the only usable index was `idx_job_status_created_at`, so each page sorted the whole status partition, which is most of the table once jobs are COMPLETED. New index `idx_job_status_priority_created_at`.
- **Average processing time.** `get_avg_processing_time` reads three columns for every COMPLETED job through the status index, one row fetch each. New covering index `idx_job_status_duration` keeps the aggregate inside the index. This query runs with the pipeline stats, polled every 5 s on the dashboard and 10 s on the jobs page.
- **Counts by status.** `get_job_counts_by_status` summed five `CASE` expressions per row. Rewritten as `GROUP BY status`, which walks the existing status index once. Same `JobCounts` result; unknown statuses cannot occur because of the `CHECK` constraint on `job.status`.
- **Sessions list default order.** `list_sessions_filtered` orders by `start_time DESC`; without a streamer filter no index matched, so each page sorted all sessions. New index `idx_live_sessions_start_time`.

Not changed: the sessions `COUNT` with the `total_size_bytes > 0 OR end_time IS NULL` predicate still scans (3 ms at 20k rows), and the jobs list filtered by streamer still sorts that streamer's jobs (1 ms). Neither is polled.

## Scope

- Affected components: backend (one migration, one repository method)
- Breaking change: no. Additive indexes and an equivalent aggregate.

Trade-off: `idx_job_status_duration` is maintained on every job write that touches status, duration or timestamps, roughly three updates per job lifecycle. That is the cost of a covering index; it is small next to the per-poll scan it replaces.

## How to test

```
cargo test -p rust-srec --lib database::repositories::job
```

Or apply `rust-srec/migrations/*.sql` to an empty SQLite database, populate jobs and sessions, run `ANALYZE`, and `EXPLAIN QUERY PLAN` the four queries above.

## Verification

Measured per query on a scratch SQLite database, 60k jobs / 20k sessions, statistics present:

| Query | Before | After |
|---|---|---|
| Jobs list, `status = 'COMPLETED'`, page of 20 | 24 ms, temp B-tree sort | 0.1 ms, index walk |
| Stats: average processing time | 23 ms, row fetch per completed job | 6 ms, covering index |
| Stats: counts by status | 17 ms, five CASE sums per row | 4 ms, GROUP BY over index |
| Sessions list, default order, page of 20 | 4.7 ms, temp B-tree sort | 0.03 ms, index walk |

Statistics come from the weekly `PRAGMA optimize` in `MaintenanceService::run_optimize`. The `GROUP BY` rewrite and the covering index apply without statistics as well since they are the only matching plan shapes.

`cargo fmt --all -- --check` clean. `cargo clippy -p rust-srec --lib --tests` clean. `cargo test -p rust-srec --lib`: 1623 passed, 0 failed, 1 ignored, including the existing `get_job_counts_by_status` assertions in the job repository, job queue and DAG scheduler tests.

## Checklist

- [x] I ran formatting (`cargo fmt --all`) if Rust code changed
- [x] I ran lint (`cargo clippy ...`) if Rust code changed
- [x] I ran tests (`cargo test` or `cargo nextest run`) if feasible
- [x] I updated docs/config examples if behavior changed (none needed)
- [x] I avoided logging secrets and redacted sensitive info in screenshots/logs

## Related issues

Follow-up to #803.
