### PR TITLE
ci: reuse main caches and prebuilt desktop tooling

### DIFF
--- a/.github/actions/setup-tauri/action.yml
+++ b/.github/actions/setup-tauri/action.yml
@@ -1,0 +1,8 @@
+name: "Setup Tauri CLI"
+description: "Install the prebuilt Tauri CLI after pnpm/action-setup and actions/setup-node"
+runs:
+  using: "composite"
+  steps:
+    - name: Install Tauri CLI
+      shell: bash
+      run: pnpm add --global @tauri-apps/cli@2.11.4

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -35,7 +35,9 @@ jobs:
           sudo apt-get install -y pkg-config libssl-dev
       - uses: Swatinem/rust-cache@v2
         with:
-          shared-key: dev-clippy
+          # Main populates the same dependency cache used by PR checks.
+          shared-key: pr-clippy
+          save-if: false
       - name: Clippy check
         run: cargo clippy --locked --workspace --exclude rust-srec-desktop --all-targets --features rust-srec/tls-native-fallback,platforms-parser/tls-native-fallback,mesio-engine/tls-native-fallback,strev/tls-native-fallback,mesio/tls-native-fallback -- -D warnings
       - name: sccache stats
@@ -75,7 +77,8 @@ jobs:
           sudo apt-get install -y pkg-config libssl-dev
       - uses: Swatinem/rust-cache@v2
         with:
-          shared-key: dev-test
+          shared-key: pr-test
+          save-if: false
       - name: Run tests (backend only)
         if: matrix.os == 'ubuntu-latest'
         run: cargo nextest run --locked --workspace --exclude rust-srec-desktop --features rust-srec/tls-native-fallback,platforms-parser/tls-native-fallback,mesio-engine/tls-native-fallback,strev/tls-native-fallback,mesio/tls-native-fallback
@@ -137,8 +140,10 @@ jobs:
           file: rust-srec/Dockerfile
           platforms: ${{ matrix.platform }}
           outputs: type=image,name=ghcr.io/${{ github.repository_owner }}/rust-srec,push-by-digest=true,name-canonical=true,push=true
-          cache-from: type=gha,scope=${{ env.PLATFORM_PAIR }}-backend
-          cache-to: type=gha,mode=max,scope=${{ env.PLATFORM_PAIR }}-backend
+          cache-from: |
+            type=registry,ref=ghcr.io/${{ github.repository_owner }}/rust-srec:buildcache-dev-${{ env.PLATFORM_PAIR }}
+            type=registry,ref=ghcr.io/${{ github.repository_owner }}/rust-srec:buildcache-release-${{ env.PLATFORM_PAIR }}
+          cache-to: type=registry,ref=ghcr.io/${{ github.repository_owner }}/rust-srec:buildcache-dev-${{ env.PLATFORM_PAIR }},mode=max
       
       - name: Export digest backend
         run: |
@@ -154,8 +159,10 @@ jobs:
           file: rust-srec/frontend/Dockerfile
           platforms: ${{ matrix.platform }}
           outputs: type=image,name=ghcr.io/${{ github.repository_owner }}/rust-srec-frontend,push-by-digest=true,name-canonical=true,push=true
-          cache-from: type=gha,scope=${{ env.PLATFORM_PAIR }}-frontend
-          cache-to: type=gha,mode=max,scope=${{ env.PLATFORM_PAIR }}-frontend
+          cache-from: |
+            type=registry,ref=ghcr.io/${{ github.repository_owner }}/rust-srec-frontend:buildcache-dev-${{ env.PLATFORM_PAIR }}
+            type=registry,ref=ghcr.io/${{ github.repository_owner }}/rust-srec-frontend:buildcache-release-${{ env.PLATFORM_PAIR }}
+          cache-to: type=registry,ref=ghcr.io/${{ github.repository_owner }}/rust-srec-frontend:buildcache-dev-${{ env.PLATFORM_PAIR }},mode=max
 
       - name: Export digest frontend
         run: |

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,12 +1,19 @@
 name: Pull Request CI
 
 on:
+  push:
+    branches: [main]
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+  pull-requests: read
+
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  # Let main finish populating caches even when another push only changes docs.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   CARGO_TERM_COLOR: always
@@ -37,7 +44,8 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: pr-clippy
-          save-if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+          # PR merge-ref caches cannot be reused by other PRs.
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Clippy check
         run: cargo clippy --locked --workspace --exclude rust-srec-desktop --all-targets --features rust-srec/tls-native-fallback,platforms-parser/tls-native-fallback,mesio-engine/tls-native-fallback,strev/tls-native-fallback,mesio/tls-native-fallback -- -D warnings
       - name: sccache stats
@@ -60,7 +68,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: pr-rustdoc
-          save-if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Check private-item rustdoc
         env:
           RUSTDOCFLAGS: "-D warnings"
@@ -102,7 +110,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: pr-test
-          save-if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Run tests (backend only)
         if: matrix.os == 'ubuntu-latest'
         run: cargo nextest run --locked --workspace --exclude rust-srec-desktop --features rust-srec/tls-native-fallback,platforms-parser/tls-native-fallback,mesio-engine/tls-native-fallback,strev/tls-native-fallback,mesio/tls-native-fallback
@@ -129,24 +137,49 @@ jobs:
       - uses: dorny/paths-filter@v4
         id: filter
         with:
+          # On main pushes, compare with the commit before the push.
+          base: main
           filters: |
             rust:
               - 'crates/**'
+              - 'mesio-cli/**'
+              - 'strev-cli/**'
               - 'Cargo.toml'
               - 'Cargo.lock'
+              - 'rust-toolchain.toml'
+              - '.cargo/**'
               - 'rust-srec/Cargo.toml'
+              - 'rust-srec/build.rs'
+              - 'rust-srec/proto/**'
+              - 'rust-srec/migrations/**'
+              - 'rust-srec/locales/**'
               - 'rust-srec/src/**'
               - 'rust-srec/tests/**'
               - 'rust-srec/src-tauri/**'
+              - '.github/actions/setup-rust/**'
+              - '.github/actions/setup-protoc/**'
               - '.github/workflows/pr.yml'
             frontend:
               - 'rust-srec/frontend/**'
             desktop:
               - 'rust-srec/src-tauri/**'
+              - 'rust-srec/frontend/**'
+              - 'rust-srec/Cargo.toml'
+              - 'rust-srec/build.rs'
+              - 'rust-srec/proto/**'
+              - 'rust-srec/migrations/**'
+              - 'rust-srec/locales/**'
               - 'rust-srec/src/**'
               - 'crates/**'
               - 'Cargo.toml'
               - 'Cargo.lock'
+              - 'rust-toolchain.toml'
+              - '.cargo/**'
+              - '.github/actions/setup-rust/**'
+              - '.github/actions/setup-protoc/**'
+              - '.github/actions/setup-tauri/**'
+              - '.github/workflows/pr.yml'
+              - '.github/workflows/release-rust-srec.yml'
             systemd:
               - 'rust-srec/rust-srec.service'
               - '.github/workflows/pr.yml'
@@ -218,7 +251,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: pr-desktop-debug
-          save-if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - uses: pnpm/action-setup@v6
         with:
@@ -232,9 +265,12 @@ jobs:
       - name: Install frontend dependencies
         run: pnpm -C rust-srec/frontend install --frozen-lockfile
 
+      - uses: ./.github/actions/setup-tauri
+
       - uses: tauri-apps/tauri-action@action-v1.0.0
         with:
           projectPath: rust-srec/src-tauri
+          tauriScript: tauri
           args: --debug --no-bundle
       - name: sccache stats
         if: always()

--- a/.github/workflows/release-rust-srec.yml
+++ b/.github/workflows/release-rust-srec.yml
@@ -200,16 +200,15 @@ jobs:
           cache: 'pnpm'
           cache-dependency-path: rust-srec/frontend/pnpm-lock.yaml
 
-      - name: Install Tauri CLI
-        run: cargo install tauri-cli --locked
-
       - name: Install frontend dependencies
         run: pnpm -C ../frontend install --frozen-lockfile
+
+      - uses: ./.github/actions/setup-tauri
 
       - name: Build desktop bundles
         env:
           VITE_UI_BUILD: ${{ github.ref_name }}@${{ github.sha }}
-        run: cargo tauri build --ci ${{ matrix.args }}
+        run: tauri build --ci ${{ matrix.args }}
 
       - name: Collect desktop artifacts (macOS/Linux)
         if: runner.os != 'Windows'
@@ -349,8 +348,10 @@ jobs:
           file: rust-srec/Dockerfile
           platforms: ${{ matrix.platform }}
           outputs: type=image,name=ghcr.io/${{ github.repository_owner }}/rust-srec,push-by-digest=true,name-canonical=true,push=true
-          cache-from: type=gha,scope=${{ env.PLATFORM_PAIR }}-backend
-          cache-to: type=gha,mode=max,scope=${{ env.PLATFORM_PAIR }}-backend
+          cache-from: |
+            type=registry,ref=ghcr.io/${{ github.repository_owner }}/rust-srec:buildcache-release-${{ env.PLATFORM_PAIR }}
+            type=registry,ref=ghcr.io/${{ github.repository_owner }}/rust-srec:buildcache-dev-${{ env.PLATFORM_PAIR }}
+          cache-to: type=registry,ref=ghcr.io/${{ github.repository_owner }}/rust-srec:buildcache-release-${{ env.PLATFORM_PAIR }},mode=max
       
       - name: Export digest backend
         run: |
@@ -366,8 +367,8 @@ jobs:
           file: rust-srec/Dockerfile.vapid
           platforms: ${{ matrix.platform }}
           outputs: type=image,name=ghcr.io/${{ github.repository_owner }}/rust-srec-vapid,push-by-digest=true,name-canonical=true,push=true
-          cache-from: type=gha,scope=${{ env.PLATFORM_PAIR }}-vapid
-          cache-to: type=gha,mode=max,scope=${{ env.PLATFORM_PAIR }}-vapid
+          cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/rust-srec-vapid:buildcache-release-${{ env.PLATFORM_PAIR }}
+          cache-to: type=registry,ref=ghcr.io/${{ github.repository_owner }}/rust-srec-vapid:buildcache-release-${{ env.PLATFORM_PAIR }},mode=max
 
       - name: Export digest vapid
         run: |
@@ -385,8 +386,10 @@ jobs:
           build-args: |
             VITE_UI_BUILD=${{ github.ref_name }}@${{ github.sha }}
           outputs: type=image,name=ghcr.io/${{ github.repository_owner }}/rust-srec-frontend,push-by-digest=true,name-canonical=true,push=true
-          cache-from: type=gha,scope=${{ env.PLATFORM_PAIR }}-frontend
-          cache-to: type=gha,mode=max,scope=${{ env.PLATFORM_PAIR }}-frontend
+          cache-from: |
+            type=registry,ref=ghcr.io/${{ github.repository_owner }}/rust-srec-frontend:buildcache-release-${{ env.PLATFORM_PAIR }}
+            type=registry,ref=ghcr.io/${{ github.repository_owner }}/rust-srec-frontend:buildcache-dev-${{ env.PLATFORM_PAIR }}
+          cache-to: type=registry,ref=ghcr.io/${{ github.repository_owner }}/rust-srec-frontend:buildcache-release-${{ env.PLATFORM_PAIR }},mode=max
 
       - name: Export digest frontend
         run: |


### PR DESCRIPTION
## What changed?

New PRs repeatedly compile Rust dependencies from scratch because the existing caches are saved under individual PR merge refs or `dev`, with no Rust cache producer on `main`. The latest PR took 19m19s; Intel macOS spent 15m55s compiling and 47s testing. The last release also spent 16m33s compiling the Tauri CLI on Intel macOS, and a recent Docker build spent 5m43s exporting its backend cache to Actions.

- Run the existing checks on pushes to `main` to populate caches that new PRs and Dev CI can restore. Save Cargo dependency archives only from `main`, reuse the PR cache keys in Dev CI, and allow active main runs to finish populating caches. Existing sccache behavior is retained.
- Cover CLI, toolchain, build inputs, setup actions, and desktop frontend changes in the file filters so the corresponding checks and main caches stay current.
- Install the pinned prebuilt `@tauri-apps/cli@2.11.4` through a shared setup action. Both the PR desktop build and release packaging use this CLI; releases no longer compile it with `cargo install`.
- Store Docker caches in GHCR with separate component, architecture, and dev/release tags, importing both channels where available. Preserve intermediate dependency layers with `mode=max` and the existing image digest outputs.

The first main run after merge seeds the reusable Rust caches. This adds runner work on main in exchange for faster subsequent PR feedback. Registry caches also start cold on their first build. Timing improvements still require measurement after merge.

## Scope

- Affected components: CI workflows and desktop build tooling; four files under `.github/`.
- Breaking change: no. Runner matrices, test commands, application sources, and release optimization profiles are unchanged.

## How to test

- Passed `actionlint` 1.7.12 across all workflows and `git diff --cached --check`.
- Passed 22 changed-file routing cases, including documentation-only changes, CLI sources, shared build inputs, and frontend/desktop changes. Also checked main/PR cache policies, matching Dev cache keys, and preservation of runner matrices and image outputs.
- Passed Docker Buildx `bake --print` parsing of all 10 expanded registry cache exports, checking unique writer refs, `mode=max`, and matching import refs.
- Installed the pinned prebuilt CLI on Windows using pnpm 11.11.0 in approximately one second. Passed `tauri --version`, `tauri info` against the desktop project, and `tauri build --help`.
- Full PR builds/tests are pending GitHub CI. The desktop job exercises the shared prebuilt CLI. Full release packaging and authenticated registry cache export were not run locally; the local Docker daemon is unavailable. Actual main-cache reuse and registry transfers must be verified on the next applicable main/dev/release runs.

## Checklist

- Formatting for affected files: passed whitespace and workflow syntax checks.
- Lint and relevant tests for affected behavior: passed actionlint and the focused configuration checks above; full PR CI pending.
- Additional checks for affected interfaces, builds, migrations, or releases: CLI smoke checks and Buildx configuration parsing passed; platform packaging and registry transfer limitations noted above.
- Related docs, config examples, and generated outputs: N/A; no application or public configuration changes.
- Final diff reviewed; unrelated changes excluded and shared logs/screenshots redacted: done.

## Related issues

No linked issue. Timing evidence: [PR CI](https://github.com/hua0512/rust-srec/actions/runs/33962260244), [Dev CI](https://github.com/hua0512/rust-srec/actions/runs/33753310590), [application release](https://github.com/hua0512/rust-srec/actions/runs/30910144059).
