### PR TITLE
perf(api): let the job log endpoint page by 1000 rows

### DIFF
--- a/rust-srec/src/api/routes/pipeline/jobs.rs
+++ b/rust-srec/src/api/routes/pipeline/jobs.rs
@@ -181,7 +181,12 @@ pub async fn list_job_logs(
 ) -> ApiResult<Json<PaginatedResponse<ApiJobLogEntry>>> {
     let pipeline_manager = &state.pipeline_manager;
 
-    let effective_limit = pagination.limit.min(100);
+    // Log rows are small and a job keeps up to
+    // MAX_PERSISTED_LOG_ROWS_PER_JOB of them. The job page polls its loaded
+    // pages while the job runs, so each poll costs one round trip per page;
+    // a larger page keeps that to a handful for long-running jobs.
+    const MAX_LOG_PAGE_SIZE: u32 = 1000;
+    let effective_limit = pagination.limit.min(MAX_LOG_PAGE_SIZE);
     let db_pagination = Pagination::new(effective_limit, pagination.offset);
 
     let (logs, total) = pipeline_manager


### PR DESCRIPTION
## What changed?

`list_job_logs` clamped every page to 100 rows, the same cap as the job and output lists. The job detail page requests 1000 rows per page, pages by whatever the server returns, and while the job is PROCESSING or PENDING refetches every loaded page every 2 seconds, which is how TanStack's `useInfiniteQuery` polls. A job at the `MAX_PERSISTED_LOG_ROWS_PER_JOB` cap of 5000 rows therefore became 50 pages, and a user who had scrolled through them cost 50 count-plus-select round trips per poll.

This endpoint now caps at 1000 rows, so the same job is five pages. Log rows are small, the query is an indexed range on `(job_id, created_at)`, and the frontend already asks for this size. The other list endpoints keep their 100-row cap.

Left alone: a cursor-based tail fetch would let the page poll only new rows, but the log ring buffer trims the oldest rows while a job runs, so offsets shift and a correct cursor needs an API addition. That is a feature change rather than a cap.

## Scope

- Affected components: backend (one handler constant)
- Breaking change: no. Clients asking for 100 or fewer rows see no difference.

## How to test

```
cargo test -p rust-srec --lib api::routes::pipeline
```

Open a running job with a few thousand log lines and confirm the log view still streams and scrolls.

## Verification

Per 2-second poll for a job at the 5000-row cap with all pages loaded: 50 round trips before, 5 after. `cargo fmt --all` clean, `cargo clippy -p rust-srec --lib --tests` clean, pipeline route tests 21 passed.

## Checklist

- [x] I ran formatting (`cargo fmt --all`) if Rust code changed
- [x] I ran lint (`cargo clippy ...`) if Rust code changed
- [x] I ran tests (`cargo test` or `cargo nextest run`) if feasible
- [x] I updated docs/config examples if behavior changed (none needed)
- [x] I avoided logging secrets and redacted sensitive info in screenshots/logs

## Related issues

Follow-up to #806.
