### PR TITLE
docs: align agent guidance with task scope and validation risk

### DIFF
--- a/.claude/skills/release-rust-srec/SKILL.md
+++ b/.claude/skills/release-rust-srec/SKILL.md
@@ -1,88 +1,67 @@
 ---
 name: release-rust-srec
-description: Prepare a new rust-srec application release end to end — pick the next semver version, bump the workspace version, promote the staged unreleased.md notes into versioned en+zh release-notes pages, reset unreleased, refresh the release-notes index/sidebar/GitHub-body, and emit the rust-srec-vX.Y.Z tag command. Use when asked to cut, prepare, plan, or draft a new rust-srec release or version bump.
+description: Plan, prepare, or publish a rust-srec application release, including workspace version changes and localized release notes. Select the stage from the user's request; planning does not modify release files. Use for application release/version tasks, not ordinary development or strev/mesio releases.
 ---
 
 # Release rust-srec
 
-Prepares a `rust-srec` application release: version bump + localized release notes + GitHub release body, ready for the maintainer to tag. This is a docs-and-version task — it does **not** publish. Tagging/pushing is the maintainer's call; never tag or push unless explicitly asked.
+This is the canonical application release procedure. Paths below are relative to the repository root. Read only the material needed for the requested stage.
 
-## Source of truth
+## Select the requested outcome
 
-- **Version**: root `Cargo.toml` `[workspace.package].version`. It flows to `rust-srec/Cargo.toml` and `rust-srec/src-tauri/Cargo.toml` (both `version.workspace = true`) and to Tauri via Cargo fallback. Never hand-edit those downstream files.
-- **User-facing notes**: `rust-srec/docs/{en,zh}/release-notes/unreleased.md` — the running draft of changes since the last release. **Promote this**; do not re-derive notes from raw commit subjects.
-- **Tag scheme**: `rust-srec-vX.Y.Z` (per-package). Do **not** use bare `vX.Y.Z` — those are legacy tags from an unrelated lineage. `strev`/`mesio` have their own `strev-v*` / `mesio-v*` tags.
+- **Plan**: Recommend a version and summarize release scope, compatibility implications, and unresolved evidence. Use read-only inspection; do not bump versions, reset unreleased notes, commit, or tag.
+- **Draft notes**: Write or refine the requested release-note draft. Preserve the workspace version and unreleased staging unless the user also requested release preparation.
+- **Prepare**: Apply the version and release-document changes, validate them, and deliver the reviewed result. If the request is only a version bump, update the version and lockfile without promoting or resetting notes. Commit/open a PR when that is part of the existing request.
+- **Publish**: Complete preparation, then perform the explicitly authorized tag/push operations. Preparing or drafting a release does not by itself authorize publication. Existing explicit publication authorization remains valid; do not ask for it again. If the stage is unclear, perform read-only planning and only the preparation edits already authorized before asking about the dependent step.
 
-## Steps
+## Sources and release scope
 
-### 1. Pick the next version
-- Last release: `git tag --list 'rust-srec-v*' --sort=-v:refname | head -1`.
-- Review changes: `git log --no-merges <last-tag>..HEAD`.
-- Semver: fixes/reliability/dependency bumps only → **patch**; a new user-facing feature → **minor**; a breaking change or a migration that needs user action → **major**. rust-srec's 0.3.x line has stayed patch-level for reliability follow-ups.
+- **Version**: root `Cargo.toml` `[workspace.package].version`. Backend and desktop manifests inherit it with `version.workspace = true`; Tauri uses the Cargo fallback. Preserve inheritance instead of adding downstream version literals.
+- **Notes**: `rust-srec/docs/{en,zh}/release-notes/unreleased.md` is the curated draft. Promote its relevant items, verifying them against the changes that will actually be released. Commit subjects alone are not a replacement for user-facing notes.
+- **Tags**: use `rust-srec-vX.Y.Z`. Bare `vX.Y.Z` tags are from another lineage; `strev-v*` and `mesio-v*` are separate releases.
+- **Release body**: `.github/workflows/release-rust-srec.yml` publishes `rust-srec/docs/release-notes-body.md` directly.
 
-### 2. Verify the unreleased draft is accurate
-- Confirm every item in `unreleased.md` landed *after* the last tag: `git show <last-tag>:rust-srec/docs/en/release-notes/unreleased.md` should be the empty shell ("No staged changes yet…"). See which commits added the items with `git log <last-tag>..HEAD -- rust-srec/docs/en/release-notes/unreleased.md`.
-- Never ship an item already announced in the previous `vX.Y.Z.md`.
-- Cross-check headline items against real commits (e.g. a "pipeline waits for X" note should map to a `fix(pipeline)` commit touching `rust-srec/src/...`). An item with no backing change since the tag is a red flag — investigate before including it.
+List application tags with `git tag --list 'rust-srec-v*' --sort=-v:refname` and select the applicable release baseline for the target branch. Review `git log <last-tag>..HEAD`; inspect relevant changes and the previous versioned notes when needed. A nonempty unreleased page at the last tag or a different commit-message style does not prove an item is invalid. Confirm that claims are present in the target release and have not already been announced; resolve unsupported claims before presenting the notes as ready.
 
-### 3. (Optional) Plan and draft with a Workflow
-For a thorough pass, run a multi-agent Workflow: one agent categorizes commits and recommends the bump; parallel agents draft the en page, the zh page, and the GitHub body; a final agent adversarially verifies en↔zh consistency and that every claim traces to `unreleased.md` or a commit. Draft agents can write the `vX.Y.Z.md` pages directly (the bump script in step 4 preserves files that already exist).
+Use an explicitly requested version. Otherwise recommend patch for fixes/reliability/dependency-only changes, minor for new user-facing features, and explain any breaking-change or migration implications using the project's versioning conventions. Do not infer the next version from a historical release-line example.
 
-### 4. Bump version + scaffold docs
+For a large release, independent drafting/review can be parallelized when delegation is available and authorized. It is optional, with the same evidence and locale checks as a single-agent pass.
+
+## Prepare the files
+
+For full release preparation, preview and apply the existing helper:
+
 ```sh
-node scripts/bump-rust-srec-version.mjs <X.Y.Z> --docs --dry-run   # preview
-node scripts/bump-rust-srec-version.mjs <X.Y.Z> --docs             # apply
+node scripts/bump-rust-srec-version.mjs <X.Y.Z> --docs --dry-run
+node scripts/bump-rust-srec-version.mjs <X.Y.Z> --docs
 ```
-The script:
-- sets `Cargo.toml` `[workspace.package].version`;
-- runs `cargo update --workspace` so `Cargo.lock` carries the new `rust-srec` / `rust-srec-desktop` versions — **required**: release CI builds with `--locked` and fails on a stale lockfile (run `cargo update --workspace` by hand if you ever bump the version without the script);
-- creates `rust-srec/docs/{en,zh}/release-notes/vX.Y.Z.md` **only if absent** (pre-written pages from step 3 are preserved);
-- moves the previous "Latest release" entry into "Archive" in both `index.md`;
-- inserts `vX.Y.Z` into the VitePress sidebar (`.vitepress/config.mts`) for both locales;
-- bumps version pointers in `release-notes.md`;
-- rewrites only the *links* in `release-notes-body.md` (its content is replaced in step 8).
 
-### 5. Write the real release notes (en + zh)
-Fill `rust-srec/docs/{en,zh}/release-notes/vX.Y.Z.md` by promoting `unreleased.md`:
-- open with a 1–2 sentence high-level summary, then themed `##` sections, each bullet shaped `- **Bold lead-in**` + a short explanatory paragraph;
-- match the tone/structure of the most recent published page (e.g. `v0.3.1.md`);
-- reuse the existing translations in `zh/.../unreleased.md` verbatim — don't re-translate good prose;
-- add a `## Compatibility` / `## 兼容性` section only when there's a real migration or behavior note;
-- keep en and zh covering the same items in the same order.
+Omit `--docs` for a version-only request. The helper updates the workspace version and runs `cargo update --workspace` to synchronize `Cargo.lock`. If the lockfile update fails, resolve it or report preparation as incomplete; the script's final output alone is not proof of success. Review the lockfile diff for unrelated changes. If bumping without the helper, synchronize the lockfile explicitly.
 
-### 6. Reset unreleased
-Reset both `unreleased.md` to the empty shell:
-- en — `# Release Notes` / ``## `unreleased` `` / `No staged changes yet for the next release.`
-- zh — `# 更新日志` / ``## `unreleased` `` / `暂无下一个版本的待发布改动。`
+With `--docs`, the helper creates versioned en/zh pages only if absent, updates the Latest/Archive indexes, inserts sidebar links, and updates version pointers in `release-notes.md` and links in `release-notes-body.md`. Existing versioned pages are preserved. Use `--from-latest` only when a previous page's structure is a useful scaffold; it does not supply this release's content.
 
-### 7. Fix the index placeholders
-The script leaves placeholders in both `index.md`; correct them:
-- set the **Unreleased** bullet to "no changes staged yet" / "暂无下一个版本的待发布改动";
-- replace the auto-generated **Latest** line ("draft release notes…" / "新版本发布说明草稿…") with a real one-line summary;
-- delete the extra blank lines the script inserts around the Latest/Archive headings.
+For full preparation:
 
-### 8. Fill the GitHub release body
-Overwrite `rust-srec/docs/release-notes-body.md` with the real body: `## rust-srec vX.Y.Z`, a summary paragraph, `### Highlights`, `### Review before upgrading`, then a closing line linking to `https://docs.srec.rs/en/release-notes/vX.Y.Z` and `/zh/release-notes/vX.Y.Z`. The release CI reads this file directly for the published GitHub Release body. (The bump script only fixed the links here, so a full rewrite is expected.)
+1. Promote the selected unreleased items to `rust-srec/docs/{en,zh}/release-notes/vX.Y.Z.md`. Follow the most recent published page's structure, reuse good existing translations, and keep both languages covering the same items in the same order. Include compatibility guidance when there is a real behavior change or migration.
+2. After preserving the promoted content, reset the corresponding unreleased items. If all staged items are included, use the empty shells: en `# Release Notes` / ``## `unreleased` `` / `No staged changes yet for the next release.`; zh `# 更新日志` / ``## `unreleased` `` / `暂无下一个版本的待发布改动。`. Preserve any explicitly deferred items.
+3. Replace the helper's draft placeholders in both `index.md` files with an accurate Latest summary and the remaining Unreleased status. Remove incidental extra blank lines introduced by the helper.
+4. Fill `rust-srec/docs/release-notes-body.md` with `## rust-srec vX.Y.Z`, a short summary, highlights, any actual upgrade guidance, and links to `https://docs.srec.rs/en/release-notes/vX.Y.Z` and the matching zh page. Check that it agrees with the detailed notes.
 
-### 9. Verify
-- Every `vX.Y.Z` link in the sidebars and both `index.md` resolves to an existing file.
-- `.vitepress/config.mts` still parses (balanced braces/commas around the inserted sidebar entry).
-- Confirm the lockfile is `--locked`-clean: `cargo metadata --locked` (fast, no compile) — the `rust-srec` / `rust-srec-desktop` entries in `Cargo.lock` must already show the new version, or the tagged release build fails under `--locked`.
-- If docs deps are installed: `cd rust-srec/docs && pnpm run docs:build`.
-- Optional: `cargo build --locked -p rust-srec` to confirm the version bump compiles under the same flags CI uses.
+## Validate and finish preparation
 
-### 10. Tag (only when asked)
+- Check versioned pages, index/sidebar links, and version pointers for consistency. Verify en/zh content parity and the evidence behind release claims.
+- Run `cargo metadata --locked --format-version 1` to verify lockfile consistency without compilation. Confirm the backend and desktop workspace versions match the requested version.
+- For release-document changes, run `pnpm -C rust-srec/docs run docs:build` to check configuration and links. Restore dependencies with the pinned toolchain if feasible; otherwise report this check as outstanding and its impact. A version-only request does not need a docs build.
+- A pure version/docs change does not require a backend compilation or full workspace test run locally. Expand validation for actual dependency/build changes or explicit release requirements using the root task-based guidance and release CI.
+- Review the final diff. Preparation is complete when the requested files are consistent and relevant validation is accounted for; distinguish completed preparation from missing evidence needed before publication. Commit or create a PR if already requested. Otherwise provide the result and intended tag without waiting for permission to complete ordinary preparation.
+
+## Publish when authorized
+
+Before tagging, ensure the intended release changes are committed on the target revision, the required release checks have passed, and the tag is not already assigned to a different revision. Unrelated untracked files are not a publication blocker. Do not publish with unresolved version/lockfile or release-content failures.
+
 ```sh
 git tag rust-srec-vX.Y.Z
 git push origin rust-srec-vX.Y.Z
 ```
 
-## Files touched
-- `Cargo.toml`
-- `Cargo.lock` (workspace-member versions, via `cargo update --workspace`)
-- `rust-srec/docs/{en,zh}/release-notes/vX.Y.Z.md` (new)
-- `rust-srec/docs/{en,zh}/release-notes/unreleased.md` (reset)
-- `rust-srec/docs/{en,zh}/release-notes/index.md`
-- `rust-srec/docs/.vitepress/config.mts`
-- `rust-srec/docs/release-notes.md`
-- `rust-srec/docs/release-notes-body.md`
+Push only the intended release ref. If an operation fails or its outcome is uncertain, inspect the local/remote tag state before retrying; do not overwrite an existing release tag. Report the pushed tag and available release/CI status. Do not equate a successful tag push with completed release artifacts while the workflow is still running.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,15 +9,15 @@ Describe the change and the motivation.
 
 ## How to test
 
-Steps reviewers can run to validate locally.
+List checks actually run, their results, and useful reproduction steps. Mark checks not applicable to this change as N/A; explain unavailable or failed checks and their impact. Use the task-based validation guidance in AGENTS.md.
 
 ## Checklist
 
-- [ ] I ran formatting (`cargo fmt --all`) if Rust code changed
-- [ ] I ran lint (`cargo clippy ...`) if Rust code changed
-- [ ] I ran tests (`cargo test` or `cargo nextest run`) if feasible
-- [ ] I updated docs/config examples if behavior changed
-- [ ] I avoided logging secrets and redacted sensitive info in screenshots/logs
+- Formatting for affected files: passed / N/A / limitation
+- Lint and relevant tests for affected behavior: passed / N/A / limitation
+- Additional checks for affected interfaces, builds, migrations, or releases: passed / N/A / limitation
+- Related docs, config examples, and generated outputs: updated / N/A
+- Final diff reviewed; unrelated changes excluded and shared logs/screenshots redacted: done / limitation
 
 ## Related issues
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,161 +1,92 @@
-This file is for agentic coding tools operating in this repository.
+# Repository guidance
 
-Repo overview
+## Scope and reading
 
-- Rust workspace (edition 2024) with multiple crates and binaries.
-- Backend app: `rust-srec/` (package `rust-srec`) - REST API + scheduler + pipeline + SQLite.
-- CLIs: `strev-cli/` (package `strev`), `mesio-cli/` (package `mesio`).
-- Libraries: `crates/*` (protocol/container + platform extractors + download engine).
-- Frontend UI: `rust-srec/frontend/` (Vite/TanStack + Tailwind, pnpm).
-- Docs site: `rust-srec/docs/` (VitePress, pnpm).
+This file and the `AGENTS.md` files governing the area being changed define project conventions, subject to higher-priority instructions and the user's task scope. Read the applicable rules when entering an area; reuse context already read unless it has changed. Tool-specific entrypoints should refer here for shared rules.
 
-Build / lint / test
+Use the map below to locate the task. Read supporting docs, examples, and skills only when they answer a concrete question or supply a procedure needed for the work. A link is a lookup aid, not a requirement to read every referenced file before each edit.
 
-Rust (run from repo root; match CI by adding `--locked`)
+| Area | Location / task-specific guidance |
+| --- | --- |
+| Backend: REST API, scheduler, pipeline, SQLite | `rust-srec/`, package `rust-srec`; [backend rules](rust-srec/AGENTS.md) |
+| CLIs | `strev-cli/` (package `strev`), `mesio-cli/` (package `mesio`) |
+| Protocols, containers, platform extractors, download engine | `crates/*`; use the affected crate's `Cargo.toml` for its package name |
+| Web UI and desktop frontend | `rust-srec/frontend/`; [frontend rules](rust-srec/frontend/AGENTS.md) |
+| Desktop wrapper | `rust-srec/src-tauri/`; [desktop rules](rust-srec/src-tauri/AGENTS.md) |
+| Documentation site | `rust-srec/docs/`; [docs rules](rust-srec/docs/AGENTS.md) |
+| Application release planning, preparation, or publishing | Read the [release skill](.claude/skills/release-rust-srec/SKILL.md) only for a `rust-srec` release/version task; it is the canonical procedure even if the tool does not discover `.claude/skills` automatically |
 
-- Build default applications (debug, excludes desktop): `cargo build`
-- Build default applications (release, excludes desktop): `cargo build --release`
-- Build the full workspace: `cargo build --workspace`
-- Build specific package: `cargo build -p rust-srec` (or `-p strev`, `-p mesio`)
-- Format: `cargo fmt --all`
-- Lint (CI): `cargo clippy --locked --all-targets --all-features -- -D warnings`
-  **Windows note**: do not use `--all-features` on Windows; OpenSSL is not available. Use default features instead.
-- Test (nextest, preferred; used in CI): `cargo nextest run --locked --workspace`
-- Test (Cargo fallback if nextest not installed): `cargo test --locked --workspace`
-- Doctests (nextest does not run doctests; CI runs on ubuntu): `cargo test --locked --workspace --doc`
+## Toolchain and command reference
 
-Run / debug (Rust)
+- Rust edition and minimum supported version: [Cargo.toml](Cargo.toml). Development toolchain and components: [rust-toolchain.toml](rust-toolchain.toml).
+- Node: [.nvmrc](.nvmrc). pnpm and scripts: [frontend package.json](rust-srec/frontend/package.json) and [docs package.json](rust-srec/docs/package.json). Install dependencies when needed with `pnpm install --frozen-lockfile` in the relevant directory.
+- Rust builds involving protobuf generation need `protoc` on PATH; the CI version is in [.github/actions/setup-protoc/action.yml](.github/actions/setup-protoc/action.yml).
+- Exact CI targets, platform prerequisites, and feature combinations live in [.github/workflows/pr.yml](.github/workflows/pr.yml). Release build combinations live in the corresponding `.github/workflows/release-*.yml` files. Consult these when reproducing CI or changing build/release behavior.
 
-- Run backend (dev): `cargo run -p rust-srec --bin rust-srec`
-- Run backend (release): `cargo run -p rust-srec --release --bin rust-srec`
-- Run CLI (strev): `cargo run -p strev -- --help`
-- Run CLI (mesio): `cargo run -p mesio -- --help`
+Run Rust commands from the repository root. Replace `<package>` and `<test_name>` with the affected package and test filter:
 
-Common env vars (backend)
+```sh
+cargo build --locked                         # default applications, excludes desktop
+cargo build --locked -p <package>
+cargo fmt --all -- --check
+cargo clippy --locked -p <package> --all-targets -- -D warnings
+cargo nextest run --locked -p <package>
+cargo nextest run --locked -p <package> -E 'test(<test_name>)'
+cargo test --locked -p <package> <test_name>  # fallback if nextest is unavailable
+cargo test --locked -p <package> --doc       # when doctests are affected
+```
 
-- `DATABASE_URL` default: `sqlite:srec.db?mode=rwc` (see `rust-srec/src/main.rs`)
-- `LOG_DIR` default: `logs` (see `rust-srec/src/main.rs`)
-- `API_BIND_ADDRESS`, `API_PORT` (see `rust-srec/src/api/server.rs`)
+Use `cargo fmt --all` to apply formatting, and review the diff for unrelated changes. Add `--release` when release-mode behavior or a release artifact is relevant. Use default features on Windows; do not use `--all-features` there with the current OpenSSL prerequisites. On Linux, reproduce the specific CI feature selection when it is relevant rather than assuming `--all-features` is equivalent.
 
-Release build notes (CI parity)
+For broader integration checks, use `--workspace --exclude rust-srec-desktop` in place of `-p <package>`. Desktop validation is separate because it needs frontend and platform dependencies. Full workspace builds including desktop use `cargo build --locked --workspace` when those prerequisites and that scope apply.
 
-- CI builds cross-target releases with `--locked` and uses `static-ssl` for musl builds.
-  Example (static Linux): `cargo build -p rust-srec --locked --release --target x86_64-unknown-linux-musl --features static-ssl --bins`
-  Example (static Linux strev): `cargo build -p strev --locked --release --target x86_64-unknown-linux-musl --features static-ssl`
+Run/debug examples:
 
-Test runner (cargo-nextest, preferred; used in CI)
+```sh
+cargo run --locked -p rust-srec --bin rust-srec
+cargo run --locked -p strev -- --help
+cargo run --locked -p mesio -- --help
+```
 
-- Install: `cargo install cargo-nextest --locked`
-- Run full suite: `cargo nextest run --locked --workspace`
-- Run a single package: `cargo nextest run --locked -p rust-srec`
-- Run a single test binary: `cargo nextest run --locked -p rust-srec --test <test_target_name>`
-- Filter by test name substring (nextest expression):
-  `cargo nextest run --locked -p rust-srec -E 'test(name ~ "some_substring")'`
+Frontend and docs commands are in their respective `AGENTS.md` files. [CONTRIBUTING.md](CONTRIBUTING.md) contains contributor setup and broader local command examples.
 
-Run a single test (Cargo fallback)
+## Validation by task
 
-- Unit test by substring: `cargo test -p rust-srec -- <substring>`
-- Integration test target: `cargo test -p rust-srec --test <test_target_name>`
-- Specific test in a module: `cargo test -p rust-srec some::module::tests::test_name`
+Choose checks from the changed behavior and its consumers. These are local validation requirements, not a requirement to reproduce every CI job for every edit.
 
-Protobuf toolchain
+| Change | Local validation |
+| --- | --- |
+| Agent rules, prose, spelling | Review the diff; verify affected paths, commands, links, and factual claims. No Rust/frontend build or new tests solely for prose changes. |
+| Docs navigation, configuration, or complex Markdown | Build the docs site and check affected links; preview pages when layout or rendering needs inspection. |
+| Local Rust behavior | Formatting, affected-package Clippy, and focused tests covering the behavior. Add or adjust regression tests where they protect an observable contract. |
+| Frontend behavior | Formatting check, lint, and relevant tests. Add type checking for type/interface changes, web build for routing/bundling/SSR changes, and desktop build for affected CSR integration. |
+| Shared interfaces, dependencies, features, cross-component changes | Expand checks to affected consumers and build/platform combinations; use the wider workspace suite when the impact crosses package boundaries. |
+| SQLite migrations | Migration upgrade/integrity checks; for table rebuilds use the conditional procedure in [CONTRIBUTING.md](CONTRIBUTING.md#sqlite-table-rebuilds). |
+| Release preparation | Version/lockfile consistency, release-note provenance and locale parity, links, and docs build as described in the release skill. |
 
-- CI installs `protoc` (see `.github/actions/setup-protoc/action.yml`, version default 33.2).
-- If you touch `prost-build` outputs / proto generation, ensure `protoc` is on PATH locally.
+Prefer deterministic tests without real network calls unless testing an integration explicitly. Put unit tests beside the module and integration tests under the crate's `tests/`. Use Tokio's test harness for async tests; bound waits that could otherwise hang. Nextest does not run doctests, so run Cargo doctests when documentation examples or the APIs they exercise change.
 
-Frontend (run from `rust-srec/frontend/`)
+After relevant checks pass, repeat or broaden them only for new changes, failures, or unresolved risks. If a tool or platform is unavailable, complete independent work and applicable alternative checks, then report the exact unverified portion and its impact. Do not describe blocked validation as passed or a release as ready when required evidence is missing. CI remains the integration gate; see its workflow for the full matrix.
 
-- Install: `pnpm install` (CI uses `pnpm install --frozen-lockfile`)
-- Dev server: `pnpm dev` (uses port 15275)
-- Build: `pnpm build`
-- Lint: `pnpm run lint` (oxlint)
-- Format: `pnpm run format` (oxfmt)
-- Test: `pnpm test` (vitest)
+## Rust engineering conventions
 
-Frontend toolchain
+- Use rustfmt defaults and idiomatic names. Group explicit imports as `std`, external crates, then `crate`/`super`.
+- Prefer extending an existing module unless the change introduces a separate logical component. Use `src/foo.rs` / `src/foo/`; do not introduce `mod.rs` files.
+- Comments explain invariants, caller contracts, ordering constraints, and non-obvious reasons. Avoid restating code or narrating a chat/PR history. A relevant upstream issue may support a workaround, but explain the constraint locally so the comment stands on its own.
+- Collapse nested `if` statements with let chains when equivalent and clearer, following Clippy. Keep stylistic cleanup within the task's changed area.
+- Prefer explicit types over string-based APIs; validate strings at boundaries. Prefer `Arc<T>` for shared ownership and release locks before `.await` where possible; never hold a synchronous mutex guard across an await.
+- Do not introduce `unwrap()` / `expect()` in production paths. Propagate errors with context and use targeted `thiserror` variants before flattening errors to strings. `anyhow::Result<()>` is acceptable at binary entrypoints.
+- Do not silently discard an unhandled `Result`. Use `?` for propagation or an explicit recovery path with appropriate logging/metrics. `let _ = call()?;` propagates errors and discards the success value; use `call()?;` when no binding is needed. Propagation alone does not require a duplicate log.
+- Backend errors use `rust-srec/src/error.rs`; path-related IO should use `Error::io_path(op, path, source)`. Library errors belong to the library's own error type.
+- Use structured `tracing` fields. Add `#[instrument]` where context is useful, with `skip(...)` for secrets or unsuitable fields. Log-and-continue only when proceeding is safe; redact tokens, cookies, stream keys, and private data.
+- Preserve runtime and architecture boundaries: backend orchestration in `rust-srec/src/main.rs`, services in `rust-srec/src/services/`, Tokio tasks, and the existing allocator setup. Avoid blocking async handlers and unnecessary allocations in hot paths; prefer borrowing or `Bytes` for byte-oriented data.
 
-- pnpm is pinned via `packageManager` in `rust-srec/frontend/package.json` (`pnpm@10.28.1`).
-- CI uses Node 22 for frontend jobs (see `.github/workflows/pr.yml`).
+## Completion, commits, and cleanup
 
-Docs site (run from `rust-srec/docs/`)
+A task is complete when the requested scope is implemented, necessary related docs/generated outputs are updated, relevant validation is accounted for, and the final diff has been reviewed. Report what changed, the checks and their results, and any remaining limitation. A review-only task ends with findings and recommendations, following any requested approval boundary.
 
-- Install: `pnpm install` (CI uses `pnpm install --frozen-lockfile`)
-- Dev: `pnpm run docs:dev`
-- Build: `pnpm run docs:build`
-- Preview: `pnpm run docs:preview`
+Continue authorized work through implementation and validation. Existing user instructions or an agreed issue establish scope; do not reopen that decision for routine implementation choices. If essential information is missing, ask once with the concrete dependency and continue work that does not depend on the answer. Explain an actual blocker rather than stopping at a plan or treating optional checks as mandatory approval gates.
 
-Docs toolchain
+Commit, open a PR, push, or tag according to the task's existing authorization; a request for a PR includes the needed task branch, commit, and branch push. Release tags/publication follow the release skill's separate scope. Review the staged diff and include only the task's files/hunks. An unrequested commit or a completely clean worktree is not a completion requirement.
 
-- pnpm is pinned via `packageManager` in `rust-srec/docs/package.json` (`pnpm@10.28.1`).
-- CI uses Node 24 for docs deploy (see `.github/workflows/deploy-docs.yml`).
-
-Code style / engineering conventions
-
-Authoritative local rules
-
-- This `AGENTS.md` and any more-specific nested `AGENTS.md` files are the enforced policy.
-- Copilot instructions: none found (`.github/copilot-instructions.md` is absent).
-
-Rust style
-
-- Formatting: use rustfmt defaults (`cargo fmt --all`); no `rustfmt.toml` present.
-- Imports: group as `std` -> external crates -> `crate`/`super` modules; keep imports explicit.
-  Example: `rust-srec/src/credentials/service.rs`.
-- Modules/files: do not introduce `mod.rs` modules; prefer `src/foo.rs` / `src/foo/` layout.
-- Comments/doc: avoid “organizational” comments; only write comments explaining non-obvious "why".
-- Collapsible ifs: always collapse nested `if` statements using `if let ... && condition` syntax.
-  Example: prefer `if let Some(x) = opt && !x.is_empty() { ... }` over nested `if let` + `if`.
-
-Naming / API shape
-
-- Use idiomatic Rust naming: `PascalCase` for types/traits, `snake_case` for fns/modules/vars.
-- Prefer small, explicit types over `Stringly-typed` APIs; when you must use strings, validate early.
-- Prefer `Arc<T>` for shared state across async tasks; avoid holding locks across `.await`.
-
-Error handling
-
-- Avoid panics: do not add `unwrap()` / `expect()` in production code.
-- Never silently discard errors:
-  avoid `let _ = fallible_call()?;` or `let _ = fallible_call();`.
-  If ignoring errors is required, do it explicitly and with visibility (log/metrics).
-- App-wide errors (`rust-srec`): prefer `rust-srec/src/error.rs` (thiserror enum + `Result<T>` alias).
-- Prefer adding context instead of flattening errors into `String` too early; use targeted variants.
-- For path-related IO, prefer `Error::io_path(op, path, source)` (see `rust-srec/src/error.rs`).
-- Library crate errors: prefer `thiserror` enums in `crates/*/src/error.rs` (e.g. `crates/tars-codec/src/error.rs`).
-- Binary entrypoints: `anyhow::Result<()>` is acceptable at the outermost boundary for user-facing errors.
-  Example: `rust-srec/src/main.rs`, `rust-srec/src/bin/rust-srec-vapid.rs`.
-
-Logging / observability
-
-- Use `tracing` for logging; prefer structured fields (e.g. `warn!(error = %e, ...)`).
-  Examples: `rust-srec/src/notification/web_push.rs`, `rust-srec/src/database/maintenance.rs`.
-- For async functions with important context, use `#[instrument]` and `skip(...)` to avoid logging secrets.
-  Examples: `rust-srec/src/credentials/service.rs`, `crates/mesio/src/hls/fetcher.rs`.
-- Keep a clear fatal vs non-fatal boundary: log-and-continue only when the system can safely proceed.
-  Example: startup/shutdown notifications in `rust-srec/src/main.rs`.
-
-Testing conventions
-
-- Prefer deterministic tests; avoid real network calls unless explicitly testing integrations.
-- Put unit tests next to the module; integration tests live under each crate's `tests/` (Cargo standard).
-- When adding async tests, use Tokio's test harness (`#[tokio::test]`) and keep timeouts explicit.
-
-Performance / runtime conventions
-
-- Backend uses Tokio (`#[tokio::main]`) and a global mimalloc allocator.
-  Example: `rust-srec/src/main.rs`.
-- Avoid unnecessary allocations in hot paths; prefer borrowing / `Bytes` for byte-oriented code.
-  See zero-copy patterns in `crates/tars-codec/`.
-
-When adding new code
-
-- Prefer extending existing modules over creating lots of tiny files.
-- Follow existing abstraction boundaries: app orchestration in `rust-srec/src/main.rs` and services in `rust-srec/src/services/`.
-- Add/adjust tests close to the crate you changed; use nextest to verify quickly.
-
-CI parity checklist (before PR)
-
-- `cargo fmt --all`
-- `cargo clippy --locked --all-targets --all-features -- -D warnings`
-- `cargo nextest run --locked --workspace` (or `cargo test --locked --workspace` if nextest not available)
-- If frontend changed: from `rust-srec/frontend/` run `pnpm run lint` and `pnpm run build`
+Remove only clearly disposable temporary artifacts created by this task. Preserve pre-existing changes, untracked work, local data, and useful caches. Avoid repository-wide formatting, unrelated fixes, destructive cleanup, or deleting files merely to make `git status` clean.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,21 +1,3 @@
 # Project guidance
 
-## Comment style
-
-Code comments must describe **what the code does and why, in terms of the code itself**. They are read by people staring at the function, not at the PR that introduced it.
-
-**Do:**
-
-- State the invariant the code preserves, the contract with its caller, or the ordering requirement it relies on.
-- Name the specific functions, fields, or modules the code interacts with (`monitor::service::handle_error`, `streamer_manager.reload_from_repo`, `live_sessions.end_time`, ...). Concrete references age well; readers can `grep` them.
-- Explain why an error is logged-and-continued vs. propagated, why a check is gated on a flag, or why two operations must run in a particular order.
-
-**Do not:**
-
-- Reference internal design labels invented in a PR body or chat thread ("Strategy B", "the kinetic gap fix", etc.). They are unfamiliar to anyone who didn't read that PR.
-- Cite PR numbers, issue numbers, or commit hashes inline. If a comment depends on that history, the comment is documenting the wrong thing — push the explanation into the *what* of the surrounding code or drop it.
-- Describe pre-fix behaviour, regression history, or what the code "used to do". The diff already shows that; the comment is for the current code.
-- Repeat the user-facing bug-report wording (e.g. "showing offline on web while recording is in flight"). That belongs in the release notes / PR body, not in code.
-- Narrate. One precise sentence beats three about how we got here.
-
-When a comment naturally wants to reach for forbidden context, the underlying explanation is almost always recoverable in code-local terms: name the function whose behaviour creates the constraint, name the field that must hold a specific value before another operation runs, name the call ordering between modules. Those references stay correct as the codebase evolves; design-history references rot the day the PR closes.
+Follow [AGENTS.md](AGENTS.md) and the applicable nested `AGENTS.md` for the area being changed. Shared comment style, validation, completion, and release-task routing are maintained there. Read linked supporting material only when the task needs it.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,22 +16,24 @@ The web UI and desktop wrapper live under `rust-srec/frontend` and `rust-srec/sr
 
 Please avoid sharing secrets. Redact tokens, cookies, stream keys, private URLs, and any personal data from logs/config.
 
-If you are planning a larger change (new platform support, pipeline changes, DB migrations), open an issue first so we can align on scope.
+For a larger external contribution (new platform support, pipeline changes, DB migrations) whose scope has not been discussed, propose an issue to align with maintainers. An existing issue, task description, or explicit maintainer request can already establish that scope; no additional issue or confirmation is needed. Agents should not post an issue on the contributor's behalf without authorization.
 
 ## Development setup
 
 Prereqs:
 
-- Rust stable toolchain
-- `protoc` (Protocol Buffers compiler)
+- Rust toolchain pinned in [rust-toolchain.toml](rust-toolchain.toml); the minimum supported version is recorded separately in [Cargo.toml](Cargo.toml)
+- `protoc` for Rust builds involving protobuf generation (CI version: [.github/actions/setup-protoc/action.yml](.github/actions/setup-protoc/action.yml))
 - Git
 
-Optional (only if working on the web UI / desktop wrapper):
+For the web UI, desktop wrapper, or docs site:
 
-- Node.js (CI uses Node 22)
-- pnpm (CI uses pnpm 10)
+- Node.js from [.nvmrc](.nvmrc)
+- pnpm from the relevant `package.json` `packageManager` field
 
 ## Common commands (repo root)
+
+Choose the scope using [Validation by task](AGENTS.md#validation-by-task). The workspace examples below cover broader integration work; replace `--workspace --exclude rust-srec-desktop` with `-p <package>` for a local package change. Prose-only changes do not require Rust builds or tests.
 
 Format:
 
@@ -42,10 +44,10 @@ cargo fmt --all
 Build:
 
 ```bash
-cargo build
+cargo build --locked
 ```
 
-Lint (CI-style):
+Lint with default features:
 
 ```bash
 cargo clippy --locked --workspace --exclude rust-srec-desktop --all-targets -- -D warnings
@@ -57,19 +59,23 @@ Tests:
 cargo test --locked --workspace --exclude rust-srec-desktop
 ```
 
-If you have `cargo-nextest` installed, you can run the faster suite used in CI:
+If you have `cargo-nextest` installed, use it for the test suite:
 
 ```bash
 cargo nextest run --locked --workspace --exclude rust-srec-desktop
 ```
 
+Nextest does not run doctests. When examples or the APIs they exercise change, run `cargo test --locked -p <package> --doc`. Exact CI features and platform prerequisites are maintained in [.github/workflows/pr.yml](.github/workflows/pr.yml); Linux CI enables selected TLS fallback features. Follow the Windows feature restriction in [AGENTS.md](AGENTS.md#toolchain-and-command-reference).
+
 ## Frontend (optional)
 
-The web UI is in `rust-srec/frontend`.
+The web UI is in `rust-srec/frontend`. These are setup and command examples; see its [agent guide](rust-srec/frontend/AGENTS.md#validation) for when each check applies.
 
 ```bash
 pnpm -C rust-srec/frontend install --frozen-lockfile
+pnpm -C rust-srec/frontend fmt:check
 pnpm -C rust-srec/frontend lint
+pnpm -C rust-srec/frontend test
 pnpm -C rust-srec/frontend build
 ```
 
@@ -81,7 +87,7 @@ CI builds without bundling:
 
 ```bash
 # Requires frontend deps installed (see Frontend section).
-cargo build -p rust-srec-desktop
+cargo build --locked -p rust-srec-desktop
 ```
 
 ## Reporting bugs
@@ -106,9 +112,21 @@ Keep PRs focused and easy to review.
 - One logical change per PR when possible
 - Include tests for behavior changes where practical
 - Update docs when changing flags/config/API behavior
-- Run format + clippy + tests locally if you can
+- Run the checks appropriate to the changed behavior and consumers; report failures or unavailable checks with their impact
 
 If a change affects multiple surfaces (backend + frontend + desktop), call that out clearly in the PR description.
+
+Use the [completion, commit, and cleanup rules](AGENTS.md#completion-commits-and-cleanup) for agent-assisted work. Review the final diff and keep unrelated work out of the commit; existing local changes do not need to be removed to finish a task.
+
+## SQLite table rebuilds
+
+Read this procedure when a migration rebuilds an existing SQLite table. Ordinary schema changes still go in new migration files; never edit a shipped migration because SQLx verifies its checksum on existing installations.
+
+- Preserve the old table's data, indexes, and triggers. `DROP TABLE` removes its triggers, so a create-copy-drop-rename must recreate them as well as the indexes.
+- When a rebuild needs foreign keys disabled to avoid cascading into child tables, set `PRAGMA foreign_keys=OFF` outside a transaction. Use SQLx's `-- no-transaction` marker at the start of the file, then manage the rebuild in its own `BEGIN` / `COMMIT` and restore foreign-key enforcement afterward.
+- Account for replay: SQLx records the migration version only after a `-- no-transaction` script returns. Make the migration safe to rerun after interruption or completion, including temporary tables and indexes; `DROP TABLE IF EXISTS <t>_new` and `CREATE INDEX IF NOT EXISTS` can help, but do not alone prove replay safety.
+- Exercise the upgrade on representative fixtures, including related rows and triggers, and check retained data and behavior. Query `PRAGMA foreign_key_check` and assert that it returns no violations. A pragma inside the migration is insufficient because SQLx discards its result set.
+- When correctness depends on historical data distributions or upgrade states not represented by fixtures, rehearse on a suitably redacted real database copy before shipping. If that evidence is unavailable, finish independent implementation and fixture checks, document the missing release validation, and do not claim the migration is ready to ship. Never use the live database for this rehearsal.
 
 ## Code style / conventions
 

--- a/rust-srec/AGENTS.md
+++ b/rust-srec/AGENTS.md
@@ -1,16 +1,18 @@
 # Backend AGENTS.md
 
+These backend-specific rules apply to `src/`, `migrations/`, `proto/`, and backend build/deployment files in this package. The frontend, docs, and desktop wrapper use their own nested rules plus the repository-wide guidance; backend service conventions do not apply to their unrelated work.
+
 ## OVERVIEW
 Production-ready recorder backend (REST API + scheduler + pipeline + SQLite).
 
 ## STRUCTURE
-- `api/`: Axum server, JWT auth, and route handlers.
-- `scheduler/`: Streamer monitoring and job management.
-- `pipeline/`: Post-processing DAG logic (segment, session completion).
-- `downloader/`: Manager for `ffmpeg`, `streamlink`, and `mesio` engines.
-- `database/`: SQLx repositories, models, and SQLite migrations.
-- `notification/`: Event-driven system (Discord, Email, Webhooks, Web Push).
-- `credentials/`: Platform-specific credential/cookie management.
+- `src/api/`: Axum server, JWT auth, and route handlers.
+- `src/scheduler/`: Streamer monitoring and job management.
+- `src/pipeline/`: Post-processing DAG logic (segment, session completion).
+- `src/downloader/`: Manager for `ffmpeg`, `streamlink`, and `mesio` engines.
+- `src/database/`: SQLx repositories and models; migrations are in `migrations/`.
+- `src/notification/`: Event-driven system (Discord, Email, Webhooks, Web Push).
+- `src/credentials/`: Platform-specific credential/cookie management.
 
 ## WHERE TO LOOK
 - `src/pipeline/manager.rs`: Pipeline execution engine (hotspot).
@@ -24,16 +26,14 @@ Production-ready recorder backend (REST API + scheduler + pipeline + SQLite).
 ## CONVENTIONS
 - **State**: Use `Arc<ServiceContainer>` for shared ownership across services.
 - **API State**: `AppState` (`src/api/server.rs`) is the shared context for Axum routes.
-- **Logging**: Use structured `tracing` macros; avoid `println!`.
 - **Errors**: Propagate to `crate::error::Error`; handle API-specific errors in `src/api/error.rs`.
 - **Migrations**: New schema changes go in new files in `migrations/`; never edit a shipped one — sqlx checksums applied migrations and any change breaks startup on existing installs, so correct it with another new file.
-- **Table rebuilds**: `DROP TABLE` takes the table's triggers with it, so a create-copy-drop-rename must reinstate every trigger the old table carried, not just its indexes. Dropping also cascades into FK children unless `PRAGMA foreign_keys=OFF` is in effect, and it is not inside the transaction sqlx wraps each migration in, so the file must start with `-- no-transaction` and run its work in its own `BEGIN`…`COMMIT`. A `-- no-transaction` file can be replayed — sqlx records the version in `_sqlx_migrations` only after the script returns — so keep every statement re-runnable (`DROP TABLE IF EXISTS <t>_new`, `CREATE INDEX IF NOT EXISTS`). Verify the outcome with `PRAGMA foreign_key_check` against a copy of a real database before shipping; sqlx discards result sets, so the pragma inside the migration can never fail it.
+- **Table rebuilds**: Preserve data, triggers, indexes, and foreign-key integrity, and account for interrupted migration replay. Read the [table rebuild procedure](../CONTRIBUTING.md#sqlite-table-rebuilds) when changing a migration that rebuilds a table; it specifies fixture checks and when a real-data rehearsal is needed.
 
 ## ANTI-PATTERNS
-- **Panics**: No `unwrap()`/`expect()` in services; return `Result`.
-- **Isolation**: Do not instantiate services manually outside of `ServiceContainer`.
+- **Isolation**: Wire production services through `ServiceContainer`; focused tests may construct the service under test directly.
 - **Blocking**: Avoid long-running synchronous work in async handlers; use `spawn_blocking`.
-- **Locks**: Never hold `MutexGuard` across an `.await` point.
+- **Locks**: Never hold a synchronous mutex guard across `.await`. Keep async-lock critical sections short and await while holding one only when the operation requires that serialization.
 
 ## COMMANDS
 - **Run (Dev)**: `cargo run -p rust-srec --bin rust-srec`

--- a/rust-srec/docs/AGENTS.md
+++ b/rust-srec/docs/AGENTS.md
@@ -1,5 +1,7 @@
 # Documentation AGENTS.md
 
+Applies to `rust-srec/docs/`; backend-specific service rules in the parent directory do not govern docs work. Use the repository-wide workflow and read referenced material only for the task at hand.
+
 ## OVERVIEW
 VitePress-based documentation site for `rust-srec`. Multi-language (EN/ZH). 
 
@@ -16,9 +18,9 @@ VitePress-based documentation site for `rust-srec`. Multi-language (EN/ZH).
 - `public/`: Place images and shared assets here.
 
 ## CONVENTIONS / ANTI-PATTERNS
-- **Sync**: Maintain parity between `en/` and `zh/` content and file structure.
-- **Node Version**: CI uses **Node 26**, pinned in the repo-root `.nvmrc`. Ensure local environment compatibility.
-- **Sidebars**: New pages must be manually added to `sidebar` in `config.mts`.
+- **Sync**: Keep changed facts, interfaces, and navigation structure aligned between the corresponding `en/` and `zh/` pages. A wording or spelling fix in one language does not require a mechanical edit to the other or a full-site translation audit.
+- **Toolchain**: Use Node from the repo-root `.nvmrc` and pnpm from this directory's `package.json`.
+- **Sidebars**: Add new navigable pages to the appropriate locale's `sidebar` in `config.mts`. Auxiliary or intentionally unlisted pages need no sidebar entry.
 - **Assets**: Reference assets in `public/` using root-relative paths (e.g., `/stream-rec.svg`).
 - **Dead Links**: Backend-managed links (e.g., `/api/docs`) are ignored via `ignoreDeadLinks` in config.
 
@@ -32,3 +34,7 @@ Run from `rust-srec/docs/`:
 ## NOTES
 - **Generated Folders**: `.vitepress/dist/` and `.vitepress/cache/` are build/cache outputs and are git-ignored. 
 - **Mermaid**: Support for diagrams is included via the `mermaid` dependency.
+
+## VALIDATION
+
+For prose-only edits, check the affected facts and links. Run `pnpm run docs:build` for navigation/configuration changes, complex Markdown, or release-page preparation; preview affected pages when rendering or layout needs inspection. Report unavailable build prerequisites and remaining validation without blocking unrelated work. Docs changes do not require backend/frontend application builds.

--- a/rust-srec/docs/release-notes.md
+++ b/rust-srec/docs/release-notes.md
@@ -11,16 +11,11 @@ The GitHub release workflow now reads `rust-srec/docs/release-notes-body.md` dir
 
 Update that file before tagging a release if you want the published GitHub Release body to match the curated notes.
 
-## Suggested release workflow
+## Release workflow
 
-1. Run `node scripts/bump-rust-srec-version.mjs <X.Y.Z> --docs`
-2. If you want the new localized pages to start from the latest version's structure, add `--from-latest`
-3. Fill in:
-   - `./release-notes-body.md`
-   - `./en/release-notes/vX.Y.Z.md`
-   - `./zh/release-notes/vX.Y.Z.md`
-4. Review archive links and sidebar entries
-5. Tag the release as `rust-srec-vX.Y.Z`
+Follow the [application release procedure](../../.claude/skills/release-rust-srec/SKILL.md) for the canonical steps and validation. It distinguishes read-only planning, drafting notes, preparing version/docs changes, and publishing an explicitly authorized release tag. A version-only bump does not promote or reset release notes.
+
+Preparation includes the version/lockfile update, curated en/zh notes, the GitHub body, and index/sidebar checks. Tagging and pushing are a separate publication stage; a request to prepare or draft a release does not authorize it. Reuse existing explicit publication authorization without asking again.
 
 ## Docs release pages
 

--- a/rust-srec/frontend/AGENTS.md
+++ b/rust-srec/frontend/AGENTS.md
@@ -1,5 +1,7 @@
 # Frontend Agent Guide
 
+Applies to `rust-srec/frontend/`. Use the root rules for shared workflow and completion; backend-specific service rules in the parent directory do not govern frontend work.
+
 ## OVERVIEW
 
 - Vite-powered React app using **TanStack Start** (SSR/Streaming) and **TanStack Router**.
@@ -11,7 +13,7 @@
 
 - `src/routes/`: File-based routing (TanStack Router).
 - `src/server/functions/`: Server-side logic (TanStack Start server functions).
-- `src/api/proto/`: Generated Protobuf files for real-time progress/logs.
+- `src/api/proto/gen/`: Generated Protobuf TypeScript files for real-time progress/logs.
 - `src/components/ui/`: shadcn/ui base components.
 - `src/store/`: Global state management (Zustand).
 - `src/hooks/`: Reusable React hooks.
@@ -19,9 +21,9 @@
 ## WHERE TO LOOK
 
 - `src/routeTree.gen.ts`: AUTO-GENERATED route definitions. Do not edit.
-- `src/api/proto/*.js`: AUTO-GENERATED Protobuf modules. Regenerate via `proto:gen`.
-- `router.tsx` / `router.desktop.tsx`: Router configuration for web vs desktop.
-- `main.desktop.tsx`: Entry point for Tauri desktop build.
+- `src/api/proto/gen/*_pb.ts`: AUTO-GENERATED Protobuf modules. Regenerate via `proto:gen`; `buf.gen.yaml` defines the output.
+- `src/router.tsx` / `src/router.desktop.tsx`: Router configuration for web vs desktop.
+- `src/main.desktop.tsx`: Entry point for Tauri desktop build.
 
 ## CONVENTIONS
 
@@ -29,20 +31,30 @@
 - **Server Functions**: Use `src/server/functions/` for API calls/backend logic.
 - **Type Safety**: Prefer Zod schemas for validation and TanStack Query for data fetching.
 - **Components**: Follow shadcn/ui patterns; use `cn()` utility for Tailwind class merging.
-- **Performance**: Minimize client-side state; leverage SSR and streaming where possible.
+- **Performance**: Use SSR and streaming for the web deployment where useful; preserve the CSR path for the desktop deployment.
 
 ## ANTI-PATTERNS
 
 - **Manual Route Trees**: Never edit `routeTree.gen.ts` manually.
-- **Direct Proto Edits**: Never edit `src/api/proto/*.js` directly. Use `pnpm proto:gen`.
+- **Direct Proto Edits**: Never edit `src/api/proto/gen/*_pb.ts` directly. Use `pnpm proto:gen` after changing the source protos.
 - **Standard Lint**: Avoid ESLint; stick to **oxlint** for speed and consistency.
 
 ## COMMANDS
 
+Run from `rust-srec/frontend/`. Use Node from the root `.nvmrc` and pnpm from this directory's `package.json`.
+
 - `pnpm dev`: Start dev server on http://localhost:15275.
 - `pnpm build`: Production web build.
 - `pnpm build:desktop`: Production desktop build (requires Tauri context).
-- `pnpm proto:gen`: Regenerate Protobuf JavaScript modules.
+- `pnpm proto:gen`: Regenerate Protobuf TypeScript modules using Buf.
 - `pnpm lint`: Run oxlint.
-- `pnpm format`: Run oxfmt.
+- `pnpm fmt`: Apply oxfmt; review the diff for unrelated formatting changes.
+- `pnpm fmt:check`: Check formatting without rewriting files.
 - `pnpm test`: Run vitest.
+- `pnpm typecheck`: Check TypeScript types.
+
+## VALIDATION
+
+For frontend behavior changes, run formatting checks, lint, and relevant tests (`pnpm test <test-file>` for a focused test). Run `pnpm typecheck` when types or interfaces change, `pnpm build` for routing, SSR, or bundling changes, and `pnpm build:desktop` for affected desktop integration. Shared frontend infrastructure or dependency changes warrant the wider test/build scope for the deployments they affect.
+
+For prose-only edits, follow the root validation table. Regenerate protobuf outputs only when their sources or generation configuration change. CI's full frontend checks are maintained in `.github/workflows/pr.yml` at the repository root; the command list above is not a mandatory sequence for every edit.

--- a/rust-srec/src-tauri/AGENTS.md
+++ b/rust-srec/src-tauri/AGENTS.md
@@ -1,5 +1,7 @@
 # rust-srec-desktop AGENTS.md
 
+Applies to the desktop wrapper. Follow root workflow rules; apply parent backend service conventions only when changing the embedded backend integration.
+
 ## OVERVIEW
 - Tauri wrapper for `rust-srec`.
 - Runs backend in-process (scheduler + API server).
@@ -27,9 +29,14 @@
 - **Environment mutation**: Prefer reading `JWT_SECRET` from file in app data dir rather than forcing system env vars.
 
 ## COMMANDS
+
+Run Tauri commands from `rust-srec/`, with the frontend and platform prerequisites installed. Node and pnpm versions come from the root `.nvmrc` and frontend `package.json`.
+
 - Dev: `cargo tauri dev`
   - Uses frontend dev server at `http://localhost:15275`.
 - Build: `cargo tauri build`
-- Check: `cargo check -p rust-srec-desktop`
+- Check: `cargo check --locked -p rust-srec-desktop`
 
-*Note: For core backend or frontend commands, see root `AGENTS.md` and `rust-srec/frontend/README.md` respectively.*
+For a local wrapper change, start with the package check and relevant tests. Build the desktop frontend when its integration changes; use a Tauri build for changes affecting packaging, capabilities, or application startup. Exercise affected startup/persistence behavior on a supported platform. Full desktop checks are not prerequisites for unrelated backend or prose changes.
+
+For core backend or frontend commands, see [root AGENTS.md](../../AGENTS.md) and the [frontend guide](../frontend/AGENTS.md).


### PR DESCRIPTION
## What changed?

The agent guides contained stale toolchain and frontend commands, mismatched CI examples, and validation instructions that could turn small edits into full-workspace checks. Shared rules now route reading and validation by task, define completion and cleanup, and preserve existing authorization through implementation and delivery.

- Use checked-in toolchain/workflow configuration as the source of truth, correct frontend formatting and generated Proto paths, and clarify backend/frontend/docs/desktop scope.
- Consolidate comment and error-handling guidance, scope contributor issue alignment, and retain migration integrity/replay checks in a procedure read only for table rebuilds.
- Separate release planning, note drafting, version-only changes, full preparation, and authorized publication. Preserve lockfile, provenance, locale, and release validation requirements.

## Scope

- Affected components: agent instructions, project release skill, contributor/release workflow docs, and PR template (10 Markdown files).
- Breaking change: no.
- No application code, dependencies, migrations, CI workflows, or release versions changed.

## How to test

- Passed `git diff --cached --check` before committing.
- Passed the skill-creator `quick_validate.py` check for the release skill.
- Checked 33 local Markdown links/anchors, referenced frontend/docs package scripts, and the generated Proto output path with a one-off validation script.
- Reviewed stage behavior: planning remains read-only; drafts and version-only changes preserve unrelated release state; preparation does not publish; explicit publication authorization is reused.
- Rust/frontend tests and application/docs builds: N/A for these rules and prose changes. The modified docs guidance files are excluded from site pages by the existing VitePress configuration.

## Checklist

- Formatting for affected files: passed diff/whitespace checks.
- Lint and relevant tests for affected behavior: skill validation passed; application lint/tests N/A.
- Additional checks: local references, command configuration, stage boundaries, and final diff reviewed.
- Related docs/config examples: updated; generated application outputs N/A.
- Unrelated local work excluded from the commit.

## Related issues

None.
