### PR TITLE
perf(recording): remove per-byte and per-tag overhead around the FLV pipeline

### DIFF
--- a/crates/flv-fix/src/operators/timing_repair.rs
+++ b/crates/flv-fix/src/operators/timing_repair.rs
@@ -102,14 +102,16 @@ struct TimingState {
     /// Current accumulated offset to apply to timestamps
     delta: i64,
 
-    /// Last tag processed (any type)
-    last_tag: Option<FlvTag>,
+    /// Timestamp of the last tag processed (any type). Only the timestamps
+    /// are kept: holding the tags themselves would pin their payload slices,
+    /// and with them the decoder's read buffer, until the next tag arrives.
+    last_timestamp_ms: Option<u32>,
 
-    /// Last audio tag processed
-    last_audio_tag: Option<FlvTag>,
+    /// Timestamp of the last audio tag processed
+    last_audio_timestamp_ms: Option<u32>,
 
-    /// Last video tag processed
-    last_video_tag: Option<FlvTag>,
+    /// Timestamp of the last video tag processed
+    last_video_timestamp_ms: Option<u32>,
 
     /// Video frame rate in frames per second
     frame_rate: f64,
@@ -146,9 +148,9 @@ impl TimingState {
 
         Self {
             delta: 0,
-            last_tag: None,
-            last_audio_tag: None,
-            last_video_tag: None,
+            last_timestamp_ms: None,
+            last_audio_timestamp_ms: None,
+            last_video_timestamp_ms: None,
             frame_rate: config.default_frame_rate,
             audio_rate: config.default_audio_rate,
             video_frame_interval,
@@ -175,9 +177,9 @@ impl TimingState {
     /// Reset the timing state
     fn reset(&mut self, config: &TimingRepairConfig) {
         self.delta = 0;
-        self.last_tag = None;
-        self.last_audio_tag = None;
-        self.last_video_tag = None;
+        self.last_timestamp_ms = None;
+        self.last_audio_timestamp_ms = None;
+        self.last_video_timestamp_ms = None;
         self.frame_rate = config.default_frame_rate;
         self.video_frame_interval = Self::calculate_video_frame_interval(config.default_frame_rate);
         self.audio_rate = config.default_audio_rate;
@@ -258,20 +260,20 @@ impl TimingState {
         let expected = Self::apply_delta(current, self.delta);
 
         if tag.is_audio_tag() {
-            if let Some(ref last) = self.last_audio_tag {
+            if let Some(last_ts) = self.last_audio_timestamp_ms {
                 // Treat equal timestamps as valid: an audio tag sharing the previous
                 // audio tag's timestamp is not a backwards jump, so only a strictly
                 // smaller `expected` is a rebound.
-                expected < last.timestamp_ms
+                expected < last_ts
             } else {
                 false
             }
         } else if tag.is_video_tag() {
-            if let Some(ref last) = self.last_video_tag {
+            if let Some(last_ts) = self.last_video_timestamp_ms {
                 // Treat equal timestamps as valid: an enhanced METADATA video packet
                 // (tag type 9) legitimately shares its coded frame's timestamp, so only
                 // a strictly smaller `expected` is a rebound.
-                expected < last.timestamp_ms
+                expected < last_ts
             } else {
                 false
             }
@@ -282,18 +284,16 @@ impl TimingState {
 
     /// Check if there's a discontinuity in timestamps
     fn is_timestamp_discontinuous(&self, tag: &FlvTag, config: &TimingRepairConfig) -> bool {
-        if self.last_tag.is_none() {
+        let Some(last_ts) = self.last_timestamp_ms else {
             return false;
-        }
-
-        let last = self.last_tag.as_ref().unwrap();
+        };
         let current = tag.timestamp_ms;
 
         let expected = Self::apply_delta(current, self.delta);
 
         // Calculate the difference between expected and last timestamp
         // Convert to i64 before subtraction to avoid overflow
-        let diff: i64 = (expected as i64) - (last.timestamp_ms as i64);
+        let diff: i64 = (expected as i64) - (last_ts as i64);
 
         // Determine threshold based on media type, considering rounding errors
         let base_threshold = match tag.tag_type() {
@@ -315,7 +315,7 @@ impl TimingState {
         match config.strategy {
             RepairStrategy::Strict => {
                 // In strict mode, we check if the timestamp differs from what we'd expect
-                if tag.is_video_tag() && self.last_video_tag.is_some() {
+                if tag.is_video_tag() && self.last_video_timestamp_ms.is_some() {
                     diff < 0 || diff > threshold.into()
                 } else {
                     // For non-video tags or when no video history exists
@@ -330,26 +330,23 @@ impl TimingState {
     fn calculate_delta_correction(&mut self, tag: &FlvTag) -> i64 {
         let current = tag.timestamp_ms;
         let mut new_delta = self.delta;
-        let last_ts = self.last_tag.as_ref().map(|t| t.timestamp_ms).unwrap_or(0);
+        let last_ts = self.last_timestamp_ms.unwrap_or(0);
 
-        if let Some(last_video) = self.last_video_tag.as_ref().filter(|_| tag.is_video_tag()) {
+        if let Some(last_video_ts) = self.last_video_timestamp_ms.filter(|_| tag.is_video_tag()) {
             // Calculate ideal next frame timestamp; saturating_add keeps the u32 timeline
             // from wrapping near u32::MAX after ~49.7 days accumulated in one segment.
-            let ideal_next_ts = last_video
-                .timestamp_ms
-                .saturating_add(self.video_frame_interval);
+            let ideal_next_ts = last_video_ts.saturating_add(self.video_frame_interval);
 
             new_delta = ideal_next_ts as i64 - current as i64;
-        } else if let Some(last_audio) = self.last_audio_tag.as_ref().filter(|_| tag.is_audio_tag())
+        } else if let Some(last_audio_ts) =
+            self.last_audio_timestamp_ms.filter(|_| tag.is_audio_tag())
         {
-            let ideal_next_ts = last_audio
-                .timestamp_ms
-                .saturating_add(self.audio_sample_interval);
+            let ideal_next_ts = last_audio_ts.saturating_add(self.audio_sample_interval);
             new_delta = ideal_next_ts as i64 - current as i64;
-        } else if let Some(last) = &self.last_tag {
+        } else if let Some(last_ts) = self.last_timestamp_ms {
             // No type-specific last tag, use generic last tag
             let interval = max(self.video_frame_interval, self.audio_sample_interval);
-            new_delta = last.timestamp_ms.saturating_add(interval) as i64 - current as i64;
+            new_delta = last_ts.saturating_add(interval) as i64 - current as i64;
         }
 
         let expected = Self::apply_delta(current, new_delta);
@@ -380,11 +377,11 @@ impl TimingState {
     }
 
     fn update_last_tags(&mut self, tag: &FlvTag) {
-        self.last_tag = Some(tag.clone());
+        self.last_timestamp_ms = Some(tag.timestamp_ms);
         if tag.is_audio_tag() {
-            self.last_audio_tag = Some(tag.clone());
+            self.last_audio_timestamp_ms = Some(tag.timestamp_ms);
         } else if tag.is_video_tag() {
-            self.last_video_tag = Some(tag.clone());
+            self.last_video_timestamp_ms = Some(tag.timestamp_ms);
         }
     }
 }
@@ -552,7 +549,7 @@ impl Processor<FlvData> for TimingRepairOperator {
                         "{} TimingRepair: Timestamp rebound detected: {}ms, last ts: {}ms,  would go back in time - applying correction delta: {}ms",
                         self.context.name,
                         tag.timestamp_ms,
-                        self.state.last_tag.as_ref().map_or(0, |t| t.timestamp_ms),
+                        self.state.last_timestamp_ms.unwrap_or(0),
                         new_delta
                     );
 
@@ -568,7 +565,7 @@ impl Processor<FlvData> for TimingRepairOperator {
                         "{} TimingRepair: Timestamp discontinuity detected: {}ms, last ts: {}ms, applying correction delta: {}ms",
                         self.context.name,
                         tag.timestamp_ms,
-                        self.state.last_tag.as_ref().map_or(0, |t| t.timestamp_ms),
+                        self.state.last_timestamp_ms.unwrap_or(0),
                         new_delta
                     );
 
@@ -584,15 +581,13 @@ impl Processor<FlvData> for TimingRepairOperator {
                             "{} TimingRepair: Negative timestamp detected, applying frame-rate aware correction",
                             self.context.name
                         );
-                        if let Some(last) = &self.state.last_tag {
+                        if let Some(last_ts) = self.state.last_timestamp_ms {
                             if tag.is_video_tag() {
-                                last.timestamp_ms
-                                    .saturating_add(self.state.video_frame_interval)
+                                last_ts.saturating_add(self.state.video_frame_interval)
                             } else if tag.is_audio_tag() {
-                                last.timestamp_ms
-                                    .saturating_add(self.state.audio_sample_interval)
+                                last_ts.saturating_add(self.state.audio_sample_interval)
                             } else {
-                                last.timestamp_ms.saturating_add(max(
+                                last_ts.saturating_add(max(
                                     self.state.video_frame_interval,
                                     self.state.audio_sample_interval,
                                 ))

--- a/crates/flv-fix/src/utils/file_utils.rs
+++ b/crates/flv-fix/src/utils/file_utils.rs
@@ -4,7 +4,6 @@ use std::{
     path::PathBuf,
 };
 
-use bytes::Bytes;
 use flv::{FlvWriter, tag::FlvTagType};
 use tracing::debug;
 
@@ -23,7 +22,7 @@ pub fn write_flv_tag<T: Write + Seek>(
     file_handle.seek(io::SeekFrom::Start(position))?;
 
     let mut flv_writer = FlvWriter::new(file_handle)?;
-    flv_writer.write_tag(tag_type, Bytes::copy_from_slice(data), timestamp)?;
+    flv_writer.write_tag(tag_type, data, timestamp)?;
     let file = flv_writer.into_inner()?;
     file.flush()?;
 

--- a/crates/flv/src/writer.rs
+++ b/crates/flv/src/writer.rs
@@ -90,7 +90,7 @@ impl<W: Write + Seek> FlvWriter<W> {
     pub fn write_tag(
         &mut self,
         tag_type: FlvTagType,
-        data: Bytes,
+        data: &[u8],
         timestamp_ms: u32,
     ) -> io::Result<()> {
         self.write_tag_with_filter(tag_type, false, data, timestamp_ms)
@@ -100,7 +100,7 @@ impl<W: Write + Seek> FlvWriter<W> {
         &mut self,
         tag_type: FlvTagType,
         is_filtered: bool,
-        data: Bytes,
+        data: &[u8],
         timestamp_ms: u32,
     ) -> io::Result<()> {
         let data_size = data.len() as u32;
@@ -111,7 +111,7 @@ impl<W: Write + Seek> FlvWriter<W> {
         self.writer.write_all(&header_bytes)?;
 
         // Write tag data
-        self.writer.write_all(&data)?;
+        self.writer.write_all(data)?;
 
         // Update previous tag size
         self.previous_tag_size = data_size + TAG_HEADER_SIZE as u32; // data size + tag header size
@@ -130,7 +130,7 @@ impl<W: Write + Seek> FlvWriter<W> {
         self.write_tag_with_filter(
             tag.tag_type(),
             tag.is_filtered(),
-            tag.data().clone(),
+            tag.data(),
             tag.timestamp_ms,
         )?;
         Ok(())
@@ -166,7 +166,7 @@ impl<W: Write + Seek> FlvWriter<W> {
         Amf0Encoder::encode_object(&mut buffer, &amf_properties)?;
 
         // Write script tag
-        self.write_tag(FlvTagType::ScriptData, Bytes::from(buffer), 0)
+        self.write_tag(FlvTagType::ScriptData, &buffer, 0)
             .map_err(Amf0WriteError::Io)
     }
 
@@ -188,7 +188,7 @@ impl<W: Write + Seek> FlvWriter<W> {
             ));
         }
 
-        self.write_tag(FlvTagType::Video, data, timestamp_ms)
+        self.write_tag(FlvTagType::Video, &data, timestamp_ms)
     }
 
     /// Writes audio data to the output
@@ -209,7 +209,7 @@ impl<W: Write + Seek> FlvWriter<W> {
             ));
         }
 
-        self.write_tag(FlvTagType::Audio, data, timestamp_ms)
+        self.write_tag(FlvTagType::Audio, &data, timestamp_ms)
     }
 
     /// Flushes any buffered data to the underlying writer

--- a/crates/mesio/src/flv/flv_downloader.rs
+++ b/crates/mesio/src/flv/flv_downloader.rs
@@ -162,14 +162,12 @@ impl FlvDownloader {
     where
         R: tokio::io::AsyncRead + Send + 'static,
     {
-        // Determine optimal buffer size based on expected content
-        // Use larger buffers (at least 64KB) for better throughput, as most modern networks
-        // can easily saturate smaller buffers
+        // FlvDecoderStream reads straight into its own read buffer of this
+        // size, and BytesStreamReader already hands out whole network chunks,
+        // so a BufReader in between would only copy every byte a second time.
         let buffer_size = self.config.buffer_size.max(64 * 1024);
 
-        let buffered_reader = tokio::io::BufReader::with_capacity(buffer_size, reader);
-        let pinned_reader = Box::pin(buffered_reader);
-        let flv_stream = FlvDecoderStream::with_capacity(pinned_reader, buffer_size);
+        let flv_stream = FlvDecoderStream::with_capacity(Box::pin(reader), buffer_size);
         flv_stream
             .map(|result| match result {
                 Ok(data) => Ok(data),

--- a/rust-srec/src/downloader/engine/mesio/helpers.rs
+++ b/rust-srec/src/downloader/engine/mesio/helpers.rs
@@ -308,11 +308,16 @@ pub(super) async fn consume_stream<T: Send, E: Display>(
 ) -> Option<(DownloadFailureKind, String)> {
     let mut stream = std::pin::pin!(stream);
     let mut stream_error: Option<(DownloadFailureKind, String)> = None;
+    // One wait-list registration per token for the whole stream. A fresh
+    // `cancelled()` future inside each `select!` would register and
+    // deregister on every item, once to receive it and once to forward it.
+    let mut parent_cancelled = std::pin::pin!(context.parent_token.cancelled());
+    let mut child_cancelled = std::pin::pin!(context.child_token.cancelled());
 
     loop {
         let result = tokio::select! {
             biased;
-            _ = context.parent_token.cancelled() => {
+            _ = &mut parent_cancelled => {
                 debug!(
                     protocol = context.protocol,
                     streamer_id = context.streamer_id,
@@ -320,7 +325,7 @@ pub(super) async fn consume_stream<T: Send, E: Display>(
                 );
                 break;
             }
-            _ = context.child_token.cancelled() => {
+            _ = &mut child_cancelled => {
                 debug!(
                     protocol = context.protocol,
                     streamer_id = context.streamer_id,
@@ -339,7 +344,7 @@ pub(super) async fn consume_stream<T: Send, E: Display>(
                 inspect(&item);
                 let send_result = tokio::select! {
                     biased;
-                    _ = context.parent_token.cancelled() => {
+                    _ = &mut parent_cancelled => {
                         debug!(
                             protocol = context.protocol,
                             streamer_id = context.streamer_id,
@@ -347,7 +352,7 @@ pub(super) async fn consume_stream<T: Send, E: Display>(
                         );
                         break;
                     }
-                    _ = context.child_token.cancelled() => {
+                    _ = &mut child_cancelled => {
                         debug!(
                             protocol = context.protocol,
                             streamer_id = context.streamer_id,
@@ -377,7 +382,7 @@ pub(super) async fn consume_stream<T: Send, E: Display>(
                 stream_error = Some((kind, msg.clone()));
                 let send_result = tokio::select! {
                     biased;
-                    _ = context.parent_token.cancelled() => {
+                    _ = &mut parent_cancelled => {
                         debug!(
                             protocol = context.protocol,
                             streamer_id = context.streamer_id,
@@ -385,7 +390,7 @@ pub(super) async fn consume_stream<T: Send, E: Display>(
                         );
                         break;
                     }
-                    _ = context.child_token.cancelled() => {
+                    _ = &mut child_cancelled => {
                         debug!(
                             protocol = context.protocol,
                             streamer_id = context.streamer_id,


### PR DESCRIPTION
## What changed?

Follow-up to #804, #805 and #806, this time on the recording data path. I traced the FLV path from `reqwest` through `FlvDecoderStream`, the operator chain and `WriterTask` to disk. The tag parser is zero-copy and the file writer flushes a 1 MiB buffer about once a second, so those stay as they are. The costs were in the plumbing around them.

- **A second copy of every downloaded byte.** `FlvDownloader::create_decoder_stream` wrapped the reader in a 64 KiB `tokio::io::BufReader` before `FlvDecoderStream`. The decoder's `FramedRead` reads into its own 64 KiB buffer, and `BytesStreamReader` already serves whole network chunks, so the `BufReader` only added a memcpy per byte and 64 KiB of resident buffer per stream. It is gone.
- **Retained tags pinning the read buffer.** `TimingRepairOperator` cloned the last tag, last audio tag and last video tag on every tag, but every consumer read only `timestamp_ms`. Each clone kept a payload slice alive, and with it the decoder's whole read buffer allocation, until the next tag replaced it. The state now holds three `Option<u32>` timestamps.
- **Cancellation wait-list churn per tag.** `consume_stream` created fresh `cancelled()` futures for the parent and child tokens inside every `select!`, and there are two selects per item, so each tag registered and deregistered on both tokens' wait lists twice. One pinned future per token now lives for the whole stream.
- **A refcount bump per tag in the writer.** `FlvWriter::write_tag` and `write_tag_with_filter` took `Bytes` by value, so `write_tag_f` cloned the payload handle just to borrow it. They take `&[u8]`; `write_flv_tag` in flv-fix no longer materialises a `Bytes` for the call either.

Left alone on purpose: the duplicate-tag filter CRC over every payload, and the pipeline output channel sizing. Both are measurable but change behaviour or backpressure, and neither is a clear win without a benchmark.

## Scope

- Affected components: crates (`mesio`, `flv`, `flv-fix`), backend (`downloader::engine::mesio::helpers`)
- Breaking change: no user-facing change. Within the workspace, `FlvWriter::write_tag` and `write_tag_with_filter` now take `&[u8]` instead of `Bytes`; all callers are updated and the desktop crate has none.

## How to test

```
cargo test -p flv -p flv-fix -p mesio
cargo test -p rust-srec --lib downloader::
```

Record an FLV stream and confirm the output plays and the timing-repair log lines look as before.

## Verification

Per stream at 5 Mbps and 60 tags/s, the removed work is roughly 625 KB/s of extra memcpy, three payload-handle clones plus one for the writer per tag, and eight wait-list lock/unlock pairs per tag. Per-stream CPU savings are small in absolute terms; the memory effect of the timing-repair change is up to three 64 KiB read buffers per stream no longer held past their tag.

`cargo fmt --all` clean. `cargo clippy -p mesio -p flv -p flv-fix -p rust-srec --lib --tests` clean. `cargo check --workspace --all-targets` clean apart from the desktop crate, which needs GTK system libraries this machine lacks. Tests: flv 95 passed, flv-fix 94 passed, mesio 15 passed, rust-srec downloader 188 passed.

## Checklist

- [x] I ran formatting (`cargo fmt --all`) if Rust code changed
- [x] I ran lint (`cargo clippy ...`) if Rust code changed
- [x] I ran tests (`cargo test` or `cargo nextest run`) if feasible
- [x] I updated docs/config examples if behavior changed (none needed)
- [x] I avoided logging secrets and redacted sensitive info in screenshots/logs

## Related issues

Follow-up to #804, #805, #806.
