### PR TITLE
test: isolate injected worker panics from diagnostic hooks

### DIFF
--- a/rust-srec/src/api/routes/logging/archive/tests.rs
+++ b/rust-srec/src/api/routes/logging/archive/tests.rs
@@ -205,7 +205,8 @@ async fn producer_panic_is_an_error_instead_of_successful_eof() {
         receiver,
         task: tokio::task::spawn_blocking(move || {
             let _sender = sender;
-            panic!("archive test panic");
+            // Exercise task failure without timing global panic-hook diagnostics.
+            std::panic::resume_unwind(Box::new("archive test panic"));
         }),
         _cancel_on_drop: CancellationToken::new().drop_guard(),
         permit: Some(Arc::new(service.slots.clone().try_acquire_owned().unwrap())),

--- a/rust-srec/src/metrics/health/sampling_tests.rs
+++ b/rust-srec/src/metrics/health/sampling_tests.rs
@@ -63,7 +63,7 @@ async fn sampler_panic_becomes_a_stable_failure_without_restarting_workers() {
     let observed = calls.clone();
     let mut sampler = SystemSampler::with_sampling_fn(move |_| {
         observed.fetch_add(1, Ordering::SeqCst);
-        panic!("injected sampler panic");
+        std::panic::resume_unwind(Box::new("injected sampler panic"));
     });
     for _ in 0..3 {
         assert!(

--- a/rust-srec/src/scheduler/actor/registry.rs
+++ b/rust-srec/src/scheduler/actor/registry.rs
@@ -699,7 +699,7 @@ mod tests {
             self.entered.notify_one();
             self.release.notified().await;
             if matches!(self.on_release, OnRelease::Panic) {
-                panic!("status check exploded");
+                std::panic::resume_unwind(Box::new("status check exploded"));
             }
             Ok((
                 crate::scheduler::actor::messages::CheckResult::success(StreamerState::NotLive),
@@ -742,7 +742,7 @@ mod tests {
             _streamer: &StreamerMetadata,
         ) -> Result<(crate::scheduler::actor::messages::CheckResult, LiveStatus), CheckError>
         {
-            panic!("status check exploded");
+            std::panic::resume_unwind(Box::new("status check exploded"));
         }
 
         async fn process_status(

--- a/rust-srec/src/scheduler/actor/supervisor.rs
+++ b/rust-srec/src/scheduler/actor/supervisor.rs
@@ -865,7 +865,7 @@ mod tests {
             ),
             CheckError,
         > {
-            panic!("status check exploded");
+            std::panic::resume_unwind(Box::new("status check exploded"));
         }
 
         async fn process_status(

--- a/rust-srec/src/utils/task_supervisor.rs
+++ b/rust-srec/src/utils/task_supervisor.rs
@@ -474,7 +474,7 @@ mod tests {
         let supervisor = TaskSupervisor::new();
 
         assert!(supervisor.spawn_critical("critical panic", async {
-            panic!("test panic");
+            std::panic::resume_unwind(Box::new("test panic"));
             #[expect(
                 unreachable_code,
                 reason = "typed return value follows the intentional panic in this test"


### PR DESCRIPTION
## What changed?

Injected worker panics can exhaust bounded failure-propagation waits while the global panic hook formats a backtrace on Windows CI. This was observed in both archive-stream and health-sampler regressions. Trigger unwinding directly with the same payloads in six intentional injections across archive, health, actor registry/supervisor and critical-task tests.

Actual worker failures, sender drops, crash classification, cancellation, EOF/capacity assertions and deadlines remain exercised. Unexpected-path/assertion panics retain their diagnostics; no global hook is changed.

## Scope

Five existing test files; production behavior is unchanged. Dependent PRs include this fix and require it to merge first with ancestry retained.

## How to test

Independent source review, formatting, workspace Clippy and all 256 focused service/session/server/archive/panic tests passed (run b58394e5-74f1-4a5a-9244-765827d936e5). The following full workspace run also passed every affected panic regression; its only three failures were an unrelated new Web Push user fixture. All nine applicable final-head CI checks passed, with two skipped.

## Checklist

- Independent review, formatting and diff: passed.
- Expanded focused tests, Clippy and all applicable final-head CI: passed.
- No new runtime behavior or process-global hook mutation.

## Related issues

Supporting Wave 19 CI correction. Windows failures: jobs 102077500344, 102083719382 and 102085392069.
