### PR TITLE
perf(api): stop per-row lookups and full clones on polled list endpoints

### DIFF
--- a/rust-srec/frontend/src/server/api.ts
+++ b/rust-srec/frontend/src/server/api.ts
@@ -54,12 +54,12 @@ export const fetchBackend = async <T = any>(
   const headers = new Headers(init?.headers);
   if (token) {
     headers.set('Authorization', `Bearer ${token}`);
+  }
+  // Every server function passes through here, including the 5 s pollers,
+  // so the request trace is development-only.
+  if (import.meta.env.DEV) {
     console.log(
-      `[API] ${init?.method || 'GET'} ${endpoint} - Token present: ${token.slice(0, 10)}...`,
-    );
-  } else {
-    console.log(
-      `[API] ${init?.method || 'GET'} ${endpoint} - No token found in session.`,
+      `[API] ${init?.method || 'GET'} ${endpoint} - ${token ? 'token present' : 'no token in session'}`,
     );
   }
 
@@ -87,9 +87,11 @@ export const fetchBackend = async <T = any>(
     headers,
   });
 
-  console.log(
-    `[API] ${init?.method || 'GET'} ${endpoint} - Status: ${response.status}`,
-  );
+  if (import.meta.env.DEV) {
+    console.log(
+      `[API] ${init?.method || 'GET'} ${endpoint} - Status: ${response.status}`,
+    );
+  }
 
   // Handle errors
   if (!response.ok) {

--- a/rust-srec/src/api/routes/pipeline/dag.rs
+++ b/rust-srec/src/api/routes/pipeline/dag.rs
@@ -439,22 +439,25 @@ pub async fn list_dags(
         .await
         .map_err(ApiError::from)?;
 
-    // Batch-fetch streamer names
-    let streamer_ids: std::collections::HashSet<String> =
-        dags.iter().filter_map(|d| d.streamer_id.clone()).collect();
-    let fetches = streamer_ids.into_iter().map(|streamer_id| {
-        let repo = state.streamer_repository.clone();
-        async move {
-            let name = repo.get_streamer(&streamer_id).await.ok().map(|s| s.name);
-            (streamer_id, name)
+    // One `WHERE id IN (...)` query for every streamer on the page. A failed
+    // lookup only blanks the display names, as before.
+    let streamer_ids: Vec<String> = dags
+        .iter()
+        .filter_map(|d| d.streamer_id.clone())
+        .collect::<HashSet<_>>()
+        .into_iter()
+        .collect();
+    let streamer_names: HashMap<String, String> = match state
+        .streamer_repository
+        .get_streamers_by_ids(&streamer_ids)
+        .await
+    {
+        Ok(streamers) => streamers.into_iter().map(|s| (s.id, s.name)).collect(),
+        Err(error) => {
+            tracing::warn!(%error, "failed to resolve streamer names for DAG list");
+            HashMap::new()
         }
-    });
-    let streamer_names: std::collections::HashMap<String, String> =
-        futures::future::join_all(fetches)
-            .await
-            .into_iter()
-            .filter_map(|(id, name)| name.map(|n| (id, n)))
-            .collect();
+    };
 
     // Convert to response format
     let dag_items: Vec<DagListItem> = dags
@@ -462,10 +465,8 @@ pub async fn list_dags(
         .map(|dag| {
             let progress_percent = dag.progress_percent();
 
-            // Parse DAG definition to get the name
             let name = dag
-                .get_dag_definition()
-                .map(|def| def.name)
+                .dag_definition_name()
                 .unwrap_or_else(|| "Unknown".to_string());
 
             let streamer_name = dag

--- a/rust-srec/src/api/routes/pipeline/jobs.rs
+++ b/rust-srec/src/api/routes/pipeline/jobs.rs
@@ -568,31 +568,29 @@ pub async fn list_outputs(
         .await
         .map_err(ApiError::from)?;
 
+    // One `WHERE id IN (...)` query for every session on the page. A failed
+    // lookup only blanks the streamer ids, as before.
     let streamer_id_by_session: HashMap<String, String> = if requested_streamer_id.is_none() {
-        let mut session_ids: HashSet<String> = HashSet::new();
-        for output in &outputs {
-            session_ids.insert(output.session_id.clone());
-        }
-
-        let fetches = session_ids.into_iter().map(|session_id| {
-            let session_repository = state.session_repository.clone();
-            async move {
-                let streamer_id = session_repository
-                    .get_session(&session_id)
-                    .await
-                    .ok()
-                    .map(|session| session.streamer_id);
-                (session_id, streamer_id)
-            }
-        });
-
-        join_all(fetches)
-            .await
+        let session_ids: Vec<String> = outputs
+            .iter()
+            .map(|output| output.session_id.clone())
+            .collect::<HashSet<_>>()
             .into_iter()
-            .filter_map(|(session_id, streamer_id)| {
-                streamer_id.map(|streamer_id| (session_id, streamer_id))
-            })
-            .collect()
+            .collect();
+        match state
+            .session_repository
+            .get_sessions_by_ids(&session_ids)
+            .await
+        {
+            Ok(sessions) => sessions
+                .into_iter()
+                .map(|session| (session.id, session.streamer_id))
+                .collect(),
+            Err(error) => {
+                tracing::warn!(%error, "failed to resolve sessions for output list");
+                HashMap::new()
+            }
+        }
     } else {
         HashMap::new()
     };

--- a/rust-srec/src/api/routes/streamers.rs
+++ b/rust-srec/src/api/routes/streamers.rs
@@ -312,42 +312,43 @@ pub async fn list_streamers(
     // Get streamer manager from state
     let streamer_manager = &state.streamer_manager;
 
-    // Get all streamers from manager
-    let mut streamers = streamer_manager.get_all();
-
-    // Apply filters
-    if let Some(platform) = &filters.platform {
-        streamers.retain(|s| &s.platform_config_id == platform);
-    }
-    if let Some(template) = &filters.template {
-        streamers.retain(|s| s.template_config_id.as_ref() == Some(template));
-    }
-    if filters.template_unassigned == Some(true) {
-        streamers.retain(|s| s.template_config_id.is_none());
-    }
-    if let Some(state_str) = &filters.state
-        && !state_str.is_empty()
-    {
-        let states: Vec<StreamerState> = state_str
-            .split(',')
-            .filter_map(|s| StreamerState::parse(&s.trim().to_uppercase()))
-            .collect();
-        streamers.retain(|s| states.contains(&s.state));
-    }
-    if let Some(priority) = &filters.priority {
-        streamers.retain(|s| s.priority == *priority);
-    }
-    if let Some(enabled) = filters.enabled {
-        streamers.retain(|s| (s.state != StreamerState::Disabled) == enabled);
-    }
-    if let Some(search) = &filters.search
-        && !search.is_empty()
-    {
-        let search = search.to_lowercase();
-        streamers.retain(|s| {
-            s.name.to_lowercase().contains(&search) || s.url.to_lowercase().contains(&search)
+    // Resolve every filter once, then clone only the matching entries out of
+    // the manager's map: a narrow filter (the dashboard's `state=LIVE`) must
+    // not copy every streamer first.
+    let platform = filters.platform.as_deref();
+    let template = filters.template.as_deref();
+    let template_unassigned = filters.template_unassigned == Some(true);
+    let states: Option<Vec<StreamerState>> = filters
+        .state
+        .as_deref()
+        .filter(|state_str| !state_str.is_empty())
+        .map(|state_str| {
+            state_str
+                .split(',')
+                .filter_map(|s| StreamerState::parse(&s.trim().to_uppercase()))
+                .collect()
         });
-    }
+    let priority = filters.priority.as_ref();
+    let enabled = filters.enabled;
+    let search = filters
+        .search
+        .as_deref()
+        .filter(|search| !search.is_empty())
+        .map(str::to_lowercase);
+
+    let mut streamers = streamer_manager.get_filtered(|s| {
+        platform.is_none_or(|platform| s.platform_config_id == platform)
+            && template.is_none_or(|template| s.template_config_id.as_deref() == Some(template))
+            && (!template_unassigned || s.template_config_id.is_none())
+            && states
+                .as_ref()
+                .is_none_or(|states| states.contains(&s.state))
+            && priority.is_none_or(|priority| s.priority == *priority)
+            && enabled.is_none_or(|enabled| (s.state != StreamerState::Disabled) == enabled)
+            && search.as_ref().is_none_or(|search| {
+                s.name.to_lowercase().contains(search) || s.url.to_lowercase().contains(search)
+            })
+    });
 
     // Sort for stable pagination
     let sort_by = filters.sort_by.as_deref();

--- a/rust-srec/src/database/models/dag.rs
+++ b/rust-srec/src/database/models/dag.rs
@@ -85,6 +85,21 @@ impl DagExecutionDbModel {
         }
     }
 
+    /// Read only the `name` field of `dag_definition`.
+    ///
+    /// List views need the name alone; deserialising every step and its
+    /// processor config through `get_dag_definition` is wasted work there.
+    pub fn dag_definition_name(&self) -> Option<String> {
+        #[derive(Deserialize)]
+        struct DagDefinitionName {
+            name: String,
+        }
+
+        serde_json::from_str::<DagDefinitionName>(&self.dag_definition)
+            .ok()
+            .map(|definition| definition.name)
+    }
+
     /// Get the DAG pipeline definition.
     pub fn get_dag_definition(&self) -> Option<DagPipelineDefinition> {
         json::parse_optional(

--- a/rust-srec/src/database/repositories/session.rs
+++ b/rust-srec/src/database/repositories/session.rs
@@ -15,6 +15,18 @@ use sqlx::SqlitePool;
 pub trait SessionRepository: Send + Sync {
     // Live Sessions
     async fn get_session(&self, id: &str) -> Result<LiveSessionDbModel>;
+    /// Fetch several sessions in one round trip. Ids with no row are skipped.
+    async fn get_sessions_by_ids(&self, ids: &[String]) -> Result<Vec<LiveSessionDbModel>> {
+        let mut sessions = Vec::with_capacity(ids.len());
+        for id in ids {
+            match self.get_session(id).await {
+                Ok(session) => sessions.push(session),
+                Err(Error::NotFound { .. }) => {}
+                Err(error) => return Err(error),
+            }
+        }
+        Ok(sessions)
+    }
     async fn get_active_session_for_streamer(
         &self,
         streamer_id: &str,
@@ -216,6 +228,25 @@ impl SessionRepository for SqlxSessionRepository {
             .fetch_optional(&self.pool)
             .await?
             .ok_or_else(|| Error::not_found("LiveSession", id))
+    }
+
+    async fn get_sessions_by_ids(&self, ids: &[String]) -> Result<Vec<LiveSessionDbModel>> {
+        if ids.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let mut builder =
+            sqlx::QueryBuilder::<sqlx::Sqlite>::new("SELECT * FROM live_sessions WHERE id IN (");
+        let mut separated = builder.separated(", ");
+        for id in ids {
+            separated.push_bind(id);
+        }
+        separated.push_unseparated(")");
+
+        Ok(builder
+            .build_query_as::<LiveSessionDbModel>()
+            .fetch_all(&self.pool)
+            .await?)
     }
 
     async fn get_active_session_for_streamer(

--- a/rust-srec/src/streamer/manager.rs
+++ b/rust-srec/src/streamer/manager.rs
@@ -543,6 +543,20 @@ where
             .collect()
     }
 
+    /// Clone only the streamers `predicate` accepts. `list_streamers` pages a
+    /// filtered view of the map, so filtering during the shard walk copies the
+    /// matching entries instead of every `StreamerMetadata`.
+    pub fn get_filtered(
+        &self,
+        predicate: impl Fn(&StreamerMetadata) -> bool,
+    ) -> Vec<StreamerMetadata> {
+        self.metadata
+            .iter()
+            .filter(|entry| predicate(entry.value()))
+            .map(|entry| entry.value().clone())
+            .collect()
+    }
+
     /// Get all active streamers.
     ///
     /// Returns streamers in active states (NotLive, Live, OutOfSchedule, InspectingLive).


### PR DESCRIPTION
## What changed?

Follow-up to #804 on the request side of the polled pages. Four handlers did per-row work that scales with page size or with the number of streamers, on endpoints the frontend polls every 5 to 10 seconds.

- **DAG list (`GET /api/pipeline/dags`, polled every 10 s on the jobs page).** Streamer names were resolved with one `get_streamer` query per distinct streamer on the page, fanned out with `join_all`. It now uses the existing `get_streamers_by_ids` batch query: one round trip for the page. The DAG name was read by deserialising the whole `dag_definition` JSON, every step and processor config included. New `DagExecutionDbModel::dag_definition_name` deserialises only the `name` field.
- **Outputs list (`GET /api/pipeline/outputs`, polled every 10 s).** Each distinct session on the page was fetched with its own `get_session` query to find its streamer. New `SessionRepository::get_sessions_by_ids` does it in one `WHERE id IN (...)` query. The trait method has a per-id default so the test repository in `pipeline::manager::tests` keeps compiling unchanged.
- **Streamers list (`GET /api/streamers`, polled every 5 s by the dashboard with `state=LIVE` and by the streamers page).** `StreamerManager::get_all` cloned every `StreamerMetadata` out of the map and the handler then discarded most of them with `retain`. New `StreamerManager::get_filtered` evaluates a predicate during the shard walk and clones only matches. The handler resolves every filter once and passes one predicate, so the dashboard's LIVE poll copies a handful of entries instead of the whole map.
- **Frontend SSR proxy (`fetchBackend`).** Two `console.log` lines ran per proxied request, one including a prefix of the access token. The trace is now behind `import.meta.env.DEV` and no longer prints token material.

Behaviour on lookup failure is unchanged: a failed batch query logs a warning and blanks the display names or streamer ids, which is what the per-row `.ok()` did before.

## Scope

- Affected components: backend, frontend
- Breaking change: no. Same responses, same ordering, same filters. `SessionRepository` gains a method with a default implementation.

## How to test

```
cargo test -p rust-srec --lib
cd rust-srec/frontend && pnpm lint && pnpm typecheck && pnpm test
```

Open the dashboard and the pipeline jobs and outputs pages with several streamers and DAGs, and confirm names, streamer links and filters render as before.

## Verification

Per request, worst case at the 100-row page cap:

| Endpoint | Before | After |
|---|---|---|
| DAG list | up to 100 streamer queries + 100 full definition parses | 1 query + 100 name-only parses |
| Outputs list | up to 100 session queries | 1 query |
| Streamers list, `state=LIVE` | clone every streamer, then filter | clone only LIVE streamers |
| SSR proxy | 2 stdout writes per request | none in production |

`cargo fmt --all` clean. `cargo clippy -p rust-srec --lib --tests` clean. `cargo test -p rust-srec --lib`: 1623 passed, 0 failed, 1 ignored. Frontend: oxlint clean, `tsc --noEmit` clean, oxfmt clean, vitest 197 passed.

## Checklist

- [x] I ran formatting (`cargo fmt --all`) if Rust code changed
- [x] I ran lint (`cargo clippy ...`) if Rust code changed
- [x] I ran tests (`cargo test` or `cargo nextest run`) if feasible
- [x] I updated docs/config examples if behavior changed (none needed)
- [x] I avoided logging secrets and redacted sensitive info in screenshots/logs

## Related issues

Follow-up to #804.
