### PR TITLE
perf(danmu): skip undecoded frames and borrow fields in the chat decoders

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8095,6 +8095,7 @@ checksum = "b5772d71c9be8a8a6ac2117d949c5b224c1b72241bb611d9a3012edcf8af7812"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",
+ "rand 0.10.2",
  "serde_core",
  "wasm-bindgen",
 ]

--- a/crates/platforms/Cargo.toml
+++ b/crates/platforms/Cargo.toml
@@ -60,7 +60,7 @@ rand = { workspace = true }
 # module in lib.rs when a platform requires JS-based signing).
 # rquickjs = { version = "0.12.0", optional = true, features = ["full-async"] }
 
-uuid  = { workspace = true, features = ["v4"]}
+uuid  = { workspace = true, features = ["v4", "fast-rng"]}
 m3u8-rs = { workspace = true }
 md-5 = { workspace = true }
 aes = { workspace = true }

--- a/crates/platforms/src/extractor/platforms/bilibili/danmu.rs
+++ b/crates/platforms/src/extractor/platforms/bilibili/danmu.rs
@@ -97,7 +97,9 @@ struct AuthData {
 /// Decoded packet
 struct DecodedPacket {
     operation: u32,
-    body: Vec<u8>,
+    /// Slice of the frame (or of the decompressed buffer) the packet came
+    /// from; refcounted, so packets never copy their body.
+    body: Bytes,
 }
 
 /// Bilibili Danmu Protocol Implementation
@@ -330,7 +332,7 @@ impl BilibiliDanmuProtocol {
     }
 
     /// Decode packets, handling compression.
-    fn decode_packets(data: &[u8]) -> Vec<DecodedPacket> {
+    fn decode_packets(data: &Bytes) -> Vec<DecodedPacket> {
         let mut packets = Vec::new();
         let mut offset = 0;
 
@@ -351,18 +353,18 @@ impl BilibiliDanmuProtocol {
             match version {
                 ver::ZLIB => {
                     if let Ok(decompressed) = decompress_zlib(body) {
-                        packets.extend(Self::decode_packets(&decompressed));
+                        packets.extend(Self::decode_packets(&Bytes::from(decompressed)));
                     }
                 }
                 ver::BROTLI => {
                     if let Ok(decompressed) = decompress_brotli(body) {
-                        packets.extend(Self::decode_packets(&decompressed));
+                        packets.extend(Self::decode_packets(&Bytes::from(decompressed)));
                     }
                 }
                 ver::RAW_JSON | ver::POPULARITY => {
                     packets.push(DecodedPacket {
                         operation,
-                        body: body.to_vec(),
+                        body: data.slice(offset + 16..offset + packet_len),
                     });
                 }
                 _ => {
@@ -376,8 +378,37 @@ impl BilibiliDanmuProtocol {
         packets
     }
 
+    /// Commands `parse_notification` turns into items; everything else is
+    /// dropped.
+    fn handles_command(cmd_base: &str) -> bool {
+        matches!(
+            cmd_base,
+            "DANMU_MSG"
+                | "DANMU_MSG_MIRROR"
+                | "SEND_GIFT"
+                | "SUPER_CHAT_MESSAGE"
+                | "ROOM_CHANGE"
+                | "ROOM_LOCK"
+                | "CUT_OFF"
+        )
+    }
+
     /// Parse a notification message (op=5) into a danmu item.
     fn parse_notification(body: &[u8]) -> Option<DanmuItem> {
+        // Bilibili serialises `cmd` as the first key. Most notifications
+        // (INTERACT_WORD, ONLINE_RANK_*, WATCHED_CHANGE, STOP_LIVE_ROOM_LIST,
+        // ...) are dropped anyway, so when that layout holds and the command
+        // is not handled, skip the frame before it becomes a `Value` tree.
+        // Any other layout, or a command with escapes, takes the full parse.
+        if let Some(rest) = body.strip_prefix(b"{\"cmd\":\"")
+            && let Some(end) = rest.iter().position(|&b| b == b'"')
+            && let Ok(cmd) = std::str::from_utf8(&rest[..end])
+            && !cmd.contains('\\')
+            && !Self::handles_command(cmd.split(':').next().unwrap_or(cmd))
+        {
+            return None;
+        }
+
         let json: Value = serde_json::from_slice(body).ok()?;
         let cmd = json.get("cmd")?.as_str()?;
 
@@ -808,7 +839,7 @@ mod tests {
             let mut packet = vec![0_u8; 16];
             BigEndian::write_u32(&mut packet[0..4], packet_len);
 
-            assert!(BilibiliDanmuProtocol::decode_packets(&packet).is_empty());
+            assert!(BilibiliDanmuProtocol::decode_packets(&Bytes::from(packet)).is_empty());
         }
     }
 
@@ -817,7 +848,7 @@ mod tests {
         let mut packet = vec![0_u8; 16];
         BigEndian::write_u32(&mut packet[0..4], 17);
 
-        assert!(BilibiliDanmuProtocol::decode_packets(&packet).is_empty());
+        assert!(BilibiliDanmuProtocol::decode_packets(&Bytes::from(packet)).is_empty());
     }
 
     #[test]

--- a/crates/platforms/src/extractor/platforms/douyu/danmu.rs
+++ b/crates/platforms/src/extractor/platforms/douyu/danmu.rs
@@ -23,9 +23,9 @@ use tokio_tungstenite::tungstenite::http::HeaderMap;
 use super::URL_REGEX;
 use super::danmu_models::{
     DouyuChatMessage, DouyuGiftMessage, DouyuMessageType, create_join_group_message,
-    create_login_message, parse_message,
+    create_login_message,
 };
-use super::stt::{create_packet, parse_packets};
+use super::stt::{SttMap, create_packet, parse_packets, stt_decode, stt_message_type};
 
 /// Douyu WebSocket server URL
 const DOUYU_WS_URL: &str = "wss://danmuproxy.douyu.com:8502/";
@@ -57,7 +57,7 @@ impl DouyuDanmuProtocol {
     }
 
     /// Parse chat messages from STT payload.
-    fn parse_chat_message(map: &rustc_hash::FxHashMap<String, String>) -> Option<DanmuMessage> {
+    fn parse_chat_message(map: &SttMap<'_>) -> Option<DanmuMessage> {
         let chat = DouyuChatMessage::from_map(map)?;
 
         let mut danmu = DanmuMessage::chat(&chat.id, &chat.uid, &chat.nickname, &chat.content)
@@ -96,7 +96,7 @@ impl DouyuDanmuProtocol {
             reason = "retained for protocol variants and forward-compatible response handling"
         )
     )]
-    fn parse_gift_message(map: &rustc_hash::FxHashMap<String, String>) -> Option<DanmuMessage> {
+    fn parse_gift_message(map: &SttMap<'_>) -> Option<DanmuMessage> {
         let gift = DouyuGiftMessage::from_map(map)?;
 
         let danmu = DanmuMessage::gift(
@@ -184,10 +184,16 @@ impl DanmuProtocol for DouyuDanmuProtocol {
                 let mut items = Vec::new();
 
                 for payload in packets {
-                    let (msg_type, map) = parse_message(&payload);
+                    // Only chat messages are decoded; every other type is
+                    // dispatched on its `type` field alone, so uenter, dgb,
+                    // ranklist and the like never build a map.
+                    let msg_type = stt_message_type(&payload)
+                        .map(DouyuMessageType::from_str)
+                        .unwrap_or(DouyuMessageType::Unknown);
 
                     match msg_type {
                         DouyuMessageType::ChatMsg => {
+                            let map = stt_decode(&payload);
                             if let Some(danmu) = Self::parse_chat_message(&map) {
                                 items.push(DanmuItem::Message(danmu));
                             }

--- a/crates/platforms/src/extractor/platforms/douyu/danmu_models.rs
+++ b/crates/platforms/src/extractor/platforms/douyu/danmu_models.rs
@@ -4,7 +4,7 @@
 
 use rustc_hash::FxHashMap;
 
-use super::stt::{stt_decode, stt_encode};
+use super::stt::{SttMap, stt_encode};
 
 /// Message types used in the Douyu danmu protocol.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -126,20 +126,26 @@ pub struct DouyuChatMessage {
 
 impl DouyuChatMessage {
     /// Parse a chat message from decoded STT map.
-    pub fn from_map(map: &FxHashMap<String, String>) -> Option<Self> {
+    pub fn from_map(map: &SttMap<'_>) -> Option<Self> {
         // Required fields
-        let nickname = map.get("nn")?.clone();
-        let content = map.get("txt")?.clone();
+        let nickname = map.get("nn")?.to_string();
+        let content = map.get("txt")?.to_string();
 
         // Optional fields with defaults
-        let id = map.get("cid").cloned().unwrap_or_default();
-        let uid = map.get("uid").cloned().unwrap_or_default();
-        let room_id = map.get("rid").cloned().unwrap_or_default();
+        let id = map.get("cid").map(|s| s.to_string()).unwrap_or_default();
+        let uid = map.get("uid").map(|s| s.to_string()).unwrap_or_default();
+        let room_id = map.get("rid").map(|s| s.to_string()).unwrap_or_default();
         let level = map.get("level").and_then(|s| s.parse().ok()).unwrap_or(0);
 
-        let badge_name = map.get("bnn").cloned().filter(|s| !s.is_empty());
+        let badge_name = map
+            .get("bnn")
+            .map(|s| s.to_string())
+            .filter(|s| !s.is_empty());
         let badge_level = map.get("bl").and_then(|s| s.parse().ok());
-        let platform = map.get("plat").cloned().filter(|s| !s.is_empty());
+        let platform = map
+            .get("plat")
+            .map(|s| s.to_string())
+            .filter(|s| !s.is_empty());
         let noble_level = map.get("nl").and_then(|s| s.parse().ok());
 
         // Color is provided as an integer in the col field
@@ -199,17 +205,17 @@ pub struct DouyuGiftMessage {
 
 impl DouyuGiftMessage {
     /// Parse a gift message from decoded STT map.
-    pub fn from_map(map: &FxHashMap<String, String>) -> Option<Self> {
+    pub fn from_map(map: &SttMap<'_>) -> Option<Self> {
         // Required fields
-        let nickname = map.get("nn")?.clone();
-        let gift_id = map.get("gfid")?.clone();
+        let nickname = map.get("nn")?.to_string();
+        let gift_id = map.get("gfid")?.to_string();
 
         // Optional fields with defaults
-        let uid = map.get("uid").cloned().unwrap_or_default();
-        let room_id = map.get("rid").cloned().unwrap_or_default();
+        let uid = map.get("uid").map(|s| s.to_string()).unwrap_or_default();
+        let room_id = map.get("rid").map(|s| s.to_string()).unwrap_or_default();
         let gift_name = map
             .get("gfname")
-            .cloned()
+            .map(|s| s.to_string())
             .unwrap_or_else(|| "Gift".to_string());
         let gift_count = map.get("gfcnt").and_then(|s| s.parse().ok()).unwrap_or(1);
         let hits = map.get("hits").and_then(|s| s.parse().ok()).unwrap_or(0);
@@ -227,15 +233,20 @@ impl DouyuGiftMessage {
 }
 
 /// Parse the message type from an STT-decoded map.
-pub fn get_message_type(map: &FxHashMap<String, String>) -> DouyuMessageType {
+///
+/// The protocol reads the type with `stt_message_type` before deciding
+/// whether to decode at all; this map-based form remains for tests.
+#[cfg(test)]
+pub fn get_message_type(map: &SttMap<'_>) -> DouyuMessageType {
     map.get("type")
         .map(|s| DouyuMessageType::from_str(s))
         .unwrap_or(DouyuMessageType::Unknown)
 }
 
 /// Parse a raw STT payload and return the message type and decoded map.
-pub fn parse_message(payload: &str) -> (DouyuMessageType, FxHashMap<String, String>) {
-    let map = stt_decode(payload);
+#[cfg(test)]
+pub fn parse_message(payload: &str) -> (DouyuMessageType, SttMap<'_>) {
+    let map = super::stt::stt_decode(payload);
     let msg_type = get_message_type(&map);
     (msg_type, map)
 }

--- a/crates/platforms/src/extractor/platforms/douyu/stt.rs
+++ b/crates/platforms/src/extractor/platforms/douyu/stt.rs
@@ -10,8 +10,14 @@
 //!   - `/` → `@S`
 //!   - `@` → `@A`
 
+use std::borrow::Cow;
+
 use bytes::{BufMut, Bytes, BytesMut};
 use rustc_hash::FxHashMap;
+
+/// Key/value pairs of one decoded STT payload, borrowed from the payload
+/// wherever no `@A` / `@S` escape had to be rewritten.
+pub type SttMap<'a> = FxHashMap<Cow<'a, str>, Cow<'a, str>>;
 
 /// Magic number for client → server messages
 const CLIENT_MAGIC: [u8; 4] = [0xb1, 0x02, 0x00, 0x00];
@@ -44,9 +50,40 @@ pub fn stt_escape(s: &str) -> String {
 
 /// Unescape STT special characters.
 ///
-/// Converts `@A` back to `@` and `@S` back to `/`.
-pub fn stt_unescape(s: &str) -> String {
-    s.replace("@S", "/").replace("@A", "@")
+/// Converts `@A` back to `@` and `@S` back to `/`. Borrows the input when it
+/// contains no `@`, which is the case for almost every key and value.
+pub fn stt_unescape(s: &str) -> Cow<'_, str> {
+    if !s.contains('@') {
+        return Cow::Borrowed(s);
+    }
+    let mut out = String::with_capacity(s.len());
+    let mut chars = s.chars().peekable();
+    while let Some(ch) = chars.next() {
+        if ch == '@' {
+            match chars.peek() {
+                Some('S') => {
+                    chars.next();
+                    out.push('/');
+                    continue;
+                }
+                Some('A') => {
+                    chars.next();
+                    out.push('@');
+                    continue;
+                }
+                _ => {}
+            }
+        }
+        out.push(ch);
+    }
+    Cow::Owned(out)
+}
+
+/// Read the `type` field of an STT payload without decoding the rest.
+///
+/// Type names are plain identifiers, so the raw value is returned as is.
+pub fn stt_message_type(data: &str) -> Option<&str> {
+    data.split('/').find_map(|part| part.strip_prefix("type@="))
 }
 
 /// Encode a map of key-value pairs to STT format.
@@ -75,10 +112,10 @@ pub fn stt_encode(map: &FxHashMap<&str, &str>) -> String {
 /// # Example
 /// ```ignore
 /// let map = stt_decode("type@=loginreq/roomid@=123456/");
-/// assert_eq!(map.get("type"), Some(&"loginreq".to_string()));
+/// assert_eq!(map.get("type"), Some(&Cow::Borrowed("loginreq")));
 /// ```
-pub fn stt_decode(data: &str) -> FxHashMap<String, String> {
-    let mut map = FxHashMap::default();
+pub fn stt_decode(data: &str) -> SttMap<'_> {
+    let mut map = SttMap::default();
 
     // Split by `/` and filter out empty parts
     for part in data.split('/') {
@@ -130,7 +167,7 @@ pub fn create_packet(message: &str) -> Bytes {
 ///
 /// Returns the payload string and the number of bytes consumed.
 /// Returns None if the packet is incomplete or malformed.
-pub fn parse_packet(data: &[u8]) -> Option<(String, usize)> {
+pub fn parse_packet(data: &[u8]) -> Option<(Cow<'_, str>, usize)> {
     // Minimum packet size: 4 (len1) + 4 (len2) + 4 (magic) + 1 (null) = 13 bytes
     if data.len() < 13 {
         return None;
@@ -152,21 +189,19 @@ pub fn parse_packet(data: &[u8]) -> Option<(String, usize)> {
     let payload_end = total_size - 1;
 
     if payload_end <= payload_start {
-        return Some((String::new(), total_size));
+        return Some((Cow::Borrowed(""), total_size));
     }
 
     let payload = &data[payload_start..payload_end];
 
-    // Convert to string (lossy for robustness)
-    let payload_str = String::from_utf8_lossy(payload).to_string();
-
-    Some((payload_str, total_size))
+    // Borrowed unless the payload holds invalid UTF-8 that had to be replaced.
+    Some((String::from_utf8_lossy(payload), total_size))
 }
 
 /// Parse multiple packets from a buffer.
 ///
 /// Returns a vector of decoded payloads.
-pub fn parse_packets(data: &[u8]) -> Vec<String> {
+pub fn parse_packets(data: &[u8]) -> Vec<Cow<'_, str>> {
     let mut packets = Vec::new();
     let mut offset = 0;
 
@@ -224,15 +259,15 @@ mod tests {
     fn test_stt_decode() {
         let map = stt_decode("type@=loginreq/roomid@=123456/");
 
-        assert_eq!(map.get("type"), Some(&"loginreq".to_string()));
-        assert_eq!(map.get("roomid"), Some(&"123456".to_string()));
+        assert_eq!(map.get("type"), Some(&Cow::Borrowed("loginreq")));
+        assert_eq!(map.get("roomid"), Some(&Cow::Borrowed("123456")));
     }
 
     #[test]
     fn test_stt_decode_with_escaping() {
         let map = stt_decode("key@=value@Awith@Sslash/");
 
-        assert_eq!(map.get("key"), Some(&"value@with/slash".to_string()));
+        assert_eq!(map.get("key"), Some(&Cow::Borrowed("value@with/slash")));
     }
 
     #[test]
@@ -244,8 +279,8 @@ mod tests {
         let encoded = stt_encode(&original);
         let decoded = stt_decode(&encoded);
 
-        assert_eq!(decoded.get("type"), Some(&"test".to_string()));
-        assert_eq!(decoded.get("content"), Some(&"hello".to_string()));
+        assert_eq!(decoded.get("type"), Some(&Cow::Borrowed("test")));
+        assert_eq!(decoded.get("content"), Some(&Cow::Borrowed("hello")));
     }
 
     #[test]
@@ -283,9 +318,9 @@ mod tests {
         let (payload, _) = parse_packet(&packet).unwrap();
         let decoded = stt_decode(&payload);
 
-        assert_eq!(decoded.get("type"), Some(&"chatmsg".to_string()));
-        assert_eq!(decoded.get("nn"), Some(&"TestUser".to_string()));
-        assert_eq!(decoded.get("txt"), Some(&"Hello World!".to_string()));
+        assert_eq!(decoded.get("type"), Some(&Cow::Borrowed("chatmsg")));
+        assert_eq!(decoded.get("nn"), Some(&Cow::Borrowed("TestUser")));
+        assert_eq!(decoded.get("txt"), Some(&Cow::Borrowed("Hello World!")));
     }
 
     #[test]
@@ -323,7 +358,7 @@ mod tests {
 
         // Verify the decoded message type
         let decoded = stt_decode(&payload);
-        assert_eq!(decoded.get("type"), Some(&"mrkl".to_string()));
+        assert_eq!(decoded.get("type"), Some(&Cow::Borrowed("mrkl")));
     }
 
     #[test]

--- a/crates/platforms/src/extractor/platforms/twitch/danmu.rs
+++ b/crates/platforms/src/extractor/platforms/twitch/danmu.rs
@@ -44,8 +44,9 @@ impl TwitchDanmuProtocol {
             return None;
         }
 
-        // Parse tags
-        let mut tags = std::collections::HashMap::new();
+        // Parse tags. Keys and values borrow from `line`; only the three or
+        // four tags the message uses are copied out below.
+        let mut tags: std::collections::HashMap<&str, &str> = std::collections::HashMap::new();
         let mut remaining = line;
 
         if line.starts_with('@')
@@ -56,7 +57,7 @@ impl TwitchDanmuProtocol {
                 if let Some(eq_idx) = tag.find('=') {
                     let key = &tag[..eq_idx];
                     let value = &tag[eq_idx + 1..];
-                    tags.insert(key.to_string(), value.to_string());
+                    tags.insert(key, value);
                 }
             }
             remaining = &line[space_idx + 1..];
@@ -83,18 +84,15 @@ impl TwitchDanmuProtocol {
 
         let display_name = tags
             .get("display-name")
-            .cloned()
-            .unwrap_or_else(|| username.to_string());
+            .map_or_else(|| username.to_string(), |s| s.to_string());
 
         let user_id = tags
             .get("user-id")
-            .cloned()
-            .unwrap_or_else(|| username.to_string());
+            .map_or_else(|| username.to_string(), |s| s.to_string());
 
         let message_id = tags
             .get("id")
-            .cloned()
-            .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
+            .map_or_else(|| uuid::Uuid::new_v4().to_string(), |s| s.to_string());
 
         let mut msg = DanmuMessage::chat(message_id, user_id, display_name, content.trim());
 
@@ -102,7 +100,7 @@ impl TwitchDanmuProtocol {
         if let Some(color) = tags.get("color")
             && !color.is_empty()
         {
-            msg = msg.with_color(color);
+            msg = msg.with_color(*color);
         }
 
         // Add badges as metadata


### PR DESCRIPTION
## What changed?

Follow-up to #805 on the receive side of the danmu pipeline. Three platform decoders did per-message work for frames they then dropped, or allocated owned copies of fields they only read once.

- **Bilibili.** `parse_notification` deserialised every notification into a `serde_json::Value` tree and only then looked at `cmd`, although most commands (`INTERACT_WORD`, `ONLINE_RANK_*`, `WATCHED_CHANGE`, the periodic `STOP_LIVE_ROOM_LIST` with thousands of ids) are dropped. Bilibili serialises `cmd` as the first key, so when the body starts with `{"cmd":"` and the command is not one the decoder handles, the frame is skipped before any parse. Any other layout, or a command containing an escape, takes the full parse exactly as before, so nothing handled can be lost. `decode_packets` now slices the frame as `Bytes` instead of copying each packet body, and `uuid` gets its `fast-rng` feature so per-message ids no longer make a `getrandom` call each.
- **Douyu.** Every packet was STT-decoded into a `FxHashMap<String, String>` before its type was known, and `stt_unescape` ran two `replace` passes per key and per value. The protocol now reads the `type` field with `stt_message_type` and decodes only `chatmsg`. `stt_decode` returns an `SttMap` whose keys and values borrow from the payload, `stt_unescape` rewrites in one pass only when an `@` escape is present, and `parse_packet` returns the payload as a `Cow` instead of copying it. `get_message_type` and `parse_message` are now test-only.
- **Twitch.** IRC tags were collected into a `HashMap<String, String>` and three or four of them cloned back out. The map now borrows from the line.

## Scope

- Affected components: crates (`platforms-parser`)
- Breaking change: no. Within the crate, `stt_decode`, `stt_unescape`, `parse_packet` and `parse_packets` return borrowed types; nothing outside the Douyu module calls them.

## How to test

```
cargo test -p platforms-parser --lib
cargo test -p rust-srec --lib danmu::
```

Connect a Bilibili and a Douyu room and confirm chat, gifts and super chats still arrive.

## Verification

Timed by driving each protocol's `decode_message` with synthetic frames, 20k to 50k iterations, debug build, so absolute numbers are inflated but the ratios hold:

| Frame | Before | After |
|---|---|---|
| Bilibili `DANMU_MSG` (handled) | 25 µs | 26 µs, within run-to-run noise |
| Bilibili `ONLINE_RANK_COUNT` (dropped) | 7.5 µs | 0.7 µs |
| Bilibili `STOP_LIVE_ROOM_LIST`, 3000 ids (dropped) | 827 µs | 0.7 µs |
| Douyu `chatmsg` | 45 µs | 26 µs |
| Douyu `uenter` (dropped) | 27 µs | 0.4 µs |

An earlier version of the Bilibili change pre-parsed `cmd` with a borrowed serde struct; that still scanned the whole body and made handled messages 35% slower, which is why the prefix check replaced it.

`cargo fmt --all` clean. `cargo clippy -p platforms-parser -p rust-srec --lib --tests` clean. Tests: platforms-parser 234 passed, rust-srec danmu 33 passed.

## Checklist

- [x] I ran formatting (`cargo fmt --all`) if Rust code changed
- [x] I ran lint (`cargo clippy ...`) if Rust code changed
- [x] I ran tests (`cargo test` or `cargo nextest run`) if feasible
- [x] I updated docs/config examples if behavior changed (none needed)
- [x] I avoided logging secrets and redacted sensitive info in screenshots/logs

## Related issues

Follow-up to #805.
