### PR TITLE
fix(web): detect HTTPS behind the bundled nginx so the session cookie is marked secure

### DIFF
--- a/rust-srec/docs/en/operations/production.md
+++ b/rust-srec/docs/en/operations/production.md
@@ -21,7 +21,7 @@ Keep the backend, database, configuration, and output paths on one trusted host.
 1. Use the [Docker deployment](../getting-started/docker.md) and set `VERSION=v0.5.1` for both images. Avoid `latest` where changes must be reviewed before rollout.
 2. Generate unique values for `JWT_SECRET` and `SESSION_SECRET`; store the `.env` file with restrictive permissions.
 3. Bind host ports to a private address or loopback. In Compose, a loopback-only mapping takes the form `127.0.0.1:15275:80` and `127.0.0.1:12555:8080`.
-4. Terminate HTTPS at a maintained reverse proxy and forward `Host`, `X-Forwarded-For`, and `X-Forwarded-Proto`. The session cookie is marked `Secure` automatically once the proxy sends `X-Forwarded-Proto: https` (an RFC 7239 `Forwarded: proto=https` also works). If the proxy cannot send either header, set `COOKIE_SECURE=true` explicitly.
+4. Terminate HTTPS at a maintained reverse proxy and forward `Host`, `X-Forwarded-For`, and `X-Forwarded-Proto`. The session cookie is marked `Secure` automatically once the proxy sends `X-Forwarded-Proto: https`. If the proxy cannot send that header, set `COOKIE_SECURE=true` explicitly.
 5. Put `DATA_DIR`, `CONFIG_DIR`, `OUTPUT_DIR`, and `LOG_DIR` on persistent storage. Size and monitor the output volume separately from the system disk.
 6. Set resource and application concurrency limits for the host. Start conservatively and load-test the expected number and bitrate of simultaneous streams.
 7. Configure notifications for recording failures, pipeline failures, credential expiry, and output-root write failures.

--- a/rust-srec/docs/en/operations/production.md
+++ b/rust-srec/docs/en/operations/production.md
@@ -21,7 +21,7 @@ Keep the backend, database, configuration, and output paths on one trusted host.
 1. Use the [Docker deployment](../getting-started/docker.md) and set `VERSION=v0.5.1` for both images. Avoid `latest` where changes must be reviewed before rollout.
 2. Generate unique values for `JWT_SECRET` and `SESSION_SECRET`; store the `.env` file with restrictive permissions.
 3. Bind host ports to a private address or loopback. In Compose, a loopback-only mapping takes the form `127.0.0.1:15275:80` and `127.0.0.1:12555:8080`.
-4. Terminate HTTPS at a maintained reverse proxy and forward `Host`, `X-Forwarded-For`, and `X-Forwarded-Proto`. Set `COOKIE_SECURE=true` after HTTPS is working.
+4. Terminate HTTPS at a maintained reverse proxy and forward `Host`, `X-Forwarded-For`, and `X-Forwarded-Proto`. The session cookie is marked `Secure` automatically once the proxy sends `X-Forwarded-Proto: https` (an RFC 7239 `Forwarded: proto=https` also works). If the proxy cannot send either header, set `COOKIE_SECURE=true` explicitly.
 5. Put `DATA_DIR`, `CONFIG_DIR`, `OUTPUT_DIR`, and `LOG_DIR` on persistent storage. Size and monitor the output volume separately from the system disk.
 6. Set resource and application concurrency limits for the host. Start conservatively and load-test the expected number and bitrate of simultaneous streams.
 7. Configure notifications for recording failures, pipeline failures, credential expiry, and output-root write failures.

--- a/rust-srec/docs/en/operations/security.md
+++ b/rust-srec/docs/en/operations/security.md
@@ -12,7 +12,7 @@ Rust-Srec handles access tokens, platform cookies, notification credentials, rec
 
 ## Network and Session Security
 
-Terminate TLS before the frontend, set `COOKIE_SECURE=true`, and restrict both host ports with a firewall. Keep the backend private unless direct API consumers need it. Do not expose Swagger, media proxy routes, or logs to anonymous Internet clients.
+Terminate TLS before the frontend, set `COOKIE_SECURE=true` only if the proxy does not send `X-Forwarded-Proto: https`, and restrict both host ports with a firewall. Keep the backend private unless direct API consumers need it. Do not expose Swagger, media proxy routes, or logs to anonymous Internet clients.
 
 The stream proxy blocks private-network targets by default. Enabling `stream_proxy_allow_private_targets` allows authenticated users to make the service fetch internal addresses; enable it only for an explicit LAN-camera or restream use case.
 

--- a/rust-srec/docs/en/release-notes/unreleased.md
+++ b/rust-srec/docs/en/release-notes/unreleased.md
@@ -190,6 +190,10 @@
 
 ## Deployment
 
+- **The sign-in cookie is protected automatically behind an HTTPS reverse proxy**
+
+  When the web interface is published through a reverse proxy that terminates HTTPS, the cookie that keeps you signed in was only marked HTTPS-only if you set `COOKIE_SECURE=true` by hand; otherwise the browser was willing to send it over plain HTTP as well. The scheme reported by the proxy now reaches the app intact, so the cookie is marked HTTPS-only on its own. Plain-HTTP installs on a home or office network keep working as before, and `COOKIE_SECURE` still overrides the automatic choice in either direction. If a production install is still reached over plain HTTP, a warning is logged once to point this out.
+
 - **Optional automatic container updates**
 
   The Docker Compose file now ships an opt-in `watchtower` service (`docker compose --profile autoupdate up -d`) that pulls new images and restarts the containers on its own — but only while the system is idle. A new unauthenticated `GET /api/health/idle` endpoint reports whether anything is recording, queued to record, or being processed by a pipeline job (upload, remux, danmaku conversion, ...); while it reports busy, the update is postponed to the next check, so a restart never cuts a recording or an upload short. Automatic updates require a mutable image tag (`VERSION=latest`). See [Upgrade and Rollback](../operations/upgrading.md#automatic-updates-watchtower).

--- a/rust-srec/docs/zh/operations/production.md
+++ b/rust-srec/docs/zh/operations/production.md
@@ -21,7 +21,7 @@ flowchart LR
 1. 使用 [Docker 部署](../getting-started/docker.md)，将两个镜像的 `VERSION` 固定为 `v0.5.1`。变更需审批的环境不要使用 `latest`。
 2. 为 `JWT_SECRET` 和 `SESSION_SECRET` 生成互不相同的唯一值，并限制 `.env` 文件权限。
 3. 把宿主机端口绑定到私网地址或回环地址。Compose 的回环映射格式为 `127.0.0.1:15275:80` 和 `127.0.0.1:12555:8080`。
-4. 在持续维护的反向代理终止 HTTPS，并转发 `Host`、`X-Forwarded-For` 与 `X-Forwarded-Proto`。HTTPS 验证成功后设置 `COOKIE_SECURE=true`。
+4. 在持续维护的反向代理终止 HTTPS，并转发 `Host`、`X-Forwarded-For` 与 `X-Forwarded-Proto`。只要反向代理发送 `X-Forwarded-Proto: https`（符合 RFC 7239 的 `Forwarded: proto=https` 同样有效），会话 Cookie 就会自动带上 `Secure` 标记；如果代理无法发送这两个头，请显式设置 `COOKIE_SECURE=true`。
 5. 将 `DATA_DIR`、`CONFIG_DIR`、`OUTPUT_DIR` 和 `LOG_DIR` 放在持久化存储上；输出卷应与系统盘分开估算和监控。
 6. 按主机容量设置容器资源限制和应用并发限制。从保守值开始，按预计同时录制数和码率压测。
 7. 为录制失败、管道失败、凭据过期和输出根不可写配置通知。

--- a/rust-srec/docs/zh/operations/production.md
+++ b/rust-srec/docs/zh/operations/production.md
@@ -21,7 +21,7 @@ flowchart LR
 1. 使用 [Docker 部署](../getting-started/docker.md)，将两个镜像的 `VERSION` 固定为 `v0.5.1`。变更需审批的环境不要使用 `latest`。
 2. 为 `JWT_SECRET` 和 `SESSION_SECRET` 生成互不相同的唯一值，并限制 `.env` 文件权限。
 3. 把宿主机端口绑定到私网地址或回环地址。Compose 的回环映射格式为 `127.0.0.1:15275:80` 和 `127.0.0.1:12555:8080`。
-4. 在持续维护的反向代理终止 HTTPS，并转发 `Host`、`X-Forwarded-For` 与 `X-Forwarded-Proto`。只要反向代理发送 `X-Forwarded-Proto: https`（符合 RFC 7239 的 `Forwarded: proto=https` 同样有效），会话 Cookie 就会自动带上 `Secure` 标记；如果代理无法发送这两个头，请显式设置 `COOKIE_SECURE=true`。
+4. 在持续维护的反向代理终止 HTTPS，并转发 `Host`、`X-Forwarded-For` 与 `X-Forwarded-Proto`。只要反向代理发送 `X-Forwarded-Proto: https`，会话 Cookie 就会自动带上 `Secure` 标记；如果代理无法发送该请求头，请显式设置 `COOKIE_SECURE=true`。
 5. 将 `DATA_DIR`、`CONFIG_DIR`、`OUTPUT_DIR` 和 `LOG_DIR` 放在持久化存储上；输出卷应与系统盘分开估算和监控。
 6. 按主机容量设置容器资源限制和应用并发限制。从保守值开始，按预计同时录制数和码率压测。
 7. 为录制失败、管道失败、凭据过期和输出根不可写配置通知。

--- a/rust-srec/docs/zh/operations/security.md
+++ b/rust-srec/docs/zh/operations/security.md
@@ -12,7 +12,7 @@ Rust-Srec 会处理访问令牌、平台 Cookie、通知凭据、录制文件和
 
 ## 网络与会话安全
 
-在前端之前终止 TLS，设置 `COOKIE_SECURE=true`，并用防火墙限制两个宿主机端口。没有直接 API 消费者时保持后端私有；不要向匿名互联网客户端公开 Swagger、媒体代理或日志接口。
+在前端之前终止 TLS，仅在反向代理不发送 `X-Forwarded-Proto: https` 时设置 `COOKIE_SECURE=true`，并用防火墙限制两个宿主机端口。没有直接 API 消费者时保持后端私有；不要向匿名互联网客户端公开 Swagger、媒体代理或日志接口。
 
 流代理默认阻止私网目标。开启 `stream_proxy_allow_private_targets` 后，已认证用户可让服务请求内部地址；仅在明确的局域网摄像头或转流场景开启。
 

--- a/rust-srec/docs/zh/release-notes/unreleased.md
+++ b/rust-srec/docs/zh/release-notes/unreleased.md
@@ -190,6 +190,10 @@
 
 ## 部署
 
+- **通过 HTTPS 反向代理访问时，登录 Cookie 会自动受到保护**
+
+  当 Web 界面通过终止 HTTPS 的反向代理对外发布时，保存登录状态的 Cookie 以前只有在手动设置 `COOKIE_SECURE=true` 之后才会被标记为仅 HTTPS，否则浏览器在普通 HTTP 请求中也会发送它。现在反向代理报告的协议能够原样传递给应用，Cookie 会自动带上仅 HTTPS 标记。家庭或办公网络内的纯 HTTP 部署不受影响，`COOKIE_SECURE` 也仍然可以在两个方向上覆盖自动判断。如果生产环境仍在通过普通 HTTP 访问，会记录一条提示警告（仅记录一次）。
+
 - **可选的容器自动更新**
 
   Docker Compose 文件新增了可选的 `watchtower` 服务（`docker compose --profile autoupdate up -d`），可自动拉取新镜像并重启容器——但只在系统空闲时进行。新增的免认证 `GET /api/health/idle` 端点会报告当前是否有录制、排队录制或执行中的管道任务（上传、remux、弹幕转换等）；只要处于忙碌状态，更新就会推迟到下一次检查，因此重启不会打断任何录制或上传。自动更新要求使用可变镜像标签（`VERSION=latest`）。详见[升级与回滚](../operations/upgrading.md#自动更新watchtower)。

--- a/rust-srec/frontend/nginx.conf.template
+++ b/rust-srec/frontend/nginx.conf.template
@@ -4,6 +4,15 @@ map $http_upgrade $connection_upgrade {
     ''      close;
 }
 
+# Client-facing scheme for the X-Forwarded-Proto sent upstream. This server only
+# listens on plain HTTP, so $scheme is never https; when an external TLS
+# terminator already set X-Forwarded-Proto, its value wins. A proxy chain sends
+# the client-facing hop first, so matching the start of the value is enough.
+map $http_x_forwarded_proto $forwarded_proto {
+    default   $scheme;
+    ~*^https  https;
+}
+
 server {
     listen 80;
     server_name localhost;
@@ -24,7 +33,7 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Proto $forwarded_proto;
     }
 
     # API proxy - backend URL is configurable via environment variable
@@ -36,6 +45,6 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Proto $forwarded_proto;
     }
 }

--- a/rust-srec/frontend/nginx.conf.template
+++ b/rust-srec/frontend/nginx.conf.template
@@ -6,8 +6,9 @@ map $http_upgrade $connection_upgrade {
 
 # Client-facing scheme for the X-Forwarded-Proto sent upstream. This server only
 # listens on plain HTTP, so $scheme is never https; when an external TLS
-# terminator already set X-Forwarded-Proto, its value wins. A proxy chain sends
-# the client-facing hop first, so matching the start of the value is enough.
+# terminator already set X-Forwarded-Proto, the request is reported as https. A
+# proxy chain sends the client-facing hop first, so matching the start of the
+# value is enough.
 map $http_x_forwarded_proto $forwarded_proto {
     default   $scheme;
     ~*^https  https;

--- a/rust-srec/frontend/src/utils/session-storage.test.ts
+++ b/rust-srec/frontend/src/utils/session-storage.test.ts
@@ -1,9 +1,5 @@
 import { parseStoredSession } from './session-storage';
-import {
-  resolveCookieSecurity,
-  resolveSessionSecret,
-  warnInsecureCookieOnce,
-} from './session.server';
+import { resolveCookieSecurity, resolveSessionSecret } from './session.server';
 
 describe('parseStoredSession', () => {
   it('returns an object from valid JSON', () => {
@@ -47,30 +43,12 @@ describe('resolveCookieSecurity', () => {
     ['https, http', true],
     ['http, https', false],
     ['http', false],
+    ['', false],
   ])('reads X-Forwarded-Proto %p', (forwardedProto, secure) => {
     expect(resolveCookieSecurity({ forwardedProto })).toEqual({
       secure,
       warnInsecure: false,
     });
-  });
-
-  it.each([
-    ['for=192.0.2.60;proto=https;by=203.0.113.43', true],
-    ['proto="https"', true],
-    ['proto=HTTPS, proto=http', true],
-    ['for=192.0.2.60;proto=http', false],
-    ['for=192.0.2.60', false],
-  ])('falls back to the Forwarded header %p', (forwarded, secure) => {
-    expect(resolveCookieSecurity({ forwarded }).secure).toBe(secure);
-  });
-
-  it('prefers X-Forwarded-Proto over Forwarded', () => {
-    expect(
-      resolveCookieSecurity({
-        forwardedProto: 'https',
-        forwarded: 'proto=http',
-      }).secure,
-    ).toBe(true);
   });
 
   it('assumes HTTPS in production when no proxy header is present', () => {
@@ -119,7 +97,11 @@ describe('resolveCookieSecurity', () => {
 });
 
 describe('warnInsecureCookieOnce', () => {
-  it('logs at most once per process', () => {
+  it('logs once per module instance', async () => {
+    // The guard is module state, so load a fresh copy instead of inheriting
+    // whatever earlier tests left behind.
+    vi.resetModules();
+    const { warnInsecureCookieOnce } = await import('./session.server');
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
     warnInsecureCookieOnce();

--- a/rust-srec/frontend/src/utils/session-storage.test.ts
+++ b/rust-srec/frontend/src/utils/session-storage.test.ts
@@ -1,5 +1,9 @@
 import { parseStoredSession } from './session-storage';
-import { resolveSessionSecret } from './session.server';
+import {
+  resolveCookieSecurity,
+  resolveSessionSecret,
+  warnInsecureCookieOnce,
+} from './session.server';
 
 describe('parseStoredSession', () => {
   it('returns an object from valid JSON', () => {
@@ -33,5 +37,95 @@ describe('resolveSessionSecret', () => {
     expect(() => resolveSessionSecret(undefined, 'production')).toThrow(
       'SESSION_SECRET must be set in production',
     );
+  });
+});
+
+describe('resolveCookieSecurity', () => {
+  it.each([
+    ['https', true],
+    ['HTTPS', true],
+    ['https, http', true],
+    ['http, https', false],
+    ['http', false],
+  ])('reads X-Forwarded-Proto %p', (forwardedProto, secure) => {
+    expect(resolveCookieSecurity({ forwardedProto })).toEqual({
+      secure,
+      warnInsecure: false,
+    });
+  });
+
+  it.each([
+    ['for=192.0.2.60;proto=https;by=203.0.113.43', true],
+    ['proto="https"', true],
+    ['proto=HTTPS, proto=http', true],
+    ['for=192.0.2.60;proto=http', false],
+    ['for=192.0.2.60', false],
+  ])('falls back to the Forwarded header %p', (forwarded, secure) => {
+    expect(resolveCookieSecurity({ forwarded }).secure).toBe(secure);
+  });
+
+  it('prefers X-Forwarded-Proto over Forwarded', () => {
+    expect(
+      resolveCookieSecurity({
+        forwardedProto: 'https',
+        forwarded: 'proto=http',
+      }).secure,
+    ).toBe(true);
+  });
+
+  it('assumes HTTPS in production when no proxy header is present', () => {
+    expect(resolveCookieSecurity({ nodeEnv: 'production' })).toEqual({
+      secure: true,
+      warnInsecure: false,
+    });
+  });
+
+  it('stays insecure outside production when no proxy header is present', () => {
+    expect(resolveCookieSecurity({ nodeEnv: 'development' })).toEqual({
+      secure: false,
+      warnInsecure: false,
+    });
+  });
+
+  it('flags a plain-HTTP production request', () => {
+    expect(
+      resolveCookieSecurity({ forwardedProto: 'http', nodeEnv: 'production' }),
+    ).toEqual({ secure: false, warnInsecure: true });
+  });
+
+  it('lets COOKIE_SECURE=false win over an https proxy header', () => {
+    expect(
+      resolveCookieSecurity({
+        cookieSecure: 'false',
+        forwardedProto: 'https',
+        nodeEnv: 'production',
+      }),
+    ).toEqual({ secure: false, warnInsecure: false });
+  });
+
+  it('lets COOKIE_SECURE=true win over a plain-HTTP request', () => {
+    expect(
+      resolveCookieSecurity({ cookieSecure: 'TRUE', forwardedProto: 'http' })
+        .secure,
+    ).toBe(true);
+  });
+
+  it('ignores an unrecognised COOKIE_SECURE value', () => {
+    expect(
+      resolveCookieSecurity({ cookieSecure: 'yes', forwardedProto: 'https' })
+        .secure,
+    ).toBe(true);
+  });
+});
+
+describe('warnInsecureCookieOnce', () => {
+  it('logs at most once per process', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    warnInsecureCookieOnce();
+    warnInsecureCookieOnce();
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    warn.mockRestore();
   });
 });

--- a/rust-srec/frontend/src/utils/session.server.ts
+++ b/rust-srec/frontend/src/utils/session.server.ts
@@ -30,8 +30,6 @@ export type CookieSecuritySignals = {
   cookieSecure?: string;
   /** Raw `X-Forwarded-Proto` request header. */
   forwardedProto?: string;
-  /** Raw RFC 7239 `Forwarded` request header. */
-  forwarded?: string;
   nodeEnv?: string;
 };
 
@@ -49,48 +47,25 @@ function firstXForwardedProto(header: string | undefined): string | undefined {
   return first || undefined;
 }
 
-// RFC 7239 `Forwarded: for=1.2.3.4;proto=https, for=...`; read `proto` from the
-// first element, which is the hop closest to the client.
-function firstForwardedHeaderProto(
-  header: string | undefined,
-): string | undefined {
-  if (!header) return undefined;
-  for (const pair of (header.split(',')[0] ?? '').split(';')) {
-    const separator = pair.indexOf('=');
-    if (separator < 0) continue;
-    if (pair.slice(0, separator).trim().toLowerCase() !== 'proto') continue;
-    const value = pair
-      .slice(separator + 1)
-      .trim()
-      .replace(/^"|"$/g, '')
-      .toLowerCase();
-    if (value) return value;
-  }
-  return undefined;
-}
-
 /**
  * Decides the `secure` attribute of the `srec_session` cookie.
  *
  * Priority:
  * 1. `COOKIE_SECURE`: `true` = always secure, `false` = never secure.
- * 2. The proxy-supplied scheme (`X-Forwarded-Proto`, then `Forwarded`). Plain
- *    HTTP stays non-secure so LAN deployments without TLS can still sign in.
- * 3. `NODE_ENV`, i.e. secure in production when no proxy header is present.
+ * 2. The scheme reported in `X-Forwarded-Proto`. Plain HTTP stays non-secure so
+ *    LAN deployments without TLS can still sign in.
+ * 3. `NODE_ENV`, i.e. secure in production when the header is absent or empty.
  */
 export function resolveCookieSecurity({
   cookieSecure,
   forwardedProto,
-  forwarded,
   nodeEnv,
 }: CookieSecuritySignals): CookieSecurity {
   const override = cookieSecure?.trim().toLowerCase();
   if (override === 'true') return { secure: true, warnInsecure: false };
   if (override === 'false') return { secure: false, warnInsecure: false };
 
-  const proto =
-    firstXForwardedProto(forwardedProto) ??
-    firstForwardedHeaderProto(forwarded);
+  const proto = firstXForwardedProto(forwardedProto);
   const secure = proto ? proto === 'https' : nodeEnv === 'production';
 
   return { secure, warnInsecure: !secure && nodeEnv === 'production' };
@@ -161,18 +136,16 @@ export async function useAppSession(): Promise<SessionLike<SessionData>> {
 
   // getRequestHeader throws outside of a request context (e.g. prerendering),
   // which leaves resolveCookieSecurity on its NODE_ENV fallback.
-  const readHeader = (name: string): string | undefined => {
-    try {
-      return getRequestHeader(name);
-    } catch {
-      return undefined;
-    }
-  };
+  let forwardedProto: string | undefined;
+  try {
+    forwardedProto = getRequestHeader('x-forwarded-proto');
+  } catch {
+    forwardedProto = undefined;
+  }
 
   const { secure, warnInsecure } = resolveCookieSecurity({
     cookieSecure: process.env.COOKIE_SECURE,
-    forwardedProto: readHeader('x-forwarded-proto'),
-    forwarded: readHeader('forwarded'),
+    forwardedProto,
     nodeEnv: process.env.NODE_ENV,
   });
   if (warnInsecure) warnInsecureCookieOnce();

--- a/rust-srec/frontend/src/utils/session.server.ts
+++ b/rust-srec/frontend/src/utils/session.server.ts
@@ -25,6 +25,92 @@ export function resolveSessionSecret(
   return 'dev_secret_must_be_at_least_32_chars_long_and_random';
 }
 
+export type CookieSecuritySignals = {
+  /** Raw `COOKIE_SECURE` value, when the operator set one. */
+  cookieSecure?: string;
+  /** Raw `X-Forwarded-Proto` request header. */
+  forwardedProto?: string;
+  /** Raw RFC 7239 `Forwarded` request header. */
+  forwarded?: string;
+  nodeEnv?: string;
+};
+
+export type CookieSecurity = {
+  /** Value handed to the `secure` cookie attribute. */
+  secure: boolean;
+  /** True when a production deployment is about to issue a non-secure cookie. */
+  warnInsecure: boolean;
+};
+
+// A proxy chain appends to `X-Forwarded-Proto`, so the scheme the client
+// actually spoke is the first value.
+function firstXForwardedProto(header: string | undefined): string | undefined {
+  const first = header?.split(',')[0]?.trim().toLowerCase();
+  return first || undefined;
+}
+
+// RFC 7239 `Forwarded: for=1.2.3.4;proto=https, for=...`; read `proto` from the
+// first element, which is the hop closest to the client.
+function firstForwardedHeaderProto(
+  header: string | undefined,
+): string | undefined {
+  if (!header) return undefined;
+  for (const pair of (header.split(',')[0] ?? '').split(';')) {
+    const separator = pair.indexOf('=');
+    if (separator < 0) continue;
+    if (pair.slice(0, separator).trim().toLowerCase() !== 'proto') continue;
+    const value = pair
+      .slice(separator + 1)
+      .trim()
+      .replace(/^"|"$/g, '')
+      .toLowerCase();
+    if (value) return value;
+  }
+  return undefined;
+}
+
+/**
+ * Decides the `secure` attribute of the `srec_session` cookie.
+ *
+ * Priority:
+ * 1. `COOKIE_SECURE`: `true` = always secure, `false` = never secure.
+ * 2. The proxy-supplied scheme (`X-Forwarded-Proto`, then `Forwarded`). Plain
+ *    HTTP stays non-secure so LAN deployments without TLS can still sign in.
+ * 3. `NODE_ENV`, i.e. secure in production when no proxy header is present.
+ */
+export function resolveCookieSecurity({
+  cookieSecure,
+  forwardedProto,
+  forwarded,
+  nodeEnv,
+}: CookieSecuritySignals): CookieSecurity {
+  const override = cookieSecure?.trim().toLowerCase();
+  if (override === 'true') return { secure: true, warnInsecure: false };
+  if (override === 'false') return { secure: false, warnInsecure: false };
+
+  const proto =
+    firstXForwardedProto(forwardedProto) ??
+    firstForwardedHeaderProto(forwarded);
+  const secure = proto ? proto === 'https' : nodeEnv === 'production';
+
+  return { secure, warnInsecure: !secure && nodeEnv === 'production' };
+}
+
+let insecureCookieWarned = false;
+
+/**
+ * Logged from every request that would issue a non-secure production cookie,
+ * but emitted only once per process so it does not flood the request log.
+ */
+export function warnInsecureCookieOnce(): void {
+  if (insecureCookieWarned) return;
+  insecureCookieWarned = true;
+  console.warn(
+    '[Session] Request arrived over plain HTTP, so the srec_session cookie is issued without the Secure attribute. ' +
+      'Behind an HTTPS reverse proxy, make it send "X-Forwarded-Proto: https", or set COOKIE_SECURE=true.',
+  );
+}
+
 function getBrowserSession(): SessionLike<SessionData> {
   if (browserSessionSingleton) return browserSessionSingleton;
 
@@ -73,40 +159,29 @@ export async function useAppSession(): Promise<SessionLike<SessionData>> {
   const { useSession, getRequestHeader } =
     await import('@tanstack/react-start/server');
 
-  // Determine if cookies should use the secure flag
-  // Priority:
-  // 1. COOKIE_SECURE env var: 'true' = always secure, 'false' = never secure
-  // 2. X-Forwarded-Proto header (when behind a reverse proxy)
-  // 3. Default: secure only in production
-  const isSecureCookie = (): boolean => {
-    const cookieSecure = process.env.COOKIE_SECURE?.toLowerCase();
-    if (cookieSecure === 'true') return true;
-    if (cookieSecure === 'false') return false;
-
-    // Check X-Forwarded-Proto header for reverse proxy HTTPS detection
+  // getRequestHeader throws outside of a request context (e.g. prerendering),
+  // which leaves resolveCookieSecurity on its NODE_ENV fallback.
+  const readHeader = (name: string): string | undefined => {
     try {
-      const forwardedProto = getRequestHeader('x-forwarded-proto');
-      if (forwardedProto) {
-        const isHttps = forwardedProto.toLowerCase() === 'https';
-        console.log(
-          `[Session] X-Forwarded-Proto: ${forwardedProto}, secure cookie: ${isHttps}`,
-        );
-        return isHttps;
-      }
+      return getRequestHeader(name);
     } catch {
-      // getRequestHeader may throw if called outside of a request context
-      // Fall through to default behavior
+      return undefined;
     }
-
-    // Default: secure only in production
-    return process.env.NODE_ENV === 'production';
   };
+
+  const { secure, warnInsecure } = resolveCookieSecurity({
+    cookieSecure: process.env.COOKIE_SECURE,
+    forwardedProto: readHeader('x-forwarded-proto'),
+    forwarded: readHeader('forwarded'),
+    nodeEnv: process.env.NODE_ENV,
+  });
+  if (warnInsecure) warnInsecureCookieOnce();
 
   const session = await useSession<SessionData>({
     name: 'srec_session',
     password: resolveSessionSecret(),
     cookie: {
-      secure: isSecureCookie(),
+      secure,
       sameSite: 'lax',
       httpOnly: true,
       maxAge: 30 * 24 * 60 * 60, // 30 days


### PR DESCRIPTION
## What changed?

The frontend container's nginx listens on plain HTTP only (`listen 80;`), so `$scheme` inside it is always `http`. It nevertheless sent `proxy_set_header X-Forwarded-Proto $scheme;` to both upstreams, overwriting whatever the operator's external TLS terminator (Traefik, Caddy, another nginx) had put there.

`useAppSession()` trusts `X-Forwarded-Proto` when deciding the `Secure` attribute of the sealed `srec_session` cookie, so in the deployment we document — HTTPS terminated at a reverse proxy in front of the frontend container — it always saw `http` and issued the cookie **without `Secure`**, unless the operator set `COOKIE_SECURE=true` by hand. A browser would then also send that cookie over any plain-HTTP request to the same host. `docker-compose.yml` and `docs/*/operations/production.md` both advertise auto-detection via `X-Forwarded-Proto`, so the documented setup was the vulnerable one.

**nginx** (`rust-srec/frontend/nginx.conf.template`)

- New `map $http_x_forwarded_proto $forwarded_proto { default $scheme; ~*^https https; }`. An upstream `https` (any case, and the first hop of a comma-joined chain such as `https, http`) makes the request report as `https`; otherwise the listener's own `$scheme` is used, so a direct plain-HTTP client still reports `http`.
- Both proxying locations (SSR/websocket `/` and API `/api/`) now send `X-Forwarded-Proto $forwarded_proto`.
- `entrypoint.sh` already runs `envsubst '${BACKEND_URL}'` with an explicit variable list, so `$scheme` / `$http_x_forwarded_proto` / `$forwarded_proto` survive rendering unchanged (verified, see below). No entrypoint change needed.

**Session** (`rust-srec/frontend/src/utils/session.server.ts`)

- The `isSecureCookie` closure is replaced by an exported pure `resolveCookieSecurity()`. Header-based detection is kept deliberately — self-hosters legitimately run plain HTTP on a LAN, and defaulting to `Secure` in production would lock them out — but it is now robust: first value of a comma-separated `X-Forwarded-Proto`, compared case-insensitively, with a present-but-empty header treated as absent.
- `COOKIE_SECURE` remains the top-priority override in both directions.
- The per-request `console.log` of the header is gone. A production request that arrives over plain HTTP with no `COOKIE_SECURE` now logs a single process-lifetime warning via `warnInsecureCookieOnce()`.

**Docs**: `docs/en|zh/operations/production.md` step 4 now states that the cookie is marked `Secure` automatically once the proxy sends `X-Forwarded-Proto: https`, and that `COOKIE_SECURE=true` is the fallback when the proxy cannot send it. `docs/en|zh/operations/security.md` no longer instructs operators to set `COOKIE_SECURE=true` unconditionally — only when the proxy does not send the header. Release notes added to `docs/en/release-notes/unreleased.md` and `docs/zh/release-notes/unreleased.md` under **Deployment**.

An RFC 7239 `Forwarded: proto=https` fallback was considered and deliberately left out: the nginx map reads `$http_x_forwarded_proto` and both locations always emit an `X-Forwarded-Proto`, so behind the shipped image such a fallback would be dead code, and documenting it would advertise protection the container cannot deliver.

## Scope

- Affected components (backend / frontend / desktop / CLI / crates / docs): frontend (nginx template + SSR session), docs
- Breaking change: no. Behaviour only changes where the cookie was previously non-secure but the request was really HTTPS. Deployments that already set `COOKIE_SECURE` are unaffected; plain-HTTP LAN deployments are unaffected.

## How to test

Unit tests (`rust-srec/frontend`):

```
pnpm install --frozen-lockfile
pnpm test   # src/utils/session-storage.test.ts covers resolveCookieSecurity
```

13 new cases: `X-Forwarded-Proto` values `https`, `HTTPS`, `https, http`, `http, https`, `http` and `''`; header absent with `NODE_ENV=production` / `development`; a plain-HTTP production request setting the warn flag; `COOKIE_SECURE=false` overriding an `https` header; `COOKIE_SECURE=TRUE` overriding a plain-HTTP request; an unrecognised `COOKIE_SECURE`; and `warnInsecureCookieOnce()` logging once per module instance (the test reloads the module via `vi.resetModules()` so it does not depend on state left by earlier tests).

nginx template — render it exactly the way `entrypoint.sh` does and validate:

```
export BACKEND_URL=http://rust-srec:8080
envsubst '${BACKEND_URL}' < rust-srec/frontend/nginx.conf.template > /tmp/default.conf
docker run --rm -v /tmp/default.conf:/etc/nginx/conf.d/default.conf:ro nginx:alpine nginx -t
```

End to end: put an HTTPS reverse proxy that sets `X-Forwarded-Proto: https` in front of the frontend container, sign in, and check that the `srec_session` cookie in the response carries `Secure`.

### Validation performed here

- `pnpm lint`, `pnpm typecheck`, `pnpm fmt:check` clean; `pnpm test` 240 passed / 37 files.
- The template was rendered with `envsubst '${BACKEND_URL}'`. Confirmed that `$scheme`, `$http_x_forwarded_proto`, `$forwarded_proto`, `$host`, `$http_upgrade` and `$proxy_add_x_forwarded_for` all pass through untouched and only `${BACKEND_URL}` is substituted.
- `nginx -t` could **not** be executed in this environment: no nginx binary is installed and the Docker daemon is not running here. The rendered output was reviewed by hand against the `ngx_http_map_module` reference instead — `map` is valid in the `http` context (the file is included from `http {}` via `/etc/nginx/http.d/`, as the pre-existing `$connection_upgrade` map already demonstrates), a resulting value may be a variable (`default $scheme;`), and `~*` is the case-insensitive regex prefix. Please let CI or a reviewer run the `docker run … nginx -t` command above.

## Checklist

- [ ] I ran formatting (`cargo fmt --all`) if Rust code changed — n/a, no Rust changes
- [ ] I ran lint (`cargo clippy ...`) if Rust code changed — n/a, no Rust changes
- [x] I ran tests (`cargo test` or `cargo nextest run`) if feasible — frontend `pnpm test`, plus `pnpm lint` / `pnpm typecheck` / `pnpm fmt:check`
- [x] I updated docs/config examples if behavior changed
- [x] I avoided logging secrets and redacted sensitive info in screenshots/logs — the per-request header log was removed; the new warning contains no request data

## Related issues

None.
