### PR TITLE
fix(build): track protobuf generation inputs explicitly

### DIFF
--- a/rust-srec/build.rs
+++ b/rust-srec/build.rs
@@ -1,4 +1,19 @@
 fn main() {
+    // Include new/imported schemas while avoiding package-wide invalidation by
+    // unrelated source, documentation, or local planning files.
+    println!("cargo:rerun-if-changed=proto");
+    println!("cargo:rerun-if-env-changed=PROTOC");
+    println!("cargo:rerun-if-env-changed=PROTOC_INCLUDE");
+    println!("cargo:rerun-if-env-changed=PATH");
+    for variable in ["PROTOC", "PROTOC_INCLUDE"] {
+        if let Some(path) = std::env::var_os(variable) {
+            let path = std::path::Path::new(&path);
+            // Bare executable names are resolved through PATH, not the package root.
+            if path.exists() {
+                println!("cargo:rerun-if-changed={}", path.display());
+            }
+        }
+    }
     prost_build::compile_protos(&["proto/download_progress.proto"], &["proto/"])
         .expect("Failed to compile protos");
     prost_build::compile_protos(&["proto/log_event.proto"], &["proto/"])


### PR DESCRIPTION
## What changed?

The protobuf build script tracks schema and compiler-selection inputs explicitly, so documentation and planning edits no longer regenerate protobuf code and invalidate backend builds. The schema directory covers new/imported schemas; PROTOC, PROTOC_INCLUDE, PATH and existing explicitly configured paths are tracked.

## Scope

Build invalidation only; protobuf generation commands are unchanged. As before, replacing a PATH-resolved compiler in place without changing PATH requires an explicit rebuild; this change does not promise detection of that external tool replacement.

## How to test

Independent source review and cargo check passed. A temporary documentation input kept every build-script output timestamp unchanged and completed in 0.74 seconds. Adding a schema-directory input reran generation (12.48 seconds). Both temporary probes were removed. Formatting and combined all-target Clippy passed. All nine applicable final-head CI checks passed, including five platform suites (two unrelated checks skipped). No new regression test duplicates Cargo's own dependency tracking.

## Checklist

- Independent review and behavioral build checks: passed.
- Temporary probes removed.
- Clippy and final-head CI: passed.
- No archive finding is claimed resolved by this build-efficiency follow-up.
