### PR TITLE
perf(danmu): write each XML batch with one syscall

### DIFF
--- a/crates/platforms/src/danmaku/writer.rs
+++ b/crates/platforms/src/danmaku/writer.rs
@@ -24,11 +24,18 @@
 //! - `uid_crc32`: CRC32 hash of the sender's user ID
 //! - `row_id`: Row ID for ordering (uses message count)
 
+use std::borrow::Cow;
 use std::path::{Path, PathBuf};
 
 use chrono::{DateTime, Utc};
 use tokio::fs::File;
-use tokio::io::AsyncWriteExt;
+use tokio::io::{AsyncWriteExt, BufWriter};
+
+/// Capacity of the in-memory buffer in front of the XML file. A flush batch
+/// from `CollectionRunner::flush_buffer` is at most `MAX_BUFFER_SIZE` messages
+/// of a few hundred bytes each, so one batch fits without an intermediate
+/// write.
+const FILE_BUFFER_CAPACITY: usize = 64 * 1024;
 
 use crate::danmaku::error::Result;
 use crate::danmaku::message::{DanmuMessage, DanmuType};
@@ -60,7 +67,7 @@ const DEFAULT_POOL: u8 = 0;
 /// ```
 pub struct XmlDanmuWriter {
     path: PathBuf,
-    file: Option<File>,
+    file: Option<BufWriter<File>>,
     message_count: u64,
     /// The start time of the current segment.
     /// Timestamps are written as second offsets from this time.
@@ -91,7 +98,7 @@ impl XmlDanmuWriter {
         segment_start_time: DateTime<Utc>,
         header_comments: Vec<String>,
     ) -> Result<Self> {
-        let file = File::create(path).await?;
+        let file = BufWriter::with_capacity(FILE_BUFFER_CAPACITY, File::create(path).await?);
         let mut writer = Self {
             path: path.to_path_buf(),
             file: Some(file),
@@ -193,11 +200,19 @@ impl XmlDanmuWriter {
             };
             file.write_all(xml.as_bytes()).await?;
             self.message_count += 1;
+        }
+        Ok(())
+    }
 
-            // Flush periodically
-            if self.message_count.is_multiple_of(100) {
-                file.flush().await?;
-            }
+    /// Hand everything buffered so far to the operating system.
+    ///
+    /// `write_message` only appends to the in-memory buffer; callers that
+    /// write messages in batches (`CollectionRunner::flush_buffer`) call this
+    /// once per batch so the file grows in one write per batch instead of one
+    /// per message.
+    pub async fn flush(&mut self) -> Result<()> {
+        if let Some(file) = &mut self.file {
+            file.flush().await?;
         }
         Ok(())
     }
@@ -281,11 +296,10 @@ fn message_color_to_bilibili_color(message: &DanmuMessage) -> Option<u32> {
     u32::from_str_radix(hex, 16).ok()
 }
 
-fn message_content_for_xml(message: &DanmuMessage) -> String {
+fn message_content_for_xml(message: &DanmuMessage) -> Cow<'_, str> {
     match message.message_type {
         DanmuType::SuperChat => {
             let content = message.content.trim();
-            let content = content.to_string();
 
             let price = message
                 .metadata
@@ -295,21 +309,21 @@ fn message_content_for_xml(message: &DanmuMessage) -> String {
                 .unwrap_or(0);
 
             if price > 0 && !content.is_empty() {
-                format!("[SC ￥{}] {}", price, content)
+                Cow::Owned(format!("[SC ￥{}] {}", price, content))
             } else if price > 0 {
-                format!("[SC ￥{}]", price)
+                Cow::Owned(format!("[SC ￥{}]", price))
             } else {
-                content
+                Cow::Borrowed(content)
             }
         }
         DanmuType::Gift => {
             let content = message.content.trim();
             if !content.is_empty() {
-                return content.to_string();
+                return Cow::Borrowed(content);
             }
 
             let Some(metadata) = message.metadata.as_ref() else {
-                return String::new();
+                return Cow::Borrowed("");
             };
 
             let gift_name = metadata
@@ -322,12 +336,12 @@ fn message_content_for_xml(message: &DanmuMessage) -> String {
                 .unwrap_or(0);
 
             if gift_count > 0 && !gift_name.is_empty() {
-                format!("赠送 {} x{}", gift_name, gift_count)
+                Cow::Owned(format!("赠送 {} x{}", gift_name, gift_count))
             } else {
-                String::new()
+                Cow::Borrowed("")
             }
         }
-        _ => message.content.clone(),
+        _ => Cow::Borrowed(&message.content),
     }
 }
 
@@ -386,8 +400,14 @@ fn super_chat_to_xml(message: &DanmuMessage, ts: f64, timestamp_ms: i64) -> Stri
 }
 
 /// Escape special XML characters in a string.
-pub fn escape_xml(s: &str) -> String {
-    let mut out = String::with_capacity(s.len());
+///
+/// Borrows the input when it contains nothing to escape, which is the common
+/// case for usernames and chat content.
+pub fn escape_xml(s: &str) -> Cow<'_, str> {
+    if !s.contains(['&', '<', '>', '"', '\'']) {
+        return Cow::Borrowed(s);
+    }
+    let mut out = String::with_capacity(s.len() + 8);
     for ch in s.chars() {
         match ch {
             '&' => out.push_str("&amp;"),
@@ -398,7 +418,7 @@ pub fn escape_xml(s: &str) -> String {
             _ => out.push(ch),
         }
     }
-    out
+    Cow::Owned(out)
 }
 
 /// Calculate CRC32 hash of a string.

--- a/rust-srec/src/danmu/runner.rs
+++ b/rust-srec/src/danmu/runner.rs
@@ -680,10 +680,11 @@ impl CollectionRunner {
             // Sort messages by timestamp
             self.message_buffer.sort_by_key(|m| m.timestamp);
 
-            // Write all messages
+            // Write all messages, then hand the batch to the OS in one write.
             for message in self.message_buffer.drain(..) {
                 writer.write_message(&message).await?;
             }
+            writer.flush().await?;
         }
 
         Ok(())


### PR DESCRIPTION
## What changed?

`XmlDanmuWriter::write_message` wrote each formatted message straight to a bare `tokio::fs::File`. Every chat message therefore cost one `write` syscall plus one round trip through tokio's blocking pool, and `CollectionRunner::flush_buffer` awaited that round trip for every message in the batch. The runner already batches messages, up to `MAX_BUFFER_SIZE` (100) every `BUFFER_FLUSH_INTERVAL_MS` (500 ms), so the batching bought scheduling but not I/O.

- The file is now wrapped in a `tokio::io::BufWriter` with a 64 KiB buffer, enough for a full batch.
- New `XmlDanmuWriter::flush`, called once at the end of `flush_buffer`, hands the batch to the OS in one write. The old flush-every-100-messages branch is gone; `finalize` still flushes before writing the closing tag.
- `escape_xml` and `message_content_for_xml` return `Cow<str>` and borrow when there is nothing to escape or rewrite, which is the common case for usernames and plain chat. That removes two allocations per plain message.

Durability is unchanged in practice: the previous code never called `sync_all`, and `tokio::fs::File::flush` only drains in-flight writes. Data now reaches the OS at the batch boundary (at most 500 ms later) instead of per message.

## Scope

- Affected components: crates (`platforms-parser` danmaku writer), backend (`danmu::runner`)
- Breaking change: no. `escape_xml` is re-exported; its return type changes from `String` to `Cow<str>`, which still displays and compares the same. No other crate calls it.

## How to test

```
cargo test -p platforms-parser --lib danmaku::writer
cargo test -p rust-srec --lib danmu::
```

## Verification

At 100 messages per second on a busy stream, the writer went from 100 write syscalls and 100 blocking-pool dispatches per second to at most 2 per second, one per batch. The runner tests that read back the XML after segment rotation and shutdown cover the flush-on-finalize path.

`cargo fmt --all` clean. `cargo clippy -p platforms-parser -p rust-srec --lib --tests` clean. Writer tests: 5 passed. Danmu runner tests: 33 passed.

## Checklist

- [x] I ran formatting (`cargo fmt --all`) if Rust code changed
- [x] I ran lint (`cargo clippy ...`) if Rust code changed
- [x] I ran tests (`cargo test` or `cargo nextest run`) if feasible
- [x] I updated docs/config examples if behavior changed (none needed)
- [x] I avoided logging secrets and redacted sensitive info in screenshots/logs

## Related issues

None.
