### PR TITLE
refactor(web): type form props instead of UseFormReturn<any>

### DIFF
--- a/rust-srec/frontend/src/components/config/platforms/tabs/__tests__/raw-json-editor.test.tsx
+++ b/rust-srec/frontend/src/components/config/platforms/tabs/__tests__/raw-json-editor.test.tsx
@@ -6,10 +6,12 @@ import { useForm, type UseFormReturn } from 'react-hook-form';
 import { Form } from '@/components/ui/form';
 import { PlatformSpecificTab } from '../platform-specific-tab';
 
+type Values = { platform_specific_config: unknown };
+
 function renderEditor(initial?: Record<string, unknown>) {
-  let form!: UseFormReturn<any>;
+  let form!: UseFormReturn<Values>;
   function Harness() {
-    form = useForm<any>({
+    form = useForm<Values>({
       defaultValues: { platform_specific_config: initial },
     });
     return (

--- a/rust-srec/frontend/src/components/config/platforms/tabs/general-tab.tsx
+++ b/rust-srec/frontend/src/components/config/platforms/tabs/general-tab.tsx
@@ -11,20 +11,24 @@ import { msg } from '@lingui/core/macro';
 import { useLingui } from '@lingui/react';
 import { Clock } from 'lucide-react';
 import { InputWithUnit } from '@/components/ui/input-with-unit';
-import { UseFormReturn } from 'react-hook-form';
+import type { FieldValues, UseFormReturn } from 'react-hook-form';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { CONFIG_INPUT } from '@/components/config/shared/config-field';
 import {
   CONFIG_DESCRIPTION,
   ConfigFieldLabel,
 } from '@/components/config/shared/config-field';
+import { configPath } from '@/components/config/shared/form-path';
 
-interface GeneralTabProps {
-  form: UseFormReturn<any>;
+interface GeneralTabProps<TFieldValues extends FieldValues> {
+  form: UseFormReturn<TFieldValues>;
   basePath?: string;
 }
 
-export function GeneralTab({ form, basePath }: GeneralTabProps) {
+export function GeneralTab<TFieldValues extends FieldValues>({
+  form,
+  basePath,
+}: GeneralTabProps<TFieldValues>) {
   const { i18n } = useLingui();
   return (
     <div className="grid gap-6">
@@ -43,7 +47,7 @@ export function GeneralTab({ form, basePath }: GeneralTabProps) {
         <CardContent className="grid grid-cols-1 sm:grid-cols-2 gap-6">
           <FormField
             control={form.control}
-            name={basePath ? `${basePath}.fetch_delay_ms` : 'fetch_delay_ms'}
+            name={configPath<TFieldValues>(basePath, 'fetch_delay_ms')}
             render={({ field }) => (
               <FormItem className="space-y-2">
                 <ConfigFieldLabel>
@@ -73,9 +77,7 @@ export function GeneralTab({ form, basePath }: GeneralTabProps) {
           />
           <FormField
             control={form.control}
-            name={
-              basePath ? `${basePath}.download_delay_ms` : 'download_delay_ms'
-            }
+            name={configPath<TFieldValues>(basePath, 'download_delay_ms')}
             render={({ field }) => (
               <FormItem className="space-y-2">
                 <ConfigFieldLabel>

--- a/rust-srec/frontend/src/components/config/platforms/tabs/platform-specific-tab.tsx
+++ b/rust-srec/frontend/src/components/config/platforms/tabs/platform-specific-tab.tsx
@@ -1,6 +1,6 @@
 import type { FieldValues, Path, UseFormReturn } from 'react-hook-form';
 import type { ReactElement } from 'react';
-import { z } from 'zod';
+import type { z } from 'zod';
 import {
   FormControl,
   FormDescription,

--- a/rust-srec/frontend/src/components/config/platforms/tabs/platform-specific-tab.tsx
+++ b/rust-srec/frontend/src/components/config/platforms/tabs/platform-specific-tab.tsx
@@ -1,4 +1,6 @@
-import { UseFormReturn } from 'react-hook-form';
+import type { FieldValues, Path, UseFormReturn } from 'react-hook-form';
+import type { ReactElement } from 'react';
+import { z } from 'zod';
 import {
   FormControl,
   FormDescription,
@@ -32,8 +34,9 @@ import { TikTokConfigFields } from './specific-configs/tiktok-config-fields';
 import { TwitcastingConfigFields } from './specific-configs/twitcasting-config-fields';
 import { SoopConfigFields } from './specific-configs/soop-config-fields';
 import { BigoConfigFields } from './specific-configs/bigo-config-fields';
+import { configPath } from '@/components/config/shared/form-path';
 
-const PLATFORM_SCHEMAS: Record<string, any> = {
+const PLATFORM_SCHEMAS: Record<string, z.ZodType> = {
   huya: HuyaConfigSchema,
   douyin: DouyinConfigSchema,
   bilibili: BilibiliConfigSchema,
@@ -45,7 +48,17 @@ const PLATFORM_SCHEMAS: Record<string, any> = {
   bigo: BigoConfigSchema,
 };
 
-const SPECIFIC_CONFIG_COMPONENTS: Record<string, any> = {
+/**
+ * A per-platform field group. Each one renders the options stored under
+ * `fieldName`, so they are interchangeable from this tab's point of view.
+ */
+type PlatformConfigFields = <TFieldValues extends FieldValues>(props: {
+  form: UseFormReturn<TFieldValues>;
+  fieldName: Path<TFieldValues>;
+  inherited?: boolean;
+}) => ReactElement;
+
+const SPECIFIC_CONFIG_COMPONENTS: Record<string, PlatformConfigFields> = {
   huya: HuyaConfigFields,
   douyin: DouyinConfigFields,
   bilibili: BilibiliConfigFields,
@@ -82,15 +95,15 @@ function identityOf(value: unknown): string {
  * the form value is only adopted when it differs from what this editor last
  * emitted — a config load or a form reset, never a keystroke.
  */
-function RawJsonEditor({
+function RawJsonEditor<TFieldValues extends FieldValues>({
   form,
   fieldName,
   platformName,
   value,
   onChange,
 }: {
-  form: UseFormReturn<any>;
-  fieldName: string;
+  form: UseFormReturn<TFieldValues>;
+  fieldName: Path<TFieldValues>;
   platformName?: string;
   value: unknown;
   onChange: (value: unknown) => void;
@@ -176,8 +189,8 @@ function RawJsonEditor({
   );
 }
 
-interface PlatformSpecificTabProps {
-  form: UseFormReturn<any>;
+interface PlatformSpecificTabProps<TFieldValues extends FieldValues> {
+  form: UseFormReturn<TFieldValues>;
   basePath?: string;
   platformName?: string;
   /**
@@ -189,14 +202,14 @@ interface PlatformSpecificTabProps {
   inherited?: boolean;
 }
 
-export function PlatformSpecificTab({
+export function PlatformSpecificTab<TFieldValues extends FieldValues>({
   form,
   basePath,
   platformName,
   field: fieldKey = 'platform_specific_config',
   inherited = false,
-}: PlatformSpecificTabProps) {
-  const fieldName = basePath ? `${basePath}.${fieldKey}` : fieldKey;
+}: PlatformSpecificTabProps<TFieldValues>) {
+  const fieldName = configPath<TFieldValues>(basePath, fieldKey);
 
   const [viewMode, setViewMode] = useState<'form' | 'json'>('form');
 

--- a/rust-srec/frontend/src/components/config/platforms/tabs/specific-configs/__tests__/bilibili-inheritance.test.tsx
+++ b/rust-srec/frontend/src/components/config/platforms/tabs/specific-configs/__tests__/bilibili-inheritance.test.tsx
@@ -8,15 +8,18 @@ import {
   screen,
   waitFor,
 } from '@testing-library/react';
-import { useForm, type UseFormReturn } from 'react-hook-form';
-import { z } from 'zod';
+import type { ReactNode } from 'react';
+import { useForm } from 'react-hook-form';
+import type { FieldValues, UseFormReturn } from 'react-hook-form';
 import { Form } from '@/components/ui/form';
 import {
   PlatformConfigFormSchema,
-  StreamerSpecificConfigFormSchema,
+  StreamerFormSchema,
+  StreamerFormValues,
   UpdateTemplateRequestSchema,
 } from '@/api/schemas';
 import { PlatformOverrideCard } from '@/components/config/templates/tabs/platform-override-card';
+import type { TemplateFormValues } from '@/components/config/templates/template-editor';
 import { StreamerConfiguration } from '@/components/streamers/config/streamer-configuration';
 import { PlatformSpecificTab } from '../../platform-specific-tab';
 
@@ -33,63 +36,150 @@ vi.mock('@/components/config/shared-config-editor', () => ({
       ?.content,
 }));
 
-const schemas = {
-  platform: PlatformConfigFormSchema.partial(),
-  template: UpdateTemplateRequestSchema,
-  streamer: z.object({
-    streamer_specific_config: StreamerSpecificConfigFormSchema,
-  }),
-};
-type Scope = keyof typeof schemas;
-function values(scope: Scope, quality: number | null | undefined) {
-  const options = { quality };
-  if (scope === 'platform') return { platform_specific_config: options };
-  if (scope === 'template')
-    return {
-      name: 'Test',
-      platform_overrides: { bilibili: { platform_specific_config: options } },
-    };
-  return { streamer_specific_config: { platform_extras: options } };
+const PlatformFormSchema = PlatformConfigFormSchema.partial();
+
+type Quality = number | null | undefined;
+type Scope = 'platform' | 'template' | 'streamer';
+
+/** The same Bilibili quality field, as each scope stores it. */
+const platformValues = (quality: Quality) => ({
+  platform_specific_config: { quality },
+});
+const templateValues = (quality: Quality) => ({
+  name: 'Test',
+  platform_overrides: { bilibili: { platform_specific_config: { quality } } },
+});
+const streamerValues = (quality: Quality) => ({
+  name: 'Test',
+  url: 'https://live.bilibili.com/1',
+  enabled: true,
+  streamer_specific_config: { platform_extras: { quality } },
+});
+
+/** Reads a property of a submitted or current form value, which arrives untyped. */
+function at(value: unknown, key: string): unknown {
+  return value && typeof value === 'object'
+    ? (value as Record<string, unknown>)[key]
+    : undefined;
 }
-function qualityFrom(scope: Scope, data: any) {
-  if (scope === 'platform') return data.platform_specific_config?.quality;
-  if (scope === 'template')
-    return data.platform_overrides.bilibili.platform_specific_config?.quality;
-  return data.streamer_specific_config.platform_extras?.quality;
+
+function qualityFrom(scope: Scope, data: unknown): unknown {
+  if (scope === 'platform') {
+    return at(at(data, 'platform_specific_config'), 'quality');
+  }
+  if (scope === 'template') {
+    const override = at(at(data, 'platform_overrides'), 'bilibili');
+    return at(at(override, 'platform_specific_config'), 'quality');
+  }
+  return at(
+    at(at(data, 'streamer_specific_config'), 'platform_extras'),
+    'quality',
+  );
 }
+
+/** The submit and cancel controls the assertions drive, around the fields under test. */
+function Shell<TFieldValues extends FieldValues>({
+  form,
+  onSave,
+  onCancel,
+  children,
+}: {
+  form: UseFormReturn<TFieldValues>;
+  onSave: (data: TFieldValues) => void;
+  onCancel: () => void;
+  children: ReactNode;
+}) {
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSave)}>
+        {children}
+        <button type="submit">Save</button>
+        <button type="button" onClick={onCancel}>
+          Cancel
+        </button>
+      </form>
+    </Form>
+  );
+}
+
+/**
+ * Each scope binds its own schema and form type, so the harness is per scope and the assertions
+ * share only what they read back: the current values, the dirty flag, and a reset.
+ */
 function renderFields(scope: Scope, quality?: number | null) {
-  let form: UseFormReturn<any>;
   const onSave = vi.fn();
-  function Harness() {
-    form = useForm<any>({
-      defaultValues: values(scope, quality),
-      resolver: zodResolver(schemas[scope]) as any,
+  let getValues!: () => unknown;
+  let isDirty!: () => boolean;
+  let reset!: (next: Quality) => void;
+
+  function PlatformHarness() {
+    const form = useForm({
+      defaultValues: platformValues(quality),
+      resolver: zodResolver(PlatformFormSchema),
     });
+    getValues = () => form.getValues();
+    isDirty = () => form.formState.isDirty;
+    reset = (next) => form.reset(platformValues(next));
     return (
-      <Form {...form}>
-        <form onSubmit={form.handleSubmit(onSave)}>
-          {scope === 'template' ? (
-            <PlatformOverrideCard
-              form={form}
-              platformName="bilibili"
-              onRemove={() => {}}
-            />
-          ) : scope === 'streamer' ? (
-            <StreamerConfiguration form={form} />
-          ) : (
-            <PlatformSpecificTab form={form} platformName="bilibili" />
-          )}
-          <button type="submit">Save</button>
-          <button
-            type="button"
-            onClick={() => form.reset(values(scope, quality))}
-          >
-            Cancel
-          </button>
-        </form>
-      </Form>
+      <Shell
+        form={form}
+        onSave={onSave}
+        onCancel={() => form.reset(platformValues(quality))}
+      >
+        <PlatformSpecificTab form={form} platformName="bilibili" />
+      </Shell>
     );
   }
+
+  function TemplateHarness() {
+    const form = useForm<TemplateFormValues>({
+      defaultValues: templateValues(quality),
+      resolver: zodResolver(UpdateTemplateRequestSchema),
+    });
+    getValues = () => form.getValues();
+    isDirty = () => form.formState.isDirty;
+    reset = (next) => form.reset(templateValues(next));
+    return (
+      <Shell
+        form={form}
+        onSave={onSave}
+        onCancel={() => form.reset(templateValues(quality))}
+      >
+        <PlatformOverrideCard
+          form={form}
+          platformName="bilibili"
+          onRemove={() => {}}
+        />
+      </Shell>
+    );
+  }
+
+  function StreamerHarness() {
+    const form = useForm<StreamerFormValues>({
+      defaultValues: streamerValues(quality),
+      resolver: zodResolver(StreamerFormSchema),
+    });
+    getValues = () => form.getValues();
+    isDirty = () => form.formState.isDirty;
+    reset = (next) => form.reset(streamerValues(next));
+    return (
+      <Shell
+        form={form}
+        onSave={onSave}
+        onCancel={() => form.reset(streamerValues(quality))}
+      >
+        <StreamerConfiguration form={form} />
+      </Shell>
+    );
+  }
+
+  const Harness =
+    scope === 'platform'
+      ? PlatformHarness
+      : scope === 'template'
+        ? TemplateHarness
+        : StreamerHarness;
+
   render(
     <I18nProvider i18n={setupI18n({ locale: 'en', messages: { en: {} } })}>
       <Harness />
@@ -97,7 +187,7 @@ function renderFields(scope: Scope, quality?: number | null) {
   );
   if (scope === 'template')
     fireEvent.click(screen.getByRole('button', { name: 'Toggle' }));
-  return { onSave, form: () => form! };
+  return { onSave, getValues, isDirty, reset };
 }
 async function selectQuality(label: string) {
   fireEvent.keyDown(
@@ -122,14 +212,14 @@ describe.each(['platform', 'template', 'streamer'] as const)(
     it.each([undefined, null])(
       'keeps %j quality unset through mount, cancel, and validated save',
       async (quality) => {
-        const { onSave, form } = renderFields(scope, quality);
+        const { onSave, getValues, isDirty } = renderFields(scope, quality);
         const label =
           scope === 'platform' ? 'Default: Dolby Vision (30000)' : 'Inherited';
         expect(
           screen.getByRole('combobox', { name: /Preferred Quality/i }),
         ).toHaveTextContent(label);
-        expect(qualityFrom(scope, form().getValues())).toBe(quality);
-        expect(form().formState.isDirty).toBe(false);
+        expect(qualityFrom(scope, getValues())).toBe(quality);
+        expect(isDirty()).toBe(false);
         fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
         fireEvent.click(screen.getByRole('button', { name: 'Save' }));
         await waitFor(() => expect(onSave).toHaveBeenCalled());
@@ -152,18 +242,18 @@ describe.each(['platform', 'template', 'streamer'] as const)(
     });
 
     it('adopts saved resets and retains zero or older numeric selections', () => {
-      const { form } = renderFields(scope, 20000);
+      const { getValues, reset } = renderFields(scope, 20000);
       const trigger = () =>
         screen.getByRole('combobox', {
           name: /Preferred Quality/i,
         });
-      act(() => form().reset(values(scope, 0)));
+      act(() => reset(0));
       expect(trigger()).toHaveTextContent('Lowest (0)');
-      act(() => form().reset(values(scope, 127)));
-      expect(qualityFrom(scope, form().getValues())).toBe(127);
+      act(() => reset(127));
+      expect(qualityFrom(scope, getValues())).toBe(127);
       expect(trigger()).toHaveTextContent('127');
-      act(() => form().reset(values(scope, undefined)));
-      expect(qualityFrom(scope, form().getValues())).toBeUndefined();
+      act(() => reset(undefined));
+      expect(qualityFrom(scope, getValues())).toBeUndefined();
       expect(trigger()).toHaveTextContent(
         scope === 'platform' ? 'Default:' : 'Inherited',
       );

--- a/rust-srec/frontend/src/components/config/platforms/tabs/specific-configs/__tests__/douyu-config-fields.test.tsx
+++ b/rust-srec/frontend/src/components/config/platforms/tabs/specific-configs/__tests__/douyu-config-fields.test.tsx
@@ -6,13 +6,15 @@ import { useForm, type UseFormReturn } from 'react-hook-form';
 import { Form } from '@/components/ui/form';
 import { PlatformSpecificTab } from '../../platform-specific-tab';
 
+type Values = { platform_specific_config: Record<string, unknown> };
+
 function renderFields(
   options?: Record<string, unknown>,
   { inherited = false } = {},
 ) {
-  let form!: UseFormReturn<any>;
+  let form!: UseFormReturn<Values>;
   function Harness() {
-    form = useForm<any>({
+    form = useForm<Values>({
       defaultValues: { platform_specific_config: options },
     });
     return (

--- a/rust-srec/frontend/src/components/config/platforms/tabs/specific-configs/bigo-config-fields.tsx
+++ b/rust-srec/frontend/src/components/config/platforms/tabs/specific-configs/bigo-config-fields.tsx
@@ -1,4 +1,4 @@
-import { UseFormReturn } from 'react-hook-form';
+import type { FieldValues, Path, UseFormReturn } from 'react-hook-form';
 import {
   FormControl,
   FormDescription,
@@ -16,13 +16,18 @@ import {
   ConfigFieldLabel,
   ConfigSectionHeading,
 } from '@/components/config/shared/config-field';
+import { configPath } from '@/components/config/shared/form-path';
 
-interface BigoConfigFieldsProps {
-  form: UseFormReturn<any>;
-  fieldName: string;
+interface BigoConfigFieldsProps<TFieldValues extends FieldValues> {
+  form: UseFormReturn<TFieldValues>;
+  /** Path to the object holding this platform's options. */
+  fieldName: Path<TFieldValues>;
 }
 
-export function BigoConfigFields({ form, fieldName }: BigoConfigFieldsProps) {
+export function BigoConfigFields<TFieldValues extends FieldValues>({
+  form,
+  fieldName,
+}: BigoConfigFieldsProps<TFieldValues>) {
   const { i18n } = useLingui();
   return (
     <div className="space-y-12">
@@ -34,7 +39,7 @@ export function BigoConfigFields({ form, fieldName }: BigoConfigFieldsProps) {
         <div className="grid gap-6">
           <FormField
             control={form.control}
-            name={`${fieldName}.stream_password`}
+            name={configPath<TFieldValues>(fieldName, 'stream_password')}
             render={({ field }) => (
               <FormItem className="space-y-4">
                 <ConfigFieldLabel accent="sky">
@@ -69,7 +74,7 @@ export function BigoConfigFields({ form, fieldName }: BigoConfigFieldsProps) {
         <div className="grid gap-6">
           <FormField
             control={form.control}
-            name={`${fieldName}.mint_token`}
+            name={configPath<TFieldValues>(fieldName, 'mint_token')}
             render={({ field }) => (
               <FormItem className="flex flex-row items-center justify-between rounded-xl border border-border/40 bg-background/40 px-4 py-3">
                 <div className="space-y-1 pr-4">

--- a/rust-srec/frontend/src/components/config/platforms/tabs/specific-configs/bilibili-config-fields.tsx
+++ b/rust-srec/frontend/src/components/config/platforms/tabs/specific-configs/bilibili-config-fields.tsx
@@ -1,4 +1,5 @@
-import { get, UseFormReturn } from 'react-hook-form';
+import { get } from 'react-hook-form';
+import type { FieldValues, Path, UseFormReturn } from 'react-hook-form';
 import {
   FormControl,
   FormDescription,
@@ -21,10 +22,12 @@ import {
   ConfigFieldLabel,
   ConfigSectionHeading,
 } from '@/components/config/shared/config-field';
+import { configPath } from '@/components/config/shared/form-path';
 
-interface BilibiliConfigFieldsProps {
-  form: UseFormReturn<any>;
-  fieldName: string;
+interface BilibiliConfigFieldsProps<TFieldValues extends FieldValues> {
+  form: UseFormReturn<TFieldValues>;
+  /** Path to the object holding this platform's options. */
+  fieldName: Path<TFieldValues>;
   inherited?: boolean;
 }
 
@@ -41,11 +44,11 @@ const QUALITY_OPTIONS = [
   { code: 0, label: msg`Lowest (0)` },
 ];
 
-export function BilibiliConfigFields({
+export function BilibiliConfigFields<TFieldValues extends FieldValues>({
   form,
   fieldName,
   inherited = false,
-}: BilibiliConfigFieldsProps) {
+}: BilibiliConfigFieldsProps<TFieldValues>) {
   const { i18n } = useLingui();
   const defaultLabel = inherited
     ? i18n._(msg`Inherited`)
@@ -69,7 +72,7 @@ export function BilibiliConfigFields({
               ) ?? 'unset'
             }
             control={form.control}
-            name={`${fieldName}.quality`}
+            name={configPath<TFieldValues>(fieldName, 'quality')}
             render={({ field }) => {
               const selected = QUALITY_OPTIONS.find(
                 (option) => option.code === field.value,
@@ -126,7 +129,10 @@ export function BilibiliConfigFields({
 
           <EndStreamOnDanmuCloseField
             form={form}
-            name={`${fieldName}.end_stream_on_danmu_stream_closed`}
+            name={configPath<TFieldValues>(
+              fieldName,
+              'end_stream_on_danmu_stream_closed',
+            )}
           />
         </div>
       </section>

--- a/rust-srec/frontend/src/components/config/platforms/tabs/specific-configs/douyin-config-fields.tsx
+++ b/rust-srec/frontend/src/components/config/platforms/tabs/specific-configs/douyin-config-fields.tsx
@@ -1,4 +1,4 @@
-import { UseFormReturn } from 'react-hook-form';
+import type { FieldValues, Path, UseFormReturn } from 'react-hook-form';
 import {
   FormControl,
   FormDescription,
@@ -24,16 +24,18 @@ import {
   ConfigFieldLabel,
   ConfigSectionHeading,
 } from '@/components/config/shared/config-field';
+import { configPath } from '@/components/config/shared/form-path';
 
-interface DouyinConfigFieldsProps {
-  form: UseFormReturn<any>;
-  fieldName: string;
+interface DouyinConfigFieldsProps<TFieldValues extends FieldValues> {
+  form: UseFormReturn<TFieldValues>;
+  /** Path to the object holding this platform's options. */
+  fieldName: Path<TFieldValues>;
 }
 
-export function DouyinConfigFields({
+export function DouyinConfigFields<TFieldValues extends FieldValues>({
   form,
   fieldName,
-}: DouyinConfigFieldsProps) {
+}: DouyinConfigFieldsProps<TFieldValues>) {
   return (
     <div className="space-y-12">
       {/* Extraction Settings Section */}
@@ -45,7 +47,7 @@ export function DouyinConfigFields({
         <div className="grid gap-6">
           <FormField
             control={form.control}
-            name={`${fieldName}.force_origin_quality`}
+            name={configPath<TFieldValues>(fieldName, 'force_origin_quality')}
             render={({ field }) => (
               <FormItem className="flex flex-row items-center justify-between rounded-2xl border bg-muted/5 p-5 transition-all hover:bg-muted/10 border-border/50">
                 <div className="space-y-1.5 pr-4">
@@ -80,7 +82,7 @@ export function DouyinConfigFields({
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             <FormField
               control={form.control}
-              name={`${fieldName}.double_screen`}
+              name={configPath<TFieldValues>(fieldName, 'double_screen')}
               render={({ field }) => (
                 <FormItem className="flex flex-row items-center justify-between rounded-xl border border-border/40 p-4 bg-background/50 transition-colors hover:bg-muted/5">
                   <div className="flex items-center gap-3">
@@ -109,7 +111,7 @@ export function DouyinConfigFields({
 
             <FormField
               control={form.control}
-              name={`${fieldName}.force_mobile_api`}
+              name={configPath<TFieldValues>(fieldName, 'force_mobile_api')}
               render={({ field }) => (
                 <FormItem className="flex flex-row items-center justify-between rounded-xl border border-border/40 p-4 bg-background/50 transition-colors hover:bg-muted/5">
                   <div className="flex items-center gap-3">
@@ -139,7 +141,7 @@ export function DouyinConfigFields({
 
           <FormField
             control={form.control}
-            name={`${fieldName}.skip_interactive_games`}
+            name={configPath<TFieldValues>(fieldName, 'skip_interactive_games')}
             render={({ field }) => (
               <FormItem className="flex flex-row items-center justify-between rounded-xl border border-border/40 p-4 bg-background/50 transition-colors hover:bg-muted/5">
                 <div className="flex items-center gap-3">
@@ -179,7 +181,7 @@ export function DouyinConfigFields({
         <div className="space-y-6">
           <FormField
             control={form.control}
-            name={`${fieldName}.ttwid_management_mode`}
+            name={configPath<TFieldValues>(fieldName, 'ttwid_management_mode')}
             render={({ field }) => (
               <FormItem>
                 <ConfigFieldLabel accent="indigo" className="mb-3">
@@ -219,7 +221,7 @@ export function DouyinConfigFields({
 
           <FormField
             control={form.control}
-            name={`${fieldName}.ttwid`}
+            name={configPath<TFieldValues>(fieldName, 'ttwid')}
             render={({ field }) => (
               <FormItem>
                 <div className="flex items-center gap-2 mb-3">
@@ -255,7 +257,10 @@ export function DouyinConfigFields({
 
         <EndStreamOnDanmuCloseField
           form={form}
-          name={`${fieldName}.end_stream_on_danmu_stream_closed`}
+          name={configPath<TFieldValues>(
+            fieldName,
+            'end_stream_on_danmu_stream_closed',
+          )}
         />
       </section>
     </div>

--- a/rust-srec/frontend/src/components/config/platforms/tabs/specific-configs/douyu-config-fields.tsx
+++ b/rust-srec/frontend/src/components/config/platforms/tabs/specific-configs/douyu-config-fields.tsx
@@ -1,4 +1,4 @@
-import { UseFormReturn } from 'react-hook-form';
+import type { FieldValues, Path, UseFormReturn } from 'react-hook-form';
 import {
   FormControl,
   FormDescription,
@@ -17,20 +17,22 @@ import {
   ConfigFieldLabel,
   ConfigSectionHeading,
 } from '@/components/config/shared/config-field';
+import { configPath } from '@/components/config/shared/form-path';
 import { useDefaultPlaceholder } from '@/hooks/use-default-placeholder';
 import { NumberInput } from '@/components/ui/number-input';
 
-interface DouyuConfigFieldsProps {
-  form: UseFormReturn<any>;
-  fieldName: string;
+interface DouyuConfigFieldsProps<TFieldValues extends FieldValues> {
+  form: UseFormReturn<TFieldValues>;
+  /** Path to the object holding this platform's options. */
+  fieldName: Path<TFieldValues>;
   inherited?: boolean;
 }
 
-export function DouyuConfigFields({
+export function DouyuConfigFields<TFieldValues extends FieldValues>({
   form,
   fieldName,
   inherited = false,
-}: DouyuConfigFieldsProps) {
+}: DouyuConfigFieldsProps<TFieldValues>) {
   const { i18n } = useLingui();
   const defaultPlaceholder = useDefaultPlaceholder();
   // A template or streamer layer leaves a blank field to the layer above it;
@@ -50,7 +52,7 @@ export function DouyuConfigFields({
           <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
             <FormField
               control={form.control}
-              name={`${fieldName}.cdn`}
+              name={configPath<TFieldValues>(fieldName, 'cdn')}
               render={({ field }) => (
                 <FormItem>
                   <div className="flex items-center gap-2 mb-3">
@@ -81,7 +83,7 @@ export function DouyuConfigFields({
             />
             <FormField
               control={form.control}
-              name={`${fieldName}.rate`}
+              name={configPath<TFieldValues>(fieldName, 'rate')}
               render={({ field }) => (
                 <FormItem>
                   <ConfigFieldLabel accent="indigo" className="mb-3">
@@ -117,7 +119,10 @@ export function DouyuConfigFields({
         <div className="grid gap-6">
           <FormField
             control={form.control}
-            name={`${fieldName}.disable_interactive_game`}
+            name={configPath<TFieldValues>(
+              fieldName,
+              'disable_interactive_game',
+            )}
             render={({ field }) => (
               <FormItem className="flex flex-row items-center justify-between rounded-xl border border-border/40 p-4 bg-background/50 transition-colors hover:bg-muted/5">
                 <div className="space-y-0.5">
@@ -144,7 +149,7 @@ export function DouyuConfigFields({
 
           <FormField
             control={form.control}
-            name={`${fieldName}.request_retries`}
+            name={configPath<TFieldValues>(fieldName, 'request_retries')}
             render={({ field }) => (
               <FormItem>
                 <div className="flex items-center gap-2 mb-3">

--- a/rust-srec/frontend/src/components/config/platforms/tabs/specific-configs/douyu-quality-combobox.tsx
+++ b/rust-srec/frontend/src/components/config/platforms/tabs/specific-configs/douyu-quality-combobox.tsx
@@ -1,5 +1,6 @@
 import { type ComponentPropsWithoutRef } from 'react';
-import { UseFormReturn, useWatch } from 'react-hook-form';
+import { useWatch } from 'react-hook-form';
+import type { FieldValues, Path, UseFormReturn } from 'react-hook-form';
 import { msg } from '@lingui/core/macro';
 import { useLingui } from '@lingui/react';
 import { Trans } from '@lingui/react/macro';
@@ -7,13 +8,17 @@ import {
   EditableCombobox,
   type EditableComboboxOption,
 } from '@/components/ui/editable-combobox';
+import {
+  configPath,
+  setConfigValue,
+} from '@/components/config/shared/form-path';
 
-interface DouyuQualityComboboxProps extends Omit<
-  ComponentPropsWithoutRef<'div'>,
-  'onChange'
-> {
-  fieldName: string;
-  form: UseFormReturn<any>;
+interface DouyuQualityComboboxProps<
+  TFieldValues extends FieldValues,
+> extends Omit<ComponentPropsWithoutRef<'div'>, 'onChange'> {
+  /** Path to the object holding Douyu's options. */
+  fieldName: Path<TFieldValues>;
+  form: UseFormReturn<TFieldValues>;
   onChange: (value: number) => void;
   value: unknown;
 }
@@ -89,15 +94,15 @@ function parseQualityInput(value: string) {
   return null;
 }
 
-export function DouyuQualityCombobox({
+export function DouyuQualityCombobox<TFieldValues extends FieldValues>({
   fieldName,
   form,
   onChange,
   value,
   ...comboboxProps
-}: DouyuQualityComboboxProps) {
+}: DouyuQualityComboboxProps<TFieldValues>) {
   const { i18n } = useLingui();
-  const onlyAudioPath = `${fieldName}.only_audio`;
+  const onlyAudioPath = configPath<TFieldValues>(fieldName, 'only_audio');
   // A field-level subscription: toggling audio-only re-renders this combobox, not the component
   // that owns `useForm`.
   const onlyAudio = !!useWatch({ control: form.control, name: onlyAudioPath });
@@ -115,12 +120,12 @@ export function DouyuQualityCombobox({
 
   const applyRate = (nextRate: number) => {
     onChange(nextRate);
-    form.setValue(onlyAudioPath, false, { shouldDirty: true });
+    setConfigValue(form, onlyAudioPath, false, { shouldDirty: true });
   };
 
   const applyAudioOnly = () => {
     onChange(0);
-    form.setValue(onlyAudioPath, true, { shouldDirty: true });
+    setConfigValue(form, onlyAudioPath, true, { shouldDirty: true });
   };
 
   const options: EditableComboboxOption[] = [

--- a/rust-srec/frontend/src/components/config/platforms/tabs/specific-configs/huya-config-fields.tsx
+++ b/rust-srec/frontend/src/components/config/platforms/tabs/specific-configs/huya-config-fields.tsx
@@ -1,4 +1,4 @@
-import { UseFormReturn } from 'react-hook-form';
+import type { FieldValues, Path, UseFormReturn } from 'react-hook-form';
 import {
   FormControl,
   FormDescription,
@@ -23,6 +23,7 @@ import {
   ConfigFieldLabel,
   ConfigSectionHeading,
 } from '@/components/config/shared/config-field';
+import { configPath } from '@/components/config/shared/form-path';
 
 const HUYA_PLATFORM_LABELS: Record<
   (typeof HuyaPlatformValues)[number],
@@ -39,12 +40,16 @@ const HUYA_PLATFORM_LABELS: Record<
   random: 'Random',
 };
 
-interface HuyaConfigFieldsProps {
-  form: UseFormReturn<any>;
-  fieldName: string;
+interface HuyaConfigFieldsProps<TFieldValues extends FieldValues> {
+  form: UseFormReturn<TFieldValues>;
+  /** Path to the object holding this platform's options. */
+  fieldName: Path<TFieldValues>;
 }
 
-export function HuyaConfigFields({ form, fieldName }: HuyaConfigFieldsProps) {
+export function HuyaConfigFields<TFieldValues extends FieldValues>({
+  form,
+  fieldName,
+}: HuyaConfigFieldsProps<TFieldValues>) {
   const { i18n } = useLingui();
   return (
     <div className="space-y-12">
@@ -57,7 +62,7 @@ export function HuyaConfigFields({ form, fieldName }: HuyaConfigFieldsProps) {
         <div className="space-y-6">
           <FormField
             control={form.control}
-            name={`${fieldName}.api_mode`}
+            name={configPath<TFieldValues>(fieldName, 'api_mode')}
             render={({ field }) => (
               <FormItem>
                 <ConfigFieldLabel accent="indigo" className="mb-3">
@@ -106,7 +111,7 @@ export function HuyaConfigFields({ form, fieldName }: HuyaConfigFieldsProps) {
 
           <FormField
             control={form.control}
-            name={`${fieldName}.platform`}
+            name={configPath<TFieldValues>(fieldName, 'platform')}
             render={({ field }) => (
               <FormItem>
                 <ConfigFieldLabel accent="indigo" className="mb-3">
@@ -157,7 +162,7 @@ export function HuyaConfigFields({ form, fieldName }: HuyaConfigFieldsProps) {
         <div className="grid gap-6">
           <FormField
             control={form.control}
-            name={`${fieldName}.force_origin_quality`}
+            name={configPath<TFieldValues>(fieldName, 'force_origin_quality')}
             render={({ field }) => (
               <FormItem className="flex flex-row items-center justify-between rounded-2xl border bg-muted/5 p-5 transition-all hover:bg-muted/10 border-border/50">
                 <div className="space-y-1.5 pr-4">

--- a/rust-srec/frontend/src/components/config/platforms/tabs/specific-configs/soop-config-fields.tsx
+++ b/rust-srec/frontend/src/components/config/platforms/tabs/specific-configs/soop-config-fields.tsx
@@ -1,4 +1,4 @@
-import { UseFormReturn } from 'react-hook-form';
+import type { FieldValues, Path, UseFormReturn } from 'react-hook-form';
 import {
   FormControl,
   FormDescription,
@@ -14,13 +14,18 @@ import {
   ConfigFieldLabel,
   ConfigSectionHeading,
 } from '@/components/config/shared/config-field';
+import { configPath } from '@/components/config/shared/form-path';
 
-interface SoopConfigFieldsProps {
-  form: UseFormReturn<any>;
-  fieldName: string;
+interface SoopConfigFieldsProps<TFieldValues extends FieldValues> {
+  form: UseFormReturn<TFieldValues>;
+  /** Path to the object holding this platform's options. */
+  fieldName: Path<TFieldValues>;
 }
 
-export function SoopConfigFields({ form, fieldName }: SoopConfigFieldsProps) {
+export function SoopConfigFields<TFieldValues extends FieldValues>({
+  form,
+  fieldName,
+}: SoopConfigFieldsProps<TFieldValues>) {
   const { i18n } = useLingui();
   return (
     <div className="space-y-12">
@@ -32,7 +37,7 @@ export function SoopConfigFields({ form, fieldName }: SoopConfigFieldsProps) {
         <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
           <FormField
             control={form.control}
-            name={`${fieldName}.username`}
+            name={configPath<TFieldValues>(fieldName, 'username')}
             render={({ field }) => (
               <FormItem className="space-y-4">
                 <ConfigFieldLabel accent="emerald">
@@ -61,7 +66,7 @@ export function SoopConfigFields({ form, fieldName }: SoopConfigFieldsProps) {
 
           <FormField
             control={form.control}
-            name={`${fieldName}.password`}
+            name={configPath<TFieldValues>(fieldName, 'password')}
             render={({ field }) => (
               <FormItem className="space-y-4">
                 <ConfigFieldLabel accent="emerald">
@@ -97,7 +102,7 @@ export function SoopConfigFields({ form, fieldName }: SoopConfigFieldsProps) {
 
         <FormField
           control={form.control}
-          name={`${fieldName}.stream_password`}
+          name={configPath<TFieldValues>(fieldName, 'stream_password')}
           render={({ field }) => (
             <FormItem className="space-y-4 max-w-xl">
               <ConfigFieldLabel accent="emerald">

--- a/rust-srec/frontend/src/components/config/platforms/tabs/specific-configs/tiktok-config-fields.tsx
+++ b/rust-srec/frontend/src/components/config/platforms/tabs/specific-configs/tiktok-config-fields.tsx
@@ -1,4 +1,4 @@
-import { UseFormReturn } from 'react-hook-form';
+import type { FieldValues, Path, UseFormReturn } from 'react-hook-form';
 import {
   FormControl,
   FormDescription,
@@ -10,16 +10,18 @@ import { Switch } from '@/components/ui/switch';
 import { Trans } from '@lingui/react/macro';
 import { Zap } from 'lucide-react';
 import { ConfigSectionHeading } from '@/components/config/shared/config-field';
+import { configPath } from '@/components/config/shared/form-path';
 
-interface TikTokConfigFieldsProps {
-  form: UseFormReturn<any>;
-  fieldName: string;
+interface TikTokConfigFieldsProps<TFieldValues extends FieldValues> {
+  form: UseFormReturn<TFieldValues>;
+  /** Path to the object holding this platform's options. */
+  fieldName: Path<TFieldValues>;
 }
 
-export function TikTokConfigFields({
+export function TikTokConfigFields<TFieldValues extends FieldValues>({
   form,
   fieldName,
-}: TikTokConfigFieldsProps) {
+}: TikTokConfigFieldsProps<TFieldValues>) {
   return (
     <div className="space-y-12">
       {/* Extraction Settings Section */}
@@ -31,7 +33,7 @@ export function TikTokConfigFields({
         <div className="grid gap-6">
           <FormField
             control={form.control}
-            name={`${fieldName}.force_origin_quality`}
+            name={configPath<TFieldValues>(fieldName, 'force_origin_quality')}
             render={({ field }) => (
               <FormItem className="flex flex-row items-center justify-between rounded-2xl border bg-muted/5 p-5 transition-all hover:bg-muted/10 border-border/50">
                 <div className="space-y-1.5 pr-4">

--- a/rust-srec/frontend/src/components/config/platforms/tabs/specific-configs/twitcasting-config-fields.tsx
+++ b/rust-srec/frontend/src/components/config/platforms/tabs/specific-configs/twitcasting-config-fields.tsx
@@ -1,4 +1,4 @@
-import { UseFormReturn } from 'react-hook-form';
+import type { FieldValues, Path, UseFormReturn } from 'react-hook-form';
 import {
   FormControl,
   FormDescription,
@@ -14,16 +14,18 @@ import {
   ConfigFieldLabel,
   ConfigSectionHeading,
 } from '@/components/config/shared/config-field';
+import { configPath } from '@/components/config/shared/form-path';
 
-interface TwitcastingConfigFieldsProps {
-  form: UseFormReturn<any>;
-  fieldName: string;
+interface TwitcastingConfigFieldsProps<TFieldValues extends FieldValues> {
+  form: UseFormReturn<TFieldValues>;
+  /** Path to the object holding this platform's options. */
+  fieldName: Path<TFieldValues>;
 }
 
-export function TwitcastingConfigFields({
+export function TwitcastingConfigFields<TFieldValues extends FieldValues>({
   form,
   fieldName,
-}: TwitcastingConfigFieldsProps) {
+}: TwitcastingConfigFieldsProps<TFieldValues>) {
   const { i18n } = useLingui();
   return (
     <div className="space-y-12">
@@ -36,7 +38,7 @@ export function TwitcastingConfigFields({
         <div className="grid gap-6">
           <FormField
             control={form.control}
-            name={`${fieldName}.password`}
+            name={configPath<TFieldValues>(fieldName, 'password')}
             render={({ field }) => (
               <FormItem className="space-y-4">
                 <ConfigFieldLabel accent="indigo">

--- a/rust-srec/frontend/src/components/config/platforms/tabs/specific-configs/twitch-config-fields.tsx
+++ b/rust-srec/frontend/src/components/config/platforms/tabs/specific-configs/twitch-config-fields.tsx
@@ -1,4 +1,4 @@
-import { UseFormReturn } from 'react-hook-form';
+import type { FieldValues, Path, UseFormReturn } from 'react-hook-form';
 import {
   FormControl,
   FormDescription,
@@ -12,16 +12,18 @@ import {
   ConfigFieldLabel,
   ConfigSectionHeading,
 } from '@/components/config/shared/config-field';
+import { configPath } from '@/components/config/shared/form-path';
 
-interface TwitchConfigFieldsProps {
-  form: UseFormReturn<any>;
-  fieldName: string;
+interface TwitchConfigFieldsProps<TFieldValues extends FieldValues> {
+  form: UseFormReturn<TFieldValues>;
+  /** Path to the object holding this platform's options. */
+  fieldName: Path<TFieldValues>;
 }
 
-export function TwitchConfigFields({
+export function TwitchConfigFields<TFieldValues extends FieldValues>({
   form,
   fieldName,
-}: TwitchConfigFieldsProps) {
+}: TwitchConfigFieldsProps<TFieldValues>) {
   return (
     <div className="space-y-12">
       {/* Authentication Section */}
@@ -33,7 +35,7 @@ export function TwitchConfigFields({
         <div className="grid gap-6">
           <FormField
             control={form.control}
-            name={`${fieldName}.oauth_token`}
+            name={configPath<TFieldValues>(fieldName, 'oauth_token')}
             render={({ field }) => (
               <FormItem className="space-y-4">
                 <ConfigFieldLabel accent="indigo">

--- a/rust-srec/frontend/src/components/config/shared-config-editor.tsx
+++ b/rust-srec/frontend/src/components/config/shared-config-editor.tsx
@@ -1,6 +1,6 @@
 import { motion } from 'motion/react';
 import { useMemo } from 'react';
-import { UseFormReturn, FieldValues } from 'react-hook-form';
+import type { FieldValues, Path, UseFormReturn } from 'react-hook-form';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '../ui/tabs';
 import { EngineConfig } from '@/api/schemas';
 import { Trans } from '@lingui/react/macro';
@@ -23,20 +23,20 @@ import { NetworkSettingsCard } from './shared/network-settings-card';
 import { ProxySettingsCard } from './shared/proxy-settings-card';
 import type { CredentialSaveScope } from '@/server/functions/credentials';
 
-export interface SharedConfigPaths {
-  streamSelection: string;
-  cookies: string;
-  proxy: string;
-  retryPolicy: string;
+export interface SharedConfigPaths<T extends FieldValues> {
+  streamSelection: Path<T>;
+  cookies: Path<T>;
+  proxy: Path<T>;
+  retryPolicy: Path<T>;
   // Output settings base path (folder, template, format, engine)
   output: string;
   // Limit settings base path (duration, sizes)
   limits: string;
   // Danmu settings base path (record_danmu)
   danmu: string;
-  pipeline: string;
-  sessionCompletePipeline?: string;
-  pairedSegmentPipeline?: string;
+  pipeline: Path<T>;
+  sessionCompletePipeline?: Path<T>;
+  pairedSegmentPipeline?: Path<T>;
   // Per-platform / per-template / per-streamer overrides for the
   // offline-confirmation cadence. Omit to skip the card entirely.
   offlineCheck?: string;
@@ -59,7 +59,7 @@ export interface ExtraTab {
 
 export interface SharedConfigEditorProps<T extends FieldValues> {
   form: UseFormReturn<T>;
-  paths: SharedConfigPaths;
+  paths: SharedConfigPaths<T>;
   engines?: EngineConfig[];
   availableTabs?: ConfigTabType[];
   defaultTab?: string;

--- a/rust-srec/frontend/src/components/config/shared/__tests__/pipeline-tabs-section.test.tsx
+++ b/rust-srec/frontend/src/components/config/shared/__tests__/pipeline-tabs-section.test.tsx
@@ -1,7 +1,7 @@
 import { setupI18n } from '@lingui/core';
 import { I18nProvider } from '@lingui/react';
 import { fireEvent, render, screen } from '@testing-library/react';
-import { useForm, type UseFormReturn } from 'react-hook-form';
+import { useForm, type Path, type UseFormReturn } from 'react-hook-form';
 
 import type { DagStepDefinition } from '@/api/schemas';
 
@@ -24,7 +24,17 @@ vi.mock('@/components/pipeline/workflows/pipeline-workflow-editor', () => ({
 
 import { PipelineTabsSection } from '../pipeline-tabs-section';
 
-type Values = { pipeline: unknown };
+type Values = {
+  pipeline: unknown;
+  paired_segment_pipeline: unknown;
+  session_complete_pipeline: unknown;
+};
+
+type PipelineNames = {
+  perSegment: Path<Values>;
+  paired?: Path<Values>;
+  session?: Path<Values>;
+};
 
 const INITIAL = {
   name: 'pipeline',
@@ -35,7 +45,7 @@ function renderSection({
   names,
   dagNames,
 }: {
-  names: { perSegment: string; paired?: string; session?: string };
+  names: PipelineNames;
   dagNames?: { perSegment?: string; paired?: string; session?: string };
 }) {
   const i18n = setupI18n({ locale: 'en', messages: { en: {} } });
@@ -57,7 +67,7 @@ function renderSection({
   return { value: () => form.getValues('pipeline') };
 }
 
-const ALL_NAMES = {
+const ALL_NAMES: PipelineNames = {
   perSegment: 'pipeline',
   paired: 'paired_segment_pipeline',
   session: 'session_complete_pipeline',

--- a/rust-srec/frontend/src/components/config/shared/danmu-statistics-card.tsx
+++ b/rust-srec/frontend/src/components/config/shared/danmu-statistics-card.tsx
@@ -1,4 +1,4 @@
-import { memo, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import {
   FormControl,
   FormDescription,
@@ -14,15 +14,18 @@ import { Trans } from '@lingui/react/macro';
 import { msg } from '@lingui/core/macro';
 import { useLingui } from '@lingui/react';
 import { ChartColumn } from 'lucide-react';
-import { UseFormReturn, useWatch } from 'react-hook-form';
+import { useWatch } from 'react-hook-form';
+import type { FieldValues, Path, UseFormReturn } from 'react-hook-form';
 import {
   CONFIG_DESCRIPTION,
   CONFIG_INPUT,
   ConfigFieldLabel,
 } from './config-field';
+import { configPath } from './form-path';
+import { genericMemo } from '@/lib/generic-component';
 
-interface DanmuStatisticsCardProps {
-  form: UseFormReturn<any>;
+interface DanmuStatisticsCardProps<TFieldValues extends FieldValues> {
+  form: UseFormReturn<TFieldValues>;
   basePath?: string;
 }
 
@@ -46,12 +49,12 @@ function toWords(text: string): string[] {
  *
  * Trimming is left to the backend's `sanitized()`, which does it on save.
  */
-function IgnoredWordsField({
+function IgnoredWordsField<TFieldValues extends FieldValues>({
   form,
   name,
 }: {
-  form: UseFormReturn<any>;
-  name: string;
+  form: UseFormReturn<TFieldValues>;
+  name: Path<TFieldValues>;
 }) {
   const { i18n } = useLingui();
   const words = useWatch({ control: form.control, name }) as
@@ -115,135 +118,136 @@ function IgnoredWordsField({
  * Values are clamped server-side, which is why the hints give ranges rather than
  * the inputs enforcing them.
  */
-export const DanmuStatisticsCard = memo(
-  ({ form, basePath }: DanmuStatisticsCardProps) => {
-    const path = (field: string) =>
-      basePath
-        ? `${basePath}.danmu_statistics.${field}`
-        : `danmu_statistics.${field}`;
+function DanmuStatisticsCardImpl<TFieldValues extends FieldValues>({
+  form,
+  basePath,
+}: DanmuStatisticsCardProps<TFieldValues>) {
+  const path = (field: string) =>
+    configPath<TFieldValues>(basePath, `danmu_statistics.${field}`);
 
-    const numberField = (
-      field: string,
-      label: React.ReactNode,
-      description: React.ReactNode,
-      placeholder: string,
-    ) => (
-      <FormField
-        control={form.control}
-        name={path(field)}
-        render={({ field: formField }) => (
-          <FormItem className="space-y-2">
-            <ConfigFieldLabel>{label}</ConfigFieldLabel>
-            <FormControl>
-              <Input
-                type="number"
-                min={1}
-                className={CONFIG_INPUT}
-                placeholder={placeholder}
-                value={formField.value ?? ''}
-                onChange={(event) =>
-                  formField.onChange(
-                    event.target.value === ''
-                      ? undefined
-                      : Number(event.target.value),
-                  )
-                }
-              />
-            </FormControl>
-            <FormDescription className={CONFIG_DESCRIPTION}>
-              {description}
-            </FormDescription>
-            <FormMessage />
-          </FormItem>
-        )}
-      />
-    );
+  const numberField = (
+    field: string,
+    label: React.ReactNode,
+    description: React.ReactNode,
+    placeholder: string,
+  ) => (
+    <FormField
+      control={form.control}
+      name={path(field)}
+      render={({ field: formField }) => (
+        <FormItem className="space-y-2">
+          <ConfigFieldLabel>{label}</ConfigFieldLabel>
+          <FormControl>
+            <Input
+              type="number"
+              min={1}
+              className={CONFIG_INPUT}
+              placeholder={placeholder}
+              value={formField.value ?? ''}
+              onChange={(event) =>
+                formField.onChange(
+                  event.target.value === ''
+                    ? undefined
+                    : Number(event.target.value),
+                )
+              }
+            />
+          </FormControl>
+          <FormDescription className={CONFIG_DESCRIPTION}>
+            {description}
+          </FormDescription>
+          <FormMessage />
+        </FormItem>
+      )}
+    />
+  );
 
-    return (
-      <Card className="border-border/50 shadow-sm hover:shadow-md transition-all">
-        <CardHeader className="pb-3">
-          <div className="flex items-center gap-3">
-            <div className="p-2 rounded-lg bg-blue-500/10 text-blue-600 dark:text-blue-400">
-              <ChartColumn className="w-5 h-5" />
-            </div>
-            <div className="space-y-1">
-              <CardTitle className="text-lg">
-                <Trans>Danmu Statistics</Trans>
-              </CardTitle>
-              <p className="text-sm text-muted-foreground">
-                <Trans>
-                  How chat activity is summarised on the session page.
-                </Trans>
-              </p>
-            </div>
+  return (
+    <Card className="border-border/50 shadow-sm hover:shadow-md transition-all">
+      <CardHeader className="pb-3">
+        <div className="flex items-center gap-3">
+          <div className="p-2 rounded-lg bg-blue-500/10 text-blue-600 dark:text-blue-400">
+            <ChartColumn className="w-5 h-5" />
           </div>
-        </CardHeader>
-        <CardContent className="space-y-6">
-          <FormField
-            control={form.control}
-            name={path('enabled')}
-            render={({ field }) => (
-              <FormItem className="flex items-center justify-between gap-4">
-                <div className="space-y-1">
-                  <ConfigFieldLabel>
-                    <Trans>Collect statistics</Trans>
-                  </ConfigFieldLabel>
-                  <FormDescription className={CONFIG_DESCRIPTION}>
-                    <Trans>
-                      Chat files are still recorded when this is off; only the
-                      per-session summary, which stores viewer names, is
-                      skipped.
-                    </Trans>
-                  </FormDescription>
-                </div>
-                <FormControl>
-                  <Switch
-                    checked={field.value ?? true}
-                    onCheckedChange={field.onChange}
-                  />
-                </FormControl>
-              </FormItem>
-            )}
-          />
-
-          <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
-            {numberField(
-              'top_talkers',
-              <Trans>Top chatters to keep</Trans>,
-              <Trans>How many appear in the ranking. 1–500.</Trans>,
-              '100',
-            )}
-            {numberField(
-              'top_words',
-              <Trans>Frequent words to keep</Trans>,
-              <Trans>How many appear in the word chart. 1–500.</Trans>,
-              '50',
-            )}
-            {numberField(
-              'rate_bucket_secs',
-              <Trans>Activity resolution (seconds)</Trans>,
+          <div className="space-y-1">
+            <CardTitle className="text-lg">
+              <Trans>Danmu Statistics</Trans>
+            </CardTitle>
+            <p className="text-sm text-muted-foreground">
               <Trans>
-                Timeline granularity. Very long streams are automatically
-                coarsened past a point.
-              </Trans>,
-              '10',
-            )}
-            {numberField(
-              'talker_capacity',
-              <Trans>Chatters tracked</Trans>,
-              <Trans>
-                Counts stay exact while a stream has fewer distinct chatters
-                than this. 64–8192.
-              </Trans>,
-              '2048',
-            )}
+                How chat activity is summarised on the session page.
+              </Trans>
+            </p>
           </div>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <FormField
+          control={form.control}
+          name={path('enabled')}
+          render={({ field }) => (
+            <FormItem className="flex items-center justify-between gap-4">
+              <div className="space-y-1">
+                <ConfigFieldLabel>
+                  <Trans>Collect statistics</Trans>
+                </ConfigFieldLabel>
+                <FormDescription className={CONFIG_DESCRIPTION}>
+                  <Trans>
+                    Chat files are still recorded when this is off; only the
+                    per-session summary, which stores viewer names, is skipped.
+                  </Trans>
+                </FormDescription>
+              </div>
+              <FormControl>
+                <Switch
+                  checked={field.value ?? true}
+                  onCheckedChange={field.onChange}
+                />
+              </FormControl>
+            </FormItem>
+          )}
+        />
 
-          <IgnoredWordsField form={form} name={path('extra_stop_words')} />
-        </CardContent>
-      </Card>
-    );
-  },
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
+          {numberField(
+            'top_talkers',
+            <Trans>Top chatters to keep</Trans>,
+            <Trans>How many appear in the ranking. 1–500.</Trans>,
+            '100',
+          )}
+          {numberField(
+            'top_words',
+            <Trans>Frequent words to keep</Trans>,
+            <Trans>How many appear in the word chart. 1–500.</Trans>,
+            '50',
+          )}
+          {numberField(
+            'rate_bucket_secs',
+            <Trans>Activity resolution (seconds)</Trans>,
+            <Trans>
+              Timeline granularity. Very long streams are automatically
+              coarsened past a point.
+            </Trans>,
+            '10',
+          )}
+          {numberField(
+            'talker_capacity',
+            <Trans>Chatters tracked</Trans>,
+            <Trans>
+              Counts stay exact while a stream has fewer distinct chatters than
+              this. 64–8192.
+            </Trans>,
+            '2048',
+          )}
+        </div>
+
+        <IgnoredWordsField form={form} name={path('extra_stop_words')} />
+      </CardContent>
+    </Card>
+  );
+}
+
+export const DanmuStatisticsCard = genericMemo(
+  DanmuStatisticsCardImpl,
+  'DanmuStatisticsCard',
 );
-
-DanmuStatisticsCard.displayName = 'DanmuStatisticsCard';

--- a/rust-srec/frontend/src/components/config/shared/end-stream-on-danmu-close-field.tsx
+++ b/rust-srec/frontend/src/components/config/shared/end-stream-on-danmu-close-field.tsx
@@ -1,4 +1,4 @@
-import { UseFormReturn } from 'react-hook-form';
+import type { FieldValues, Path, UseFormReturn } from 'react-hook-form';
 import {
   FormControl,
   FormDescription,
@@ -9,15 +9,15 @@ import {
 import { Switch } from '@/components/ui/switch';
 import { Trans } from '@lingui/react/macro';
 
-interface EndStreamOnDanmuCloseFieldProps {
-  form: UseFormReturn<any>;
-  name: string;
+interface EndStreamOnDanmuCloseFieldProps<TFieldValues extends FieldValues> {
+  form: UseFormReturn<TFieldValues>;
+  name: Path<TFieldValues>;
 }
 
-export function EndStreamOnDanmuCloseField({
+export function EndStreamOnDanmuCloseField<TFieldValues extends FieldValues>({
   form,
   name,
-}: EndStreamOnDanmuCloseFieldProps) {
+}: EndStreamOnDanmuCloseFieldProps<TFieldValues>) {
   return (
     <FormField
       control={form.control}

--- a/rust-srec/frontend/src/components/config/shared/form-path.ts
+++ b/rust-srec/frontend/src/components/config/shared/form-path.ts
@@ -1,0 +1,45 @@
+import type {
+  FieldValues,
+  Path,
+  PathValue,
+  UseFormReturn,
+  UseFormSetValue,
+} from 'react-hook-form';
+
+/**
+ * Builds the form path for a config field that may live under a prefix.
+ *
+ * The same field groups are rendered against several forms and at several
+ * depths — a global config at the root, a template override under
+ * `platform_overrides.<platform>`, a streamer override under
+ * `streamer_specific_config` — and a prefix that is only known at runtime
+ * cannot be resolved to a member of `Path<T>` by the compiler, so the join is
+ * asserted here instead of at every call site.
+ */
+export function configPath<TFieldValues extends FieldValues>(
+  prefix: string | undefined,
+  key: string,
+): Path<TFieldValues> {
+  return (prefix ? `${prefix}.${key}` : key) as Path<TFieldValues>;
+}
+
+/**
+ * Writes a config field whose value shape is decided at runtime.
+ *
+ * Fields such as the stream selection config and the pipeline DAG hold either
+ * an object or its serialized form depending on the entity being edited, and
+ * `PathValue` cannot resolve to that union for a path the component only
+ * receives as a prop, so the value is asserted here rather than at each write.
+ */
+export function setConfigValue<TFieldValues extends FieldValues>(
+  form: UseFormReturn<TFieldValues>,
+  name: Path<TFieldValues>,
+  value: unknown,
+  options?: Parameters<UseFormSetValue<TFieldValues>>[2],
+): void {
+  form.setValue(
+    name,
+    value as PathValue<TFieldValues, Path<TFieldValues>>,
+    options,
+  );
+}

--- a/rust-srec/frontend/src/components/config/shared/limits-card.tsx
+++ b/rust-srec/frontend/src/components/config/shared/limits-card.tsx
@@ -8,23 +8,27 @@ import {
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Trans } from '@lingui/react/macro';
 import { Shield } from 'lucide-react';
-import { UseFormReturn } from 'react-hook-form';
+import type { FieldValues, UseFormReturn } from 'react-hook-form';
 import { InputWithUnit } from '@/components/ui/input-with-unit';
 import { msg } from '@lingui/core/macro';
 import { useLingui } from '@lingui/react';
-import { memo } from 'react';
 import {
   CONFIG_DESCRIPTION,
   CONFIG_INPUT,
   ConfigFieldLabel,
 } from './config-field';
+import { configPath } from './form-path';
+import { genericMemo } from '@/lib/generic-component';
 
-interface LimitsCardProps {
-  form: UseFormReturn<any>;
+interface LimitsCardProps<TFieldValues extends FieldValues> {
+  form: UseFormReturn<TFieldValues>;
   basePath?: string;
 }
 
-export const LimitsCard = memo(({ form, basePath }: LimitsCardProps) => {
+function LimitsCardImpl<TFieldValues extends FieldValues>({
+  form,
+  basePath,
+}: LimitsCardProps<TFieldValues>) {
   const { i18n } = useLingui();
   return (
     <Card className="border-border/50 shadow-sm hover:shadow-md transition-all">
@@ -46,11 +50,10 @@ export const LimitsCard = memo(({ form, basePath }: LimitsCardProps) => {
       <CardContent className="grid grid-cols-1 gap-6 sm:grid-cols-2 2xl:grid-cols-3">
         <FormField
           control={form.control}
-          name={
-            basePath
-              ? `${basePath}.max_download_duration_secs`
-              : 'max_download_duration_secs'
-          }
+          name={configPath<TFieldValues>(
+            basePath,
+            'max_download_duration_secs',
+          )}
           render={({ field }) => (
             <FormItem className="space-y-2">
               <ConfigFieldLabel>
@@ -74,11 +77,7 @@ export const LimitsCard = memo(({ form, basePath }: LimitsCardProps) => {
         />
         <FormField
           control={form.control}
-          name={
-            basePath
-              ? `${basePath}.min_segment_size_bytes`
-              : 'min_segment_size_bytes'
-          }
+          name={configPath<TFieldValues>(basePath, 'min_segment_size_bytes')}
           render={({ field }) => (
             <FormItem className="space-y-2">
               <ConfigFieldLabel>
@@ -102,9 +101,7 @@ export const LimitsCard = memo(({ form, basePath }: LimitsCardProps) => {
         />
         <FormField
           control={form.control}
-          name={
-            basePath ? `${basePath}.max_part_size_bytes` : 'max_part_size_bytes'
-          }
+          name={configPath<TFieldValues>(basePath, 'max_part_size_bytes')}
           render={({ field }) => (
             <FormItem className="space-y-2">
               <ConfigFieldLabel>
@@ -129,6 +126,6 @@ export const LimitsCard = memo(({ form, basePath }: LimitsCardProps) => {
       </CardContent>
     </Card>
   );
-});
+}
 
-LimitsCard.displayName = 'LimitsCard';
+export const LimitsCard = genericMemo(LimitsCardImpl, 'LimitsCard');

--- a/rust-srec/frontend/src/components/config/shared/network-settings-card.tsx
+++ b/rust-srec/frontend/src/components/config/shared/network-settings-card.tsx
@@ -1,5 +1,5 @@
-import { memo, useState } from 'react';
-import { UseFormReturn } from 'react-hook-form';
+import { useState } from 'react';
+import type { FieldValues, Path, UseFormReturn } from 'react-hook-form';
 import {
   Card,
   CardContent,
@@ -44,12 +44,13 @@ import { cn } from '@/lib/utils';
 import { BilibiliQrLoginDialog } from '@/components/credentials/bilibili-qr-login-dialog';
 import type { CredentialSaveScope } from '@/server/functions/credentials';
 import { CONFIG_DESCRIPTION, ConfigFieldLabel } from './config-field';
+import { genericMemo } from '@/lib/generic-component';
 
-interface NetworkSettingsCardProps {
-  form: UseFormReturn<any>;
+interface NetworkSettingsCardProps<TFieldValues extends FieldValues> {
+  form: UseFormReturn<TFieldValues>;
   paths: {
-    cookies: string;
-    retryPolicy: string;
+    cookies: Path<TFieldValues>;
+    retryPolicy: Path<TFieldValues>;
   };
   configMode?: 'json' | 'object';
   credentialScope?: CredentialSaveScope;
@@ -57,314 +58,310 @@ interface NetworkSettingsCardProps {
   streamerId?: string;
 }
 
-export const NetworkSettingsCard = memo(
-  ({
-    form,
-    paths,
-    configMode = 'object',
-    credentialScope,
-    credentialPlatformNameHint,
-    streamerId,
-  }: NetworkSettingsCardProps) => {
-    const { i18n } = useLingui();
-    const queryClient = useQueryClient();
-    const [qrDialogOpen, setQrDialogOpen] = useState(false);
+function NetworkSettingsCardImpl<TFieldValues extends FieldValues>({
+  form,
+  paths,
+  configMode = 'object',
+  credentialScope,
+  credentialPlatformNameHint,
+  streamerId,
+}: NetworkSettingsCardProps<TFieldValues>) {
+  const { i18n } = useLingui();
+  const queryClient = useQueryClient();
+  const [qrDialogOpen, setQrDialogOpen] = useState(false);
 
-    const scope: CredentialSaveScope | null =
-      credentialScope ??
-      (streamerId ? { type: 'streamer', id: streamerId } : null);
+  const scope: CredentialSaveScope | null =
+    credentialScope ??
+    (streamerId ? { type: 'streamer', id: streamerId } : null);
 
-    const credentialSourceQueryKey = scope
-      ? [
-          'credentials',
-          scope.type,
-          scope.id,
-          'source',
-          scope.type === 'template'
-            ? (credentialPlatformNameHint ?? null)
-            : null,
-        ]
-      : ['credentials', 'none'];
+  const credentialSourceQueryKey = scope
+    ? [
+        'credentials',
+        scope.type,
+        scope.id,
+        'source',
+        scope.type === 'template' ? (credentialPlatformNameHint ?? null) : null,
+      ]
+    : ['credentials', 'none'];
 
-    const { data: credentialSource, isLoading: isLoadingCredentials } =
-      useQuery({
-        queryKey: credentialSourceQueryKey,
-        queryFn: async () => {
-          if (!scope) return null;
-          switch (scope.type) {
-            case 'streamer':
-              return getStreamerCredentialSource({ data: scope.id });
-            case 'platform':
-              return getPlatformCredentialSource({ data: scope.id });
-            case 'template':
-              return getTemplateCredentialSource({
-                data: { id: scope.id, platform: credentialPlatformNameHint },
-              });
-          }
-        },
-        enabled: !!scope,
-      });
-
-    // Determine if this is a bilibili platform for QR login
-    const platformForQr =
-      credentialSource?.platform ?? credentialPlatformNameHint ?? null;
-    const isBilibili =
-      typeof platformForQr === 'string' &&
-      platformForQr.toLowerCase() === 'bilibili';
-
-    const refreshMutation = useMutation({
-      mutationFn: async () => {
-        if (!scope) {
-          throw new Error('Credential scope not available');
-        }
-        switch (scope.type) {
-          case 'streamer':
-            return refreshStreamerCredentials({ data: scope.id });
-          case 'platform':
-            return refreshPlatformCredentials({ data: scope.id });
-          case 'template':
-            return refreshTemplateCredentials({
-              data: { id: scope.id, platform: credentialPlatformNameHint },
-            });
-        }
-      },
-      onSuccess: (data) => {
-        if (data.refreshed) {
-          toast.success(i18n._(msg`Credentials refreshed successfully`));
-          void queryClient.invalidateQueries({
-            queryKey: credentialSourceQueryKey,
+  const { data: credentialSource, isLoading: isLoadingCredentials } = useQuery({
+    queryKey: credentialSourceQueryKey,
+    queryFn: async () => {
+      if (!scope) return null;
+      switch (scope.type) {
+        case 'streamer':
+          return getStreamerCredentialSource({ data: scope.id });
+        case 'platform':
+          return getPlatformCredentialSource({ data: scope.id });
+        case 'template':
+          return getTemplateCredentialSource({
+            data: { id: scope.id, platform: credentialPlatformNameHint },
           });
-        } else if (data.requires_relogin) {
-          toast.error(i18n._(msg`Refresh failed: Manual login required`));
-        } else {
-          toast.info(i18n._(msg`No refresh needed or not supported`));
-        }
-      },
-      onError: (error: Error) => {
-        toast.error(
-          error.message || i18n._(msg`Failed to refresh credentials`),
-        );
-      },
-    });
+      }
+    },
+    enabled: !!scope,
+  });
 
-    return (
-      <div className="grid gap-6">
-        {/* Authentication Card */}
-        <Card className="border-border/50 shadow-sm hover:shadow-md transition-all">
-          <CardHeader className="pb-3 px-6 pt-6">
-            <div className="flex items-center justify-between">
-              <div className="flex items-center gap-3">
-                <div className="p-2 rounded-lg bg-orange-500/10 text-orange-600 dark:text-orange-400">
-                  <Cookie className="w-5 h-5" />
-                </div>
-                <div>
-                  <CardTitle className="text-lg">
-                    <Trans>Authentication</Trans>
-                  </CardTitle>
-                  <CardDescription>
-                    <Trans>Manage credentials and session cookies.</Trans>
-                  </CardDescription>
-                </div>
-              </div>
-              <div className="flex items-center gap-2">
-                {/* QR Login button - only for bilibili */}
-                {scope && isBilibili && (
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    type="button"
-                    className="gap-2 h-9 rounded-xl border-purple-200 hover:border-purple-300 hover:bg-purple-50 dark:border-purple-500/20 dark:hover:bg-purple-500/10"
-                    onClick={() => setQrDialogOpen(true)}
-                  >
-                    <QrCode className="w-3.5 h-3.5" />
-                    <Trans>QR Login</Trans>
-                  </Button>
-                )}
-                {/* Refresh button */}
-                {scope && (
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    type="button"
-                    className="gap-2 h-9 rounded-xl border-orange-200 hover:border-orange-300 hover:bg-orange-50 dark:border-orange-500/20 dark:hover:bg-orange-500/10"
-                    onClick={() => refreshMutation.mutate()}
-                    disabled={refreshMutation.isPending}
-                  >
-                    <RefreshCw
-                      className={cn(
-                        'w-3.5 h-3.5',
-                        refreshMutation.isPending && 'animate-spin',
-                      )}
-                    />
-                    <Trans>Refresh</Trans>
-                  </Button>
-                )}
-              </div>
-            </div>
-          </CardHeader>
-          <CardContent className="px-6 pb-6 space-y-6">
-            <FormField
-              control={form.control}
-              name={paths.cookies}
-              render={({ field }) => (
-                <FormItem>
-                  <div className="flex items-center justify-between">
-                    <ConfigFieldLabel>
-                      <Trans>Cookies</Trans>
-                    </ConfigFieldLabel>
-                    {field.value && (
-                      <Badge
-                        variant="outline"
-                        className="text-[10px] py-0 h-4 bg-muted/50 font-mono"
-                      >
-                        {t(
-                          i18n,
-                        )`${plural(field.value.length, { one: '# char', other: '# chars' })}`}
-                      </Badge>
-                    )}
-                  </div>
-                  <FormControl>
-                    <Textarea
-                      {...field}
-                      placeholder="key=value; key2=value2"
-                      value={field.value ?? ''}
-                      className="font-mono text-sm bg-background/50 focus:bg-background min-h-[120px] resize-y rounded-xl"
-                    />
-                  </FormControl>
-                  <FormDescription className={CONFIG_DESCRIPTION}>
-                    <Trans>
-                      HTTP cookies for authentication. These are automatically
-                      updated when refreshed.
-                    </Trans>
-                  </FormDescription>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
+  // Determine if this is a bilibili platform for QR login
+  const platformForQr =
+    credentialSource?.platform ?? credentialPlatformNameHint ?? null;
+  const isBilibili =
+    typeof platformForQr === 'string' &&
+    platformForQr.toLowerCase() === 'bilibili';
 
-            {scope && (
-              <div className="pt-2 border-t border-border/50">
-                <div className="flex items-center gap-2 mb-3">
-                  <Info className="w-4 h-4 text-muted-foreground" />
-                  <h4 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-                    <Trans>Credential Source Status</Trans>
-                  </h4>
-                </div>
+  const refreshMutation = useMutation({
+    mutationFn: async () => {
+      if (!scope) {
+        throw new Error('Credential scope not available');
+      }
+      switch (scope.type) {
+        case 'streamer':
+          return refreshStreamerCredentials({ data: scope.id });
+        case 'platform':
+          return refreshPlatformCredentials({ data: scope.id });
+        case 'template':
+          return refreshTemplateCredentials({
+            data: { id: scope.id, platform: credentialPlatformNameHint },
+          });
+      }
+    },
+    onSuccess: (data) => {
+      if (data.refreshed) {
+        toast.success(i18n._(msg`Credentials refreshed successfully`));
+        void queryClient.invalidateQueries({
+          queryKey: credentialSourceQueryKey,
+        });
+      } else if (data.requires_relogin) {
+        toast.error(i18n._(msg`Refresh failed: Manual login required`));
+      } else {
+        toast.info(i18n._(msg`No refresh needed or not supported`));
+      }
+    },
+    onError: (error: Error) => {
+      toast.error(error.message || i18n._(msg`Failed to refresh credentials`));
+    },
+  });
 
-                {isLoadingCredentials ? (
-                  <div className="space-y-3">
-                    <Skeleton className="h-4 w-3/4" />
-                    <Skeleton className="h-4 w-1/2" />
-                  </div>
-                ) : credentialSource ? (
-                  <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                    <div className="flex items-start gap-3 p-3 rounded-xl bg-muted/30 border border-border/50">
-                      <div className="mt-0.5 p-1.5 rounded-lg bg-blue-500/10 text-blue-600 dark:text-blue-400">
-                        <UserCheck className="w-4 h-4" />
-                      </div>
-                      <div>
-                        <p className="text-[10px] font-medium text-muted-foreground uppercase">
-                          <Trans>Effective Scope</Trans>
-                        </p>
-                        <p className="text-sm font-semibold truncate titlecase">
-                          {credentialSource.scope_name}
-                        </p>
-                        <Badge
-                          variant="secondary"
-                          className="mt-1 text-[10px] h-4"
-                        >
-                          {credentialSource.scope_type}
-                        </Badge>
-                      </div>
-                    </div>
-
-                    <div className="flex items-start gap-3 p-3 rounded-xl bg-muted/30 border border-border/50">
-                      <div className="mt-0.5 p-1.5 rounded-lg bg-green-500/10 text-green-600 dark:text-green-400">
-                        <RefreshCw className="w-4 h-4" />
-                      </div>
-                      <div>
-                        <p className="text-[10px] font-medium text-muted-foreground uppercase">
-                          <Trans>Auto-Refresh</Trans>
-                        </p>
-                        <p className="text-sm font-semibold">
-                          {credentialSource.has_refresh_token ? (
-                            <span className="text-green-600 dark:text-green-400">
-                              <Trans>Supported</Trans>
-                            </span>
-                          ) : (
-                            <span className="text-muted-foreground">
-                              <Trans>Cookies Only</Trans>
-                            </span>
-                          )}
-                        </p>
-                        <p className="text-[10px] text-muted-foreground mt-0.5 leading-tight">
-                          {credentialSource.has_refresh_token ? (
-                            <Trans>Background refresh enabled</Trans>
-                          ) : (
-                            <Trans>Manual update required</Trans>
-                          )}
-                        </p>
-                      </div>
-                    </div>
-                  </div>
-                ) : (
-                  <div className="text-sm text-muted-foreground italic p-3 rounded-xl bg-muted/20 border">
-                    <Trans>No credentials found.</Trans>
-                  </div>
-                )}
-              </div>
-            )}
-          </CardContent>
-        </Card>
-
-        {/* Retry Policy Card */}
-        <Card className="border-border/50 shadow-sm hover:shadow-md transition-all">
-          <CardHeader className="pb-3">
+  return (
+    <div className="grid gap-6">
+      {/* Authentication Card */}
+      <Card className="border-border/50 shadow-sm hover:shadow-md transition-all">
+        <CardHeader className="pb-3 px-6 pt-6">
+          <div className="flex items-center justify-between">
             <div className="flex items-center gap-3">
-              <div className="p-2 rounded-lg bg-green-500/10 text-green-600 dark:text-green-400">
-                <Network className="w-5 h-5" />
+              <div className="p-2 rounded-lg bg-orange-500/10 text-orange-600 dark:text-orange-400">
+                <Cookie className="w-5 h-5" />
               </div>
-              <CardTitle className="text-lg">
-                <Trans>Download Retry Policy</Trans>
-              </CardTitle>
+              <div>
+                <CardTitle className="text-lg">
+                  <Trans>Authentication</Trans>
+                </CardTitle>
+                <CardDescription>
+                  <Trans>Manage credentials and session cookies.</Trans>
+                </CardDescription>
+              </div>
             </div>
-          </CardHeader>
-          <CardContent>
-            <RetryPolicyForm
-              form={form}
-              name={paths.retryPolicy}
-              mode={configMode}
-            />
-          </CardContent>
-        </Card>
-
-        {/* Bilibili QR Login Dialog */}
-        {scope && (
-          <BilibiliQrLoginDialog
-            open={qrDialogOpen}
-            onOpenChange={setQrDialogOpen}
-            scope={scope}
-            onSuccess={() => {
-              void queryClient.invalidateQueries({
-                queryKey: credentialSourceQueryKey,
-              });
-              // Invalidate the main configuration query based on scope to trigger a refresh
-              if (scope) {
-                const mainQueryKey =
-                  scope.type === 'platform'
-                    ? ['config', 'platform', scope.id]
-                    : scope.type === 'template'
-                      ? ['template', scope.id]
-                      : ['streamer', scope.id];
-                void queryClient.invalidateQueries({ queryKey: mainQueryKey });
-              }
-              toast.success(i18n._(msg`Credentials saved successfully`));
-            }}
+            <div className="flex items-center gap-2">
+              {/* QR Login button - only for bilibili */}
+              {scope && isBilibili && (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  type="button"
+                  className="gap-2 h-9 rounded-xl border-purple-200 hover:border-purple-300 hover:bg-purple-50 dark:border-purple-500/20 dark:hover:bg-purple-500/10"
+                  onClick={() => setQrDialogOpen(true)}
+                >
+                  <QrCode className="w-3.5 h-3.5" />
+                  <Trans>QR Login</Trans>
+                </Button>
+              )}
+              {/* Refresh button */}
+              {scope && (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  type="button"
+                  className="gap-2 h-9 rounded-xl border-orange-200 hover:border-orange-300 hover:bg-orange-50 dark:border-orange-500/20 dark:hover:bg-orange-500/10"
+                  onClick={() => refreshMutation.mutate()}
+                  disabled={refreshMutation.isPending}
+                >
+                  <RefreshCw
+                    className={cn(
+                      'w-3.5 h-3.5',
+                      refreshMutation.isPending && 'animate-spin',
+                    )}
+                  />
+                  <Trans>Refresh</Trans>
+                </Button>
+              )}
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent className="px-6 pb-6 space-y-6">
+          <FormField
+            control={form.control}
+            name={paths.cookies}
+            render={({ field }) => (
+              <FormItem>
+                <div className="flex items-center justify-between">
+                  <ConfigFieldLabel>
+                    <Trans>Cookies</Trans>
+                  </ConfigFieldLabel>
+                  {field.value && (
+                    <Badge
+                      variant="outline"
+                      className="text-[10px] py-0 h-4 bg-muted/50 font-mono"
+                    >
+                      {t(
+                        i18n,
+                      )`${plural(field.value.length, { one: '# char', other: '# chars' })}`}
+                    </Badge>
+                  )}
+                </div>
+                <FormControl>
+                  <Textarea
+                    {...field}
+                    placeholder="key=value; key2=value2"
+                    value={field.value ?? ''}
+                    className="font-mono text-sm bg-background/50 focus:bg-background min-h-[120px] resize-y rounded-xl"
+                  />
+                </FormControl>
+                <FormDescription className={CONFIG_DESCRIPTION}>
+                  <Trans>
+                    HTTP cookies for authentication. These are automatically
+                    updated when refreshed.
+                  </Trans>
+                </FormDescription>
+                <FormMessage />
+              </FormItem>
+            )}
           />
-        )}
-      </div>
-    );
-  },
-);
 
-NetworkSettingsCard.displayName = 'NetworkSettingsCard';
+          {scope && (
+            <div className="pt-2 border-t border-border/50">
+              <div className="flex items-center gap-2 mb-3">
+                <Info className="w-4 h-4 text-muted-foreground" />
+                <h4 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                  <Trans>Credential Source Status</Trans>
+                </h4>
+              </div>
+
+              {isLoadingCredentials ? (
+                <div className="space-y-3">
+                  <Skeleton className="h-4 w-3/4" />
+                  <Skeleton className="h-4 w-1/2" />
+                </div>
+              ) : credentialSource ? (
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                  <div className="flex items-start gap-3 p-3 rounded-xl bg-muted/30 border border-border/50">
+                    <div className="mt-0.5 p-1.5 rounded-lg bg-blue-500/10 text-blue-600 dark:text-blue-400">
+                      <UserCheck className="w-4 h-4" />
+                    </div>
+                    <div>
+                      <p className="text-[10px] font-medium text-muted-foreground uppercase">
+                        <Trans>Effective Scope</Trans>
+                      </p>
+                      <p className="text-sm font-semibold truncate titlecase">
+                        {credentialSource.scope_name}
+                      </p>
+                      <Badge
+                        variant="secondary"
+                        className="mt-1 text-[10px] h-4"
+                      >
+                        {credentialSource.scope_type}
+                      </Badge>
+                    </div>
+                  </div>
+
+                  <div className="flex items-start gap-3 p-3 rounded-xl bg-muted/30 border border-border/50">
+                    <div className="mt-0.5 p-1.5 rounded-lg bg-green-500/10 text-green-600 dark:text-green-400">
+                      <RefreshCw className="w-4 h-4" />
+                    </div>
+                    <div>
+                      <p className="text-[10px] font-medium text-muted-foreground uppercase">
+                        <Trans>Auto-Refresh</Trans>
+                      </p>
+                      <p className="text-sm font-semibold">
+                        {credentialSource.has_refresh_token ? (
+                          <span className="text-green-600 dark:text-green-400">
+                            <Trans>Supported</Trans>
+                          </span>
+                        ) : (
+                          <span className="text-muted-foreground">
+                            <Trans>Cookies Only</Trans>
+                          </span>
+                        )}
+                      </p>
+                      <p className="text-[10px] text-muted-foreground mt-0.5 leading-tight">
+                        {credentialSource.has_refresh_token ? (
+                          <Trans>Background refresh enabled</Trans>
+                        ) : (
+                          <Trans>Manual update required</Trans>
+                        )}
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              ) : (
+                <div className="text-sm text-muted-foreground italic p-3 rounded-xl bg-muted/20 border">
+                  <Trans>No credentials found.</Trans>
+                </div>
+              )}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Retry Policy Card */}
+      <Card className="border-border/50 shadow-sm hover:shadow-md transition-all">
+        <CardHeader className="pb-3">
+          <div className="flex items-center gap-3">
+            <div className="p-2 rounded-lg bg-green-500/10 text-green-600 dark:text-green-400">
+              <Network className="w-5 h-5" />
+            </div>
+            <CardTitle className="text-lg">
+              <Trans>Download Retry Policy</Trans>
+            </CardTitle>
+          </div>
+        </CardHeader>
+        <CardContent>
+          <RetryPolicyForm
+            form={form}
+            name={paths.retryPolicy}
+            mode={configMode}
+          />
+        </CardContent>
+      </Card>
+
+      {/* Bilibili QR Login Dialog */}
+      {scope && (
+        <BilibiliQrLoginDialog
+          open={qrDialogOpen}
+          onOpenChange={setQrDialogOpen}
+          scope={scope}
+          onSuccess={() => {
+            void queryClient.invalidateQueries({
+              queryKey: credentialSourceQueryKey,
+            });
+            // Invalidate the main configuration query based on scope to trigger a refresh
+            if (scope) {
+              const mainQueryKey =
+                scope.type === 'platform'
+                  ? ['config', 'platform', scope.id]
+                  : scope.type === 'template'
+                    ? ['template', scope.id]
+                    : ['streamer', scope.id];
+              void queryClient.invalidateQueries({ queryKey: mainQueryKey });
+            }
+            toast.success(i18n._(msg`Credentials saved successfully`));
+          }}
+        />
+      )}
+    </div>
+  );
+}
+
+export const NetworkSettingsCard = genericMemo(
+  NetworkSettingsCardImpl,
+  'NetworkSettingsCard',
+);

--- a/rust-srec/frontend/src/components/config/shared/offline-check-card.tsx
+++ b/rust-srec/frontend/src/components/config/shared/offline-check-card.tsx
@@ -8,122 +8,119 @@ import {
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Trans } from '@lingui/react/macro';
 import { Timer } from 'lucide-react';
-import { UseFormReturn } from 'react-hook-form';
+import type { FieldValues, UseFormReturn } from 'react-hook-form';
 import { InputWithUnit } from '@/components/ui/input-with-unit';
 import { Input } from '@/components/ui/input';
 import { msg } from '@lingui/core/macro';
 import { useLingui } from '@lingui/react';
-import { memo } from 'react';
 import {
   CONFIG_DESCRIPTION,
   CONFIG_INPUT,
   ConfigFieldLabel,
 } from './config-field';
+import { configPath } from './form-path';
+import { genericMemo } from '@/lib/generic-component';
 
-interface OfflineCheckCardProps {
-  form: UseFormReturn<any>;
+interface OfflineCheckCardProps<TFieldValues extends FieldValues> {
+  form: UseFormReturn<TFieldValues>;
   basePath?: string;
 }
 
 // Per-platform / per-template / per-streamer overrides for the
 // offline-confirmation cadence. Empty input → null = "inherit from parent".
 // Server floors enforce count >= 1, delay_ms >= 1000.
-export const OfflineCheckCard = memo(
-  ({ form, basePath }: OfflineCheckCardProps) => {
-    const { i18n } = useLingui();
-    return (
-      <Card className="border-border/50 shadow-sm hover:shadow-md transition-all">
-        <CardHeader className="pb-3">
-          <div className="flex items-center gap-3">
-            <div className="p-2 rounded-lg bg-orange-500/10 text-orange-600 dark:text-orange-400">
-              <Timer className="w-5 h-5" />
-            </div>
-            <div className="space-y-1">
-              <CardTitle className="text-lg">
-                <Trans>Offline Check</Trans>
-              </CardTitle>
-              <p className="text-sm text-muted-foreground">
-                <Trans>
-                  Override how aggressively the scheduler confirms a stream has
-                  ended.
-                </Trans>
-              </p>
-            </div>
+function OfflineCheckCardImpl<TFieldValues extends FieldValues>({
+  form,
+  basePath,
+}: OfflineCheckCardProps<TFieldValues>) {
+  const { i18n } = useLingui();
+  return (
+    <Card className="border-border/50 shadow-sm hover:shadow-md transition-all">
+      <CardHeader className="pb-3">
+        <div className="flex items-center gap-3">
+          <div className="p-2 rounded-lg bg-orange-500/10 text-orange-600 dark:text-orange-400">
+            <Timer className="w-5 h-5" />
           </div>
-        </CardHeader>
-        <CardContent className="grid grid-cols-1 sm:grid-cols-2 gap-6">
-          <FormField
-            control={form.control}
-            name={
-              basePath
-                ? `${basePath}.offline_check_delay_ms`
-                : 'offline_check_delay_ms'
-            }
-            render={({ field }) => (
-              <FormItem className="space-y-2">
-                <ConfigFieldLabel>
-                  <Trans>Offline Check Interval</Trans>
-                </ConfigFieldLabel>
-                <FormControl>
-                  <InputWithUnit
-                    unitType="duration"
-                    value={
-                      field.value !== null && field.value !== undefined
-                        ? Number(field.value) / 1000
-                        : null
-                    }
-                    onChange={(val) =>
-                      field.onChange(val !== null ? val * 1000 : null)
-                    }
-                    placeholder={i18n._(msg`Inherited`)}
-                    className={CONFIG_INPUT}
-                  />
-                </FormControl>
-                <FormDescription className={CONFIG_DESCRIPTION}>
-                  <Trans>Interval between offline checks.</Trans>
-                </FormDescription>
-                <FormMessage />
-              </FormItem>
-            )}
-          />
-          <FormField
-            control={form.control}
-            name={
-              basePath
-                ? `${basePath}.offline_check_count`
-                : 'offline_check_count'
-            }
-            render={({ field }) => (
-              <FormItem className="space-y-2">
-                <ConfigFieldLabel>
-                  <Trans>Offline Detection Count</Trans>
-                </ConfigFieldLabel>
-                <FormControl>
-                  <Input
-                    type="number"
-                    min={1}
-                    value={field.value ?? ''}
-                    onChange={(e) => {
-                      const v = e.target.value;
-                      field.onChange(v === '' ? null : Number(v));
-                    }}
-                    placeholder={i18n._(msg`Inherited`)}
-                    className={CONFIG_INPUT}
-                  />
-                </FormControl>
-                <FormDescription className={CONFIG_DESCRIPTION}>
-                  <Trans>
-                    Consecutive failed checks needed to confirm offline.
-                  </Trans>
-                </FormDescription>
-                <FormMessage />
-              </FormItem>
-            )}
-          />
-        </CardContent>
-      </Card>
-    );
-  },
-);
+          <div className="space-y-1">
+            <CardTitle className="text-lg">
+              <Trans>Offline Check</Trans>
+            </CardTitle>
+            <p className="text-sm text-muted-foreground">
+              <Trans>
+                Override how aggressively the scheduler confirms a stream has
+                ended.
+              </Trans>
+            </p>
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent className="grid grid-cols-1 sm:grid-cols-2 gap-6">
+        <FormField
+          control={form.control}
+          name={configPath<TFieldValues>(basePath, 'offline_check_delay_ms')}
+          render={({ field }) => (
+            <FormItem className="space-y-2">
+              <ConfigFieldLabel>
+                <Trans>Offline Check Interval</Trans>
+              </ConfigFieldLabel>
+              <FormControl>
+                <InputWithUnit
+                  unitType="duration"
+                  value={
+                    field.value !== null && field.value !== undefined
+                      ? Number(field.value) / 1000
+                      : null
+                  }
+                  onChange={(val) =>
+                    field.onChange(val !== null ? val * 1000 : null)
+                  }
+                  placeholder={i18n._(msg`Inherited`)}
+                  className={CONFIG_INPUT}
+                />
+              </FormControl>
+              <FormDescription className={CONFIG_DESCRIPTION}>
+                <Trans>Interval between offline checks.</Trans>
+              </FormDescription>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name={configPath<TFieldValues>(basePath, 'offline_check_count')}
+          render={({ field }) => (
+            <FormItem className="space-y-2">
+              <ConfigFieldLabel>
+                <Trans>Offline Detection Count</Trans>
+              </ConfigFieldLabel>
+              <FormControl>
+                <Input
+                  type="number"
+                  min={1}
+                  value={field.value ?? ''}
+                  onChange={(e) => {
+                    const v = e.target.value;
+                    field.onChange(v === '' ? null : Number(v));
+                  }}
+                  placeholder={i18n._(msg`Inherited`)}
+                  className={CONFIG_INPUT}
+                />
+              </FormControl>
+              <FormDescription className={CONFIG_DESCRIPTION}>
+                <Trans>
+                  Consecutive failed checks needed to confirm offline.
+                </Trans>
+              </FormDescription>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+      </CardContent>
+    </Card>
+  );
+}
 
-OfflineCheckCard.displayName = 'OfflineCheckCard';
+export const OfflineCheckCard = genericMemo(
+  OfflineCheckCardImpl,
+  'OfflineCheckCard',
+);

--- a/rust-srec/frontend/src/components/config/shared/output-settings-card.tsx
+++ b/rust-srec/frontend/src/components/config/shared/output-settings-card.tsx
@@ -1,4 +1,3 @@
-import { memo } from 'react';
 import {
   FormControl,
   FormDescription,
@@ -19,7 +18,7 @@ import { Trans } from '@lingui/react/macro';
 import { msg } from '@lingui/core/macro';
 import { useLingui } from '@lingui/react';
 import { FolderOpen } from 'lucide-react';
-import { UseFormReturn } from 'react-hook-form';
+import type { FieldValues, UseFormReturn } from 'react-hook-form';
 import { EngineConfig } from '@/api/schemas';
 import {
   CONFIG_DESCRIPTION,
@@ -28,225 +27,222 @@ import {
   CONFIG_SELECT_CONTENT,
   ConfigFieldLabel,
 } from './config-field';
+import { configPath } from './form-path';
+import { genericMemo } from '@/lib/generic-component';
 
-interface OutputSettingsCardProps {
-  form: UseFormReturn<any>;
+interface OutputSettingsCardProps<TFieldValues extends FieldValues> {
+  form: UseFormReturn<TFieldValues>;
   basePath?: string;
   engines?: EngineConfig[];
 }
 
-export const OutputSettingsCard = memo(
-  ({ form, basePath, engines }: OutputSettingsCardProps) => {
-    const { i18n } = useLingui();
-    return (
-      <Card className="border-border/50 shadow-sm hover:shadow-md transition-all">
-        <CardHeader className="pb-3">
-          <div className="flex items-center gap-3">
-            <div className="p-2 rounded-lg bg-orange-500/10 text-orange-600 dark:text-orange-400">
-              <FolderOpen className="w-5 h-5" />
-            </div>
-            <div className="space-y-1">
-              <CardTitle className="text-lg">
-                <Trans>Output Configuration</Trans>
-              </CardTitle>
-              <p className="text-sm text-muted-foreground">
-                <Trans>Manage storage paths and file formats.</Trans>
-              </p>
-            </div>
+function OutputSettingsCardImpl<TFieldValues extends FieldValues>({
+  form,
+  basePath,
+  engines,
+}: OutputSettingsCardProps<TFieldValues>) {
+  const { i18n } = useLingui();
+  return (
+    <Card className="border-border/50 shadow-sm hover:shadow-md transition-all">
+      <CardHeader className="pb-3">
+        <div className="flex items-center gap-3">
+          <div className="p-2 rounded-lg bg-orange-500/10 text-orange-600 dark:text-orange-400">
+            <FolderOpen className="w-5 h-5" />
           </div>
-        </CardHeader>
-        <CardContent className="space-y-6">
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-            <FormField
-              control={form.control}
-              name={basePath ? `${basePath}.output_folder` : 'output_folder'}
-              render={({ field }) => (
-                <FormItem className="space-y-2">
-                  <ConfigFieldLabel>
-                    <Trans>Output Folder</Trans>
-                  </ConfigFieldLabel>
+          <div className="space-y-1">
+            <CardTitle className="text-lg">
+              <Trans>Output Configuration</Trans>
+            </CardTitle>
+            <p className="text-sm text-muted-foreground">
+              <Trans>Manage storage paths and file formats.</Trans>
+            </p>
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+          <FormField
+            control={form.control}
+            name={configPath<TFieldValues>(basePath, 'output_folder')}
+            render={({ field }) => (
+              <FormItem className="space-y-2">
+                <ConfigFieldLabel>
+                  <Trans>Output Folder</Trans>
+                </ConfigFieldLabel>
+                <FormControl>
+                  <Input
+                    {...field}
+                    value={field.value ?? ''}
+                    onChange={field.onChange}
+                    placeholder="/app/output"
+                    className={CONFIG_INPUT}
+                  />
+                </FormControl>
+                <FormDescription className={CONFIG_DESCRIPTION}>
+                  <Trans>Override output folder.</Trans>
+                </FormDescription>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name={configPath<TFieldValues>(
+              basePath,
+              'output_filename_template',
+            )}
+            render={({ field }) => (
+              <FormItem className="space-y-2">
+                <ConfigFieldLabel>
+                  <Trans>Filename Template</Trans>
+                </ConfigFieldLabel>
+                <FormControl>
+                  <Input
+                    {...field}
+                    value={field.value ?? ''}
+                    onChange={field.onChange}
+                    placeholder="{streamer}-%Y%m%d-%H%M%S-{title}"
+                    className={CONFIG_INPUT}
+                  />
+                </FormControl>
+                <FormDescription className={CONFIG_DESCRIPTION}>
+                  <Trans>Override filename template.</Trans>
+                </FormDescription>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </div>
+
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+          <FormField
+            control={form.control}
+            name={configPath<TFieldValues>(basePath, 'output_file_format')}
+            render={({ field }) => (
+              <FormItem className="space-y-2">
+                <ConfigFieldLabel>
+                  <Trans>Output Format</Trans>
+                </ConfigFieldLabel>
+                <Select
+                  onValueChange={(val) =>
+                    field.onChange(val === 'default' ? undefined : val)
+                  }
+                  value={field.value || 'default'}
+                >
                   <FormControl>
-                    <Input
-                      {...field}
-                      value={field.value ?? ''}
-                      onChange={field.onChange}
-                      placeholder="/app/output"
-                      className={CONFIG_INPUT}
-                    />
+                    <SelectTrigger className={CONFIG_SELECT_TRIGGER}>
+                      <SelectValue placeholder={i18n._(msg`Select a format`)} />
+                    </SelectTrigger>
                   </FormControl>
-                  <FormDescription className={CONFIG_DESCRIPTION}>
-                    <Trans>Override output folder.</Trans>
-                  </FormDescription>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
+                  <SelectContent className={CONFIG_SELECT_CONTENT}>
+                    <SelectItem value="default">
+                      <Trans>Global Default</Trans>
+                    </SelectItem>
+                    <SelectItem value="mp4">MP4</SelectItem>
+                    <SelectItem value="flv">FLV</SelectItem>
+                    <SelectItem value="mkv">MKV</SelectItem>
+                    <SelectItem value="ts">TS</SelectItem>
+                  </SelectContent>
+                </Select>
+                <FormDescription className={CONFIG_DESCRIPTION}>
+                  <Trans>Force specific output format.</Trans>
+                </FormDescription>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
 
-            <FormField
-              control={form.control}
-              name={
-                basePath
-                  ? `${basePath}.output_filename_template`
-                  : 'output_filename_template'
-              }
-              render={({ field }) => (
-                <FormItem className="space-y-2">
-                  <ConfigFieldLabel>
-                    <Trans>Filename Template</Trans>
-                  </ConfigFieldLabel>
+          <FormField
+            control={form.control}
+            name={configPath<TFieldValues>(basePath, 'download_engine')}
+            render={({ field }) => (
+              <FormItem className="space-y-2">
+                <ConfigFieldLabel>
+                  <Trans>Download Engine</Trans>
+                </ConfigFieldLabel>
+                <Select
+                  onValueChange={(val) =>
+                    field.onChange(val === 'default' ? undefined : val)
+                  }
+                  value={field.value || 'default'}
+                >
                   <FormControl>
-                    <Input
-                      {...field}
-                      value={field.value ?? ''}
-                      onChange={field.onChange}
-                      placeholder="{streamer}-%Y%m%d-%H%M%S-{title}"
-                      className={CONFIG_INPUT}
-                    />
+                    <SelectTrigger className={CONFIG_SELECT_TRIGGER}>
+                      <SelectValue
+                        placeholder={i18n._(msg`Select an engine`)}
+                      />
+                    </SelectTrigger>
                   </FormControl>
-                  <FormDescription className={CONFIG_DESCRIPTION}>
-                    <Trans>Override filename template.</Trans>
-                  </FormDescription>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-          </div>
+                  <SelectContent className={CONFIG_SELECT_CONTENT}>
+                    <SelectItem value="default">
+                      <Trans>Inherited / Default</Trans>
+                    </SelectItem>
+                    {engines?.map((engine) => (
+                      <SelectItem key={engine.id} value={engine.id}>
+                        {engine.name} ({engine.engine_type})
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                <FormDescription className={CONFIG_DESCRIPTION}>
+                  <Trans>
+                    Which tool downloads the stream once its URL is known.
+                  </Trans>
+                </FormDescription>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
 
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-            <FormField
-              control={form.control}
-              name={
-                basePath
-                  ? `${basePath}.output_file_format`
-                  : 'output_file_format'
-              }
-              render={({ field }) => (
-                <FormItem className="space-y-2">
-                  <ConfigFieldLabel>
-                    <Trans>Output Format</Trans>
-                  </ConfigFieldLabel>
-                  <Select
-                    onValueChange={(val) =>
-                      field.onChange(val === 'default' ? undefined : val)
-                    }
-                    value={field.value || 'default'}
-                  >
-                    <FormControl>
-                      <SelectTrigger className={CONFIG_SELECT_TRIGGER}>
-                        <SelectValue
-                          placeholder={i18n._(msg`Select a format`)}
-                        />
-                      </SelectTrigger>
-                    </FormControl>
-                    <SelectContent className={CONFIG_SELECT_CONTENT}>
-                      <SelectItem value="default">
-                        <Trans>Global Default</Trans>
-                      </SelectItem>
-                      <SelectItem value="mp4">MP4</SelectItem>
-                      <SelectItem value="flv">FLV</SelectItem>
-                      <SelectItem value="mkv">MKV</SelectItem>
-                      <SelectItem value="ts">TS</SelectItem>
-                    </SelectContent>
-                  </Select>
-                  <FormDescription className={CONFIG_DESCRIPTION}>
-                    <Trans>Force specific output format.</Trans>
-                  </FormDescription>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
+          <FormField
+            control={form.control}
+            name={configPath<TFieldValues>(basePath, 'extractor')}
+            render={({ field }) => (
+              <FormItem className="space-y-2">
+                <ConfigFieldLabel>
+                  <Trans>Stream lookup</Trans>
+                </ConfigFieldLabel>
+                <Select
+                  onValueChange={(val) =>
+                    field.onChange(val === 'default' ? undefined : val)
+                  }
+                  value={field.value || 'default'}
+                >
+                  <FormControl>
+                    <SelectTrigger className={CONFIG_SELECT_TRIGGER}>
+                      <SelectValue />
+                    </SelectTrigger>
+                  </FormControl>
+                  <SelectContent className={CONFIG_SELECT_CONTENT}>
+                    <SelectItem value="default">
+                      <Trans>Inherited / Default</Trans>
+                    </SelectItem>
+                    <SelectItem value="auto">
+                      <Trans>Automatic (match the site)</Trans>
+                    </SelectItem>
+                    <SelectItem value="streamlink">
+                      <Trans>Always use Streamlink</Trans>
+                    </SelectItem>
+                  </SelectContent>
+                </Select>
+                <FormDescription className={CONFIG_DESCRIPTION}>
+                  <Trans>
+                    How the stream address is found. Switch to Streamlink when a
+                    site stops working; it needs the Streamlink tool installed.
+                  </Trans>
+                </FormDescription>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
 
-            <FormField
-              control={form.control}
-              name={
-                basePath ? `${basePath}.download_engine` : 'download_engine'
-              }
-              render={({ field }) => (
-                <FormItem className="space-y-2">
-                  <ConfigFieldLabel>
-                    <Trans>Download Engine</Trans>
-                  </ConfigFieldLabel>
-                  <Select
-                    onValueChange={(val) =>
-                      field.onChange(val === 'default' ? undefined : val)
-                    }
-                    value={field.value || 'default'}
-                  >
-                    <FormControl>
-                      <SelectTrigger className={CONFIG_SELECT_TRIGGER}>
-                        <SelectValue
-                          placeholder={i18n._(msg`Select an engine`)}
-                        />
-                      </SelectTrigger>
-                    </FormControl>
-                    <SelectContent className={CONFIG_SELECT_CONTENT}>
-                      <SelectItem value="default">
-                        <Trans>Inherited / Default</Trans>
-                      </SelectItem>
-                      {engines?.map((engine) => (
-                        <SelectItem key={engine.id} value={engine.id}>
-                          {engine.name} ({engine.engine_type})
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                  <FormDescription className={CONFIG_DESCRIPTION}>
-                    <Trans>
-                      Which tool downloads the stream once its URL is known.
-                    </Trans>
-                  </FormDescription>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-
-            <FormField
-              control={form.control}
-              name={basePath ? `${basePath}.extractor` : 'extractor'}
-              render={({ field }) => (
-                <FormItem className="space-y-2">
-                  <ConfigFieldLabel>
-                    <Trans>Stream lookup</Trans>
-                  </ConfigFieldLabel>
-                  <Select
-                    onValueChange={(val) =>
-                      field.onChange(val === 'default' ? undefined : val)
-                    }
-                    value={field.value || 'default'}
-                  >
-                    <FormControl>
-                      <SelectTrigger className={CONFIG_SELECT_TRIGGER}>
-                        <SelectValue />
-                      </SelectTrigger>
-                    </FormControl>
-                    <SelectContent className={CONFIG_SELECT_CONTENT}>
-                      <SelectItem value="default">
-                        <Trans>Inherited / Default</Trans>
-                      </SelectItem>
-                      <SelectItem value="auto">
-                        <Trans>Automatic (match the site)</Trans>
-                      </SelectItem>
-                      <SelectItem value="streamlink">
-                        <Trans>Always use Streamlink</Trans>
-                      </SelectItem>
-                    </SelectContent>
-                  </Select>
-                  <FormDescription className={CONFIG_DESCRIPTION}>
-                    <Trans>
-                      How the stream address is found. Switch to Streamlink when
-                      a site stops working; it needs the Streamlink tool
-                      installed.
-                    </Trans>
-                  </FormDescription>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-          </div>
-        </CardContent>
-      </Card>
-    );
-  },
+export const OutputSettingsCard = genericMemo(
+  OutputSettingsCardImpl,
+  'OutputSettingsCard',
 );
-
-OutputSettingsCard.displayName = 'OutputSettingsCard';

--- a/rust-srec/frontend/src/components/config/shared/pipeline-config-adapter.tsx
+++ b/rust-srec/frontend/src/components/config/shared/pipeline-config-adapter.tsx
@@ -1,12 +1,15 @@
-import { memo, useCallback, useMemo, useRef } from 'react';
-import { UseFormReturn, useWatch } from 'react-hook-form';
+import { useCallback, useMemo, useRef } from 'react';
+import { useWatch } from 'react-hook-form';
+import type { FieldValues, Path, UseFormReturn } from 'react-hook-form';
 import { PipelineWorkflowEditor } from '@/components/pipeline/workflows/pipeline-workflow-editor';
 import { DagStepDefinition, DagPipelineDefinition } from '@/api/schemas';
+import { genericMemo } from '@/lib/generic-component';
+import { setConfigValue } from './form-path';
 
-interface PipelineConfigAdapterProps {
-  form: UseFormReturn<any>;
+interface PipelineConfigAdapterProps<TFieldValues extends FieldValues> {
+  form: UseFormReturn<TFieldValues>;
   /** Field holding the DAG definition. */
-  name: string;
+  name: Path<TFieldValues>;
   /** `json` fields keep the DAG as a serialized string; `object` fields hold it as-is. */
   mode?: 'json' | 'object';
   /** Name stored inside the DAG definition when steps are written back. */
@@ -52,60 +55,61 @@ function readSteps(value: unknown): DagStepDefinition[] {
  * a partial one whose fields cannot tell `null` apart from "field omitted", so a `null` there
  * would leave the stored pipeline untouched; those fields send an empty DAG definition instead.
  */
-export const PipelineConfigAdapter = memo(
-  ({
-    form,
-    name,
-    mode = 'object',
-    dagName = 'pipeline',
-    emptyValue = 'null',
-  }: PipelineConfigAdapterProps) => {
-    const fieldValue = useWatch({ control: form.control, name });
-    const lastEmitted = useRef<{
-      serialized: string;
-      steps: DagStepDefinition[];
-    } | null>(null);
+function PipelineConfigAdapterImpl<TFieldValues extends FieldValues>({
+  form,
+  name,
+  mode = 'object',
+  dagName = 'pipeline',
+  emptyValue = 'null',
+}: PipelineConfigAdapterProps<TFieldValues>) {
+  const fieldValue = useWatch({ control: form.control, name });
+  const lastEmitted = useRef<{
+    serialized: string;
+    steps: DagStepDefinition[];
+  } | null>(null);
 
-    const steps = useMemo(() => {
-      const nextSteps = readSteps(fieldValue);
-      const emitted = lastEmitted.current;
-      // A `json` field parses back into new objects on every edit, and an `object` field can be
-      // rewritten with equal contents. Reusing the emitted array in those cases lets the editor
-      // keep its own step identities; only a genuinely different value replaces them.
-      return emitted && JSON.stringify(nextSteps) === emitted.serialized
-        ? emitted.steps
-        : nextSteps;
-    }, [fieldValue]);
+  const steps = useMemo(() => {
+    const nextSteps = readSteps(fieldValue);
+    const emitted = lastEmitted.current;
+    // A `json` field parses back into new objects on every edit, and an `object` field can be
+    // rewritten with equal contents. Reusing the emitted array in those cases lets the editor
+    // keep its own step identities; only a genuinely different value replaces them.
+    return emitted && JSON.stringify(nextSteps) === emitted.serialized
+      ? emitted.steps
+      : nextSteps;
+  }, [fieldValue]);
 
-    const handleChange = useCallback(
-      (nextSteps: DagStepDefinition[]) => {
-        lastEmitted.current = {
-          serialized: JSON.stringify(nextSteps),
-          steps: nextSteps,
-        };
+  const handleChange = useCallback(
+    (nextSteps: DagStepDefinition[]) => {
+      lastEmitted.current = {
+        serialized: JSON.stringify(nextSteps),
+        steps: nextSteps,
+      };
 
-        const dagConfig: DagPipelineDefinition = {
-          name: dagName,
-          steps: nextSteps,
-        };
-        const value =
-          nextSteps.length === 0 && emptyValue === 'null'
-            ? null
-            : mode === 'json'
-              ? JSON.stringify(dagConfig)
-              : dagConfig;
+      const dagConfig: DagPipelineDefinition = {
+        name: dagName,
+        steps: nextSteps,
+      };
+      const value =
+        nextSteps.length === 0 && emptyValue === 'null'
+          ? null
+          : mode === 'json'
+            ? JSON.stringify(dagConfig)
+            : dagConfig;
 
-        form.setValue(name, value, {
-          shouldDirty: true,
-          shouldTouch: true,
-          shouldValidate: true,
-        });
-      },
-      [dagName, emptyValue, form, mode, name],
-    );
+      setConfigValue(form, name, value, {
+        shouldDirty: true,
+        shouldTouch: true,
+        shouldValidate: true,
+      });
+    },
+    [dagName, emptyValue, form, mode, name],
+  );
 
-    return <PipelineWorkflowEditor steps={steps} onChange={handleChange} />;
-  },
+  return <PipelineWorkflowEditor steps={steps} onChange={handleChange} />;
+}
+
+export const PipelineConfigAdapter = genericMemo(
+  PipelineConfigAdapterImpl,
+  'PipelineConfigAdapter',
 );
-
-PipelineConfigAdapter.displayName = 'PipelineConfigAdapter';

--- a/rust-srec/frontend/src/components/config/shared/pipeline-tabs-section.tsx
+++ b/rust-srec/frontend/src/components/config/shared/pipeline-tabs-section.tsx
@@ -1,5 +1,5 @@
-import { lazy, ReactNode, Suspense } from 'react';
-import { UseFormReturn } from 'react-hook-form';
+import { ReactNode, Suspense } from 'react';
+import type { FieldValues, Path, UseFormReturn } from 'react-hook-form';
 import { Trans } from '@lingui/react/macro';
 import { Clock, Combine, Layers } from 'lucide-react';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
@@ -11,22 +11,29 @@ import {
   TooltipTrigger,
 } from '@/components/ui/tooltip';
 import { StatusInfoTooltip } from '@/components/shared/status-info-tooltip';
+import { genericLazy } from '@/lib/generic-component';
 
 // The step editor pulls in the flow-graph library, which is far larger than the rest of a config
 // page, so it only loads once the pipeline tab is opened.
-const PipelineConfigAdapter = lazy(() =>
+const PipelineConfigAdapter = genericLazy<
+  typeof import('./pipeline-config-adapter').PipelineConfigAdapter
+>(() =>
   import('./pipeline-config-adapter').then((m) => ({
     default: m.PipelineConfigAdapter,
   })),
 );
 
-interface PipelineTabsSectionProps {
-  form: UseFormReturn<any>;
+interface PipelineTabsSectionProps<TFieldValues extends FieldValues> {
+  form: UseFormReturn<TFieldValues>;
   /**
    * Field holding each pipeline. Omit `paired` or `session` for an entity that has no such
    * field; its tab then explains that the pipeline is unavailable.
    */
-  names: { perSegment: string; paired?: string; session?: string };
+  names: {
+    perSegment: Path<TFieldValues>;
+    paired?: Path<TFieldValues>;
+    session?: Path<TFieldValues>;
+  };
   /**
    * Names stored inside each DAG definition. Supplied by the global settings page, whose
    * partial update also needs an empty DAG rather than `null` to clear a pipeline.
@@ -53,12 +60,12 @@ function EditorFallback() {
  * The three pipeline triggers over the step editor, shared by the global settings page and the
  * template / platform / streamer editors so both offer the same tabs and explanations.
  */
-export function PipelineTabsSection({
+export function PipelineTabsSection<TFieldValues extends FieldValues>({
   form,
   names,
   dagNames,
   mode = 'object',
-}: PipelineTabsSectionProps) {
+}: PipelineTabsSectionProps<TFieldValues>) {
   // Only the global settings page names its DAGs, and its update request treats a `null` field
   // as "leave unchanged", so emptying a pipeline there has to send an empty DAG. Override fields
   // clear to `null`, which is how they express "inherit".
@@ -263,15 +270,15 @@ export function PipelineTabsSection({
   );
 }
 
-function PipelineEditor({
+function PipelineEditor<TFieldValues extends FieldValues>({
   form,
   name,
   dagName,
   mode,
   emptyValue,
 }: {
-  form: UseFormReturn<any>;
-  name: string;
+  form: UseFormReturn<TFieldValues>;
+  name: Path<TFieldValues>;
   dagName?: string;
   mode: 'json' | 'object';
   emptyValue: 'null' | 'dag';

--- a/rust-srec/frontend/src/components/config/shared/proxy-settings-card.tsx
+++ b/rust-srec/frontend/src/components/config/shared/proxy-settings-card.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { UseFormReturn } from 'react-hook-form';
+import type { FieldValues, Path, UseFormReturn } from 'react-hook-form';
 import { z } from 'zod';
 import { ProxyConfigObjectSchema } from '@/api/schemas';
 import { Input } from '@/components/ui/input';
@@ -44,7 +44,7 @@ type ProxyConfig = z.infer<typeof ProxyConfigObjectSchema>;
 
 export interface ProxyConfigSettingsProps {
   value: string | ProxyConfig | null | undefined;
-  onChange: (value: any) => void;
+  onChange: (value: string | ProxyConfig | null) => void;
   outputFormat?: 'json' | 'object';
 }
 
@@ -227,17 +227,17 @@ export function ProxyConfigSettings({
 
 // --- Wrapper Component (Exported) ---
 
-interface ProxySettingsCardProps {
-  form: UseFormReturn<any>;
-  name: string;
+interface ProxySettingsCardProps<TFieldValues extends FieldValues> {
+  form: UseFormReturn<TFieldValues>;
+  name: Path<TFieldValues>;
   proxyMode?: 'json' | 'object';
 }
 
-export function ProxySettingsCard({
+export function ProxySettingsCard<TFieldValues extends FieldValues>({
   form,
   name,
   proxyMode = 'object',
-}: ProxySettingsCardProps) {
+}: ProxySettingsCardProps<TFieldValues>) {
   return (
     <Card className="border-border/50 shadow-sm hover:shadow-md transition-all">
       <CardHeader className="pb-3 px-6 pt-6">

--- a/rust-srec/frontend/src/components/config/shared/record-danmu-card.tsx
+++ b/rust-srec/frontend/src/components/config/shared/record-danmu-card.tsx
@@ -1,4 +1,3 @@
-import { memo } from 'react';
 import {
   FormControl,
   FormDescription,
@@ -18,99 +17,103 @@ import { Trans } from '@lingui/react/macro';
 import { msg } from '@lingui/core/macro';
 import { useLingui } from '@lingui/react';
 import { Tv } from 'lucide-react';
-import { UseFormReturn } from 'react-hook-form';
+import type { FieldValues, UseFormReturn } from 'react-hook-form';
 import {
   CONFIG_DESCRIPTION,
   CONFIG_SELECT_CONTENT,
   CONFIG_SELECT_TRIGGER,
 } from './config-field';
+import { configPath } from './form-path';
+import { genericMemo } from '@/lib/generic-component';
 import { cn } from '@/lib/utils';
 
-interface RecordDanmuCardProps {
-  form: UseFormReturn<any>;
+interface RecordDanmuCardProps<TFieldValues extends FieldValues> {
+  form: UseFormReturn<TFieldValues>;
   basePath?: string;
 }
 
-export const RecordDanmuCard = memo(
-  ({ form, basePath }: RecordDanmuCardProps) => {
-    const { i18n } = useLingui();
-    return (
-      <Card className="border-border/50 shadow-sm hover:shadow-md transition-all">
-        <CardHeader>
-          <div className="flex items-center gap-3">
-            <div className="p-2 rounded-lg bg-green-500/10 text-green-600 dark:text-green-400">
-              <Tv className="w-5 h-5" />
-            </div>
-            <div className="space-y-1">
-              <CardTitle className="text-lg">
-                <Trans>Record Danmu</Trans>
-              </CardTitle>
-              <p className="text-sm text-muted-foreground">
-                <Trans>
-                  Capture real-time comments and chat messages if available.
-                </Trans>
-              </p>
-            </div>
+function RecordDanmuCardImpl<TFieldValues extends FieldValues>({
+  form,
+  basePath,
+}: RecordDanmuCardProps<TFieldValues>) {
+  const { i18n } = useLingui();
+  return (
+    <Card className="border-border/50 shadow-sm hover:shadow-md transition-all">
+      <CardHeader>
+        <div className="flex items-center gap-3">
+          <div className="p-2 rounded-lg bg-green-500/10 text-green-600 dark:text-green-400">
+            <Tv className="w-5 h-5" />
           </div>
-        </CardHeader>
-        <CardContent>
-          <FormField
-            control={form.control}
-            name={basePath ? `${basePath}.record_danmu` : 'record_danmu'}
-            render={({ field }) => (
-              <FormItem className="flex flex-row items-center justify-between rounded-xl border p-4 shadow-sm bg-muted/30">
-                <div className="space-y-0.5">
-                  <FormLabel className="text-sm font-semibold">
-                    <Trans>Capture Mode</Trans>
-                  </FormLabel>
-                  <FormDescription className={CONFIG_DESCRIPTION}>
-                    <Trans>Override global default.</Trans>
-                  </FormDescription>
-                </div>
-                <FormControl>
-                  <Select
-                    value={
-                      field.value === null || field.value === undefined
-                        ? 'null'
-                        : field.value
-                          ? 'true'
-                          : 'false'
-                    }
-                    onValueChange={(v) => {
-                      if (v === 'null') field.onChange(null);
-                      else if (v === 'true') field.onChange(true);
-                      else field.onChange(false);
-                    }}
-                  >
-                    <FormControl>
-                      <SelectTrigger
-                        className={cn(CONFIG_SELECT_TRIGGER, 'w-[180px]')}
-                      >
-                        <SelectValue
-                          placeholder={i18n._(msg`Select behavior`)}
-                        />
-                      </SelectTrigger>
-                    </FormControl>
-                    <SelectContent className={CONFIG_SELECT_CONTENT}>
-                      <SelectItem value="null">
-                        <Trans>Global Default</Trans>
-                      </SelectItem>
-                      <SelectItem value="true">
-                        <Trans>Enabled</Trans>
-                      </SelectItem>
-                      <SelectItem value="false">
-                        <Trans>Disabled</Trans>
-                      </SelectItem>
-                    </SelectContent>
-                  </Select>
-                </FormControl>
-              </FormItem>
-            )}
-          />
-        </CardContent>
-      </Card>
-    );
-  },
-);
+          <div className="space-y-1">
+            <CardTitle className="text-lg">
+              <Trans>Record Danmu</Trans>
+            </CardTitle>
+            <p className="text-sm text-muted-foreground">
+              <Trans>
+                Capture real-time comments and chat messages if available.
+              </Trans>
+            </p>
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent>
+        <FormField
+          control={form.control}
+          name={configPath<TFieldValues>(basePath, 'record_danmu')}
+          render={({ field }) => (
+            <FormItem className="flex flex-row items-center justify-between rounded-xl border p-4 shadow-sm bg-muted/30">
+              <div className="space-y-0.5">
+                <FormLabel className="text-sm font-semibold">
+                  <Trans>Capture Mode</Trans>
+                </FormLabel>
+                <FormDescription className={CONFIG_DESCRIPTION}>
+                  <Trans>Override global default.</Trans>
+                </FormDescription>
+              </div>
+              <FormControl>
+                <Select
+                  value={
+                    field.value === null || field.value === undefined
+                      ? 'null'
+                      : field.value
+                        ? 'true'
+                        : 'false'
+                  }
+                  onValueChange={(v) => {
+                    if (v === 'null') field.onChange(null);
+                    else if (v === 'true') field.onChange(true);
+                    else field.onChange(false);
+                  }}
+                >
+                  <FormControl>
+                    <SelectTrigger
+                      className={cn(CONFIG_SELECT_TRIGGER, 'w-[180px]')}
+                    >
+                      <SelectValue placeholder={i18n._(msg`Select behavior`)} />
+                    </SelectTrigger>
+                  </FormControl>
+                  <SelectContent className={CONFIG_SELECT_CONTENT}>
+                    <SelectItem value="null">
+                      <Trans>Global Default</Trans>
+                    </SelectItem>
+                    <SelectItem value="true">
+                      <Trans>Enabled</Trans>
+                    </SelectItem>
+                    <SelectItem value="false">
+                      <Trans>Disabled</Trans>
+                    </SelectItem>
+                  </SelectContent>
+                </Select>
+              </FormControl>
+            </FormItem>
+          )}
+        />
+      </CardContent>
+    </Card>
+  );
+}
 
-RecordDanmuCard.displayName = 'RecordDanmuCard';
+export const RecordDanmuCard = genericMemo(
+  RecordDanmuCardImpl,
+  'RecordDanmuCard',
+);

--- a/rust-srec/frontend/src/components/config/shared/retry-policy-form.tsx
+++ b/rust-srec/frontend/src/components/config/shared/retry-policy-form.tsx
@@ -1,4 +1,4 @@
-import { UseFormReturn } from 'react-hook-form';
+import type { FieldValues, Path, UseFormReturn } from 'react-hook-form';
 import { FormControl, FormDescription, FormItem } from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
 import { Card, CardContent } from '@/components/ui/card';
@@ -24,21 +24,22 @@ const DEFAULT_RETRY_POLICY: RetryPolicy = {
   use_jitter: true,
 };
 
-interface RetryPolicyFormProps {
-  form: UseFormReturn<any>;
-  name: string; // path to the field in the form (e.g. "download_retry_policy")
+interface RetryPolicyFormProps<TFieldValues extends FieldValues> {
+  form: UseFormReturn<TFieldValues>;
+  /** Path to the field in the form (e.g. "download_retry_policy"). */
+  name: Path<TFieldValues>;
   mode?: 'json' | 'object';
 }
 
-export function RetryPolicyForm({
+export function RetryPolicyForm<TFieldValues extends FieldValues>({
   form,
   name,
   mode = 'json',
-}: RetryPolicyFormProps) {
+}: RetryPolicyFormProps<TFieldValues>) {
   // Use the custom hook to manage nested form state
   const [policy, updateField] = useNestedFormState(
     form,
-    name as any,
+    name,
     DEFAULT_RETRY_POLICY,
     { mode },
   );

--- a/rust-srec/frontend/src/components/config/shared/stream-selection-tab.tsx
+++ b/rust-srec/frontend/src/components/config/shared/stream-selection-tab.tsx
@@ -1,85 +1,85 @@
-import { memo, useMemo } from 'react';
-import { UseFormReturn, useWatch } from 'react-hook-form';
+import { useMemo } from 'react';
+import { useWatch } from 'react-hook-form';
+import type { FieldValues, Path, UseFormReturn } from 'react-hook-form';
 import {
   StreamSelectionInput,
   StreamSelectionConfig,
 } from '../../streamers/config/stream-selection-input';
+import { configPath, setConfigValue } from './form-path';
+import { genericMemo } from '@/lib/generic-component';
 
-interface StreamSelectionTabProps {
-  form: UseFormReturn<any>;
+interface StreamSelectionTabProps<TFieldValues extends FieldValues> {
+  form: UseFormReturn<TFieldValues>;
   basePath?: string;
-  fieldName?: string;
+  fieldName?: Path<TFieldValues>;
   mode?: 'json' | 'object';
 }
 
-export const StreamSelectionTab = memo(
-  ({
-    form,
-    basePath,
-    fieldName: propFieldName,
-    mode = 'json',
-  }: StreamSelectionTabProps) => {
-    const fieldName =
-      propFieldName ??
-      (basePath
-        ? `${basePath}.stream_selection_config`
-        : 'stream_selection_config');
+function StreamSelectionTabImpl<TFieldValues extends FieldValues>({
+  form,
+  basePath,
+  fieldName: propFieldName,
+  mode = 'json',
+}: StreamSelectionTabProps<TFieldValues>) {
+  const fieldName =
+    propFieldName ??
+    configPath<TFieldValues>(basePath, 'stream_selection_config');
 
-    const rawConfig = useWatch({ control: form.control, name: fieldName });
+  const rawConfig = useWatch({ control: form.control, name: fieldName });
 
-    const currentConfig: StreamSelectionConfig = useMemo(() => {
-      if (!rawConfig) return {};
+  const currentConfig: StreamSelectionConfig = useMemo(() => {
+    if (!rawConfig) return {};
 
-      // Handle string input (JSON) - useful if mode is json OR if data is unexpectedly a string in object mode
-      if (typeof rawConfig === 'string') {
-        try {
-          return JSON.parse(rawConfig);
-        } catch (e) {
-          console.error('Failed to parse stream selection config:', e);
-          return {};
-        }
+    // Handle string input (JSON) - useful if mode is json OR if data is unexpectedly a string in object mode
+    if (typeof rawConfig === 'string') {
+      try {
+        return JSON.parse(rawConfig);
+      } catch (e) {
+        console.error('Failed to parse stream selection config:', e);
+        return {};
       }
+    }
 
-      // Handle object input - useful if mode is object OR if data is unexpectedly an object in json mode
-      if (typeof rawConfig === 'object') {
-        return rawConfig;
-      }
+    // Handle object input - useful if mode is object OR if data is unexpectedly an object in json mode
+    if (typeof rawConfig === 'object') {
+      return rawConfig;
+    }
 
-      return {};
-    }, [rawConfig]);
+    return {};
+  }, [rawConfig]);
 
-    const handleConfigChange = (newConfig: StreamSelectionConfig) => {
-      if (Object.keys(newConfig).length === 0) {
-        if (mode === 'json') {
-          form.setValue(fieldName, null, {
-            shouldDirty: true,
-            shouldTouch: true,
-          });
-        } else {
-          form.setValue(fieldName, undefined, {
-            shouldDirty: true,
-            shouldTouch: true,
-          });
-        }
+  const handleConfigChange = (newConfig: StreamSelectionConfig) => {
+    if (Object.keys(newConfig).length === 0) {
+      if (mode === 'json') {
+        setConfigValue(form, fieldName, null, {
+          shouldDirty: true,
+          shouldTouch: true,
+        });
       } else {
-        form.setValue(
-          fieldName,
-          mode === 'json' ? JSON.stringify(newConfig) : newConfig,
-          {
-            shouldDirty: true,
-            shouldTouch: true,
-          },
-        );
+        setConfigValue(form, fieldName, undefined, {
+          shouldDirty: true,
+          shouldTouch: true,
+        });
       }
-    };
+    } else {
+      setConfigValue(
+        form,
+        fieldName,
+        mode === 'json' ? JSON.stringify(newConfig) : newConfig,
+        {
+          shouldDirty: true,
+          shouldTouch: true,
+        },
+      );
+    }
+  };
 
-    return (
-      <StreamSelectionInput
-        value={currentConfig}
-        onChange={handleConfigChange}
-      />
-    );
-  },
+  return (
+    <StreamSelectionInput value={currentConfig} onChange={handleConfigChange} />
+  );
+}
+
+export const StreamSelectionTab = genericMemo(
+  StreamSelectionTabImpl,
+  'StreamSelectionTab',
 );
-
-StreamSelectionTab.displayName = 'StreamSelectionTab';

--- a/rust-srec/frontend/src/components/config/templates/tabs/__tests__/engine-override-card.test.tsx
+++ b/rust-srec/frontend/src/components/config/templates/tabs/__tests__/engine-override-card.test.tsx
@@ -6,11 +6,13 @@ import { useForm, type UseFormReturn } from 'react-hook-form';
 import { Form } from '@/components/ui/form';
 import { EngineOverrideCard } from '../engine-override-card';
 
+type Values = { engines_override?: Record<string, unknown> };
+
 function renderCard(onRemove: () => void) {
-  let form!: UseFormReturn<any>;
+  let form!: UseFormReturn<Values>;
 
   function Harness() {
-    form = useForm<any>({ defaultValues: {} });
+    form = useForm<Values>({ defaultValues: {} });
     return (
       <Form {...form}>
         <EngineOverrideCard

--- a/rust-srec/frontend/src/components/config/templates/tabs/engine-overrides-tab.tsx
+++ b/rust-srec/frontend/src/components/config/templates/tabs/engine-overrides-tab.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
-import { UseFormReturn, useWatch } from 'react-hook-form';
+import { useWatch } from 'react-hook-form';
+import type { UseFormReturn } from 'react-hook-form';
 import { useQuery } from '@tanstack/react-query';
 import { Trans } from '@lingui/react/macro';
 import { msg } from '@lingui/core/macro';
@@ -29,9 +30,10 @@ import {
   CardTitle,
   CardDescription,
 } from '@/components/ui/card';
+import type { TemplateFormValues } from '../template-editor';
 
 interface EngineOverridesTabProps {
-  form: UseFormReturn<any>;
+  form: UseFormReturn<TemplateFormValues>;
 }
 
 export function EngineOverridesTab({ form }: EngineOverridesTabProps) {

--- a/rust-srec/frontend/src/components/config/templates/tabs/platform-override-card.tsx
+++ b/rust-srec/frontend/src/components/config/templates/tabs/platform-override-card.tsx
@@ -1,4 +1,4 @@
-import { UseFormReturn } from 'react-hook-form';
+import type { UseFormReturn } from 'react-hook-form';
 import { Button } from '@/components/ui/button';
 import {
   Trash2,
@@ -25,10 +25,12 @@ import {
   SharedConfigPaths,
   ExtraTab,
 } from '../../shared-config-editor';
+import { configPath } from '../../shared/form-path';
+import type { TemplateFormValues } from '../template-editor';
 
 interface PlatformOverrideCardProps {
   platformName: string;
-  form: UseFormReturn<any>;
+  form: UseFormReturn<TemplateFormValues>;
   onRemove: () => void;
   engines?: EngineConfig[];
 }
@@ -44,17 +46,29 @@ export function PlatformOverrideCard({
   // Dynamic base path for this override
   const basePath = `platform_overrides.${platformName}`;
 
-  const paths: SharedConfigPaths = {
-    streamSelection: `${basePath}.stream_selection_config`,
-    cookies: `${basePath}.cookies`,
-    proxy: `${basePath}.proxy_config`,
-    retryPolicy: `${basePath}.download_retry_policy`,
+  const paths: SharedConfigPaths<TemplateFormValues> = {
+    streamSelection: configPath<TemplateFormValues>(
+      basePath,
+      'stream_selection_config',
+    ),
+    cookies: configPath<TemplateFormValues>(basePath, 'cookies'),
+    proxy: configPath<TemplateFormValues>(basePath, 'proxy_config'),
+    retryPolicy: configPath<TemplateFormValues>(
+      basePath,
+      'download_retry_policy',
+    ),
     output: basePath, // Output settings are flat on the config object (output_folder, etc.)
     limits: basePath, // Limits are flat
     danmu: basePath, // record_danmu is flat
-    pipeline: `${basePath}.pipeline`,
-    sessionCompletePipeline: `${basePath}.session_complete_pipeline`,
-    pairedSegmentPipeline: `${basePath}.paired_segment_pipeline`,
+    pipeline: configPath<TemplateFormValues>(basePath, 'pipeline'),
+    sessionCompletePipeline: configPath<TemplateFormValues>(
+      basePath,
+      'session_complete_pipeline',
+    ),
+    pairedSegmentPipeline: configPath<TemplateFormValues>(
+      basePath,
+      'paired_segment_pipeline',
+    ),
   };
 
   const extraTabs: ExtraTab[] = [

--- a/rust-srec/frontend/src/components/config/templates/tabs/platform-overrides-tab.tsx
+++ b/rust-srec/frontend/src/components/config/templates/tabs/platform-overrides-tab.tsx
@@ -1,4 +1,5 @@
-import { UseFormReturn, useWatch } from 'react-hook-form';
+import { useWatch } from 'react-hook-form';
+import type { UseFormReturn } from 'react-hook-form';
 import { useQuery } from '@tanstack/react-query';
 import { listPlatformConfigs, listEngines } from '@/server/functions';
 import { Button } from '@/components/ui/button';
@@ -29,9 +30,10 @@ import {
 } from '@/components/ui/card';
 import { msg } from '@lingui/core/macro';
 import { useLingui } from '@lingui/react';
+import type { TemplateFormValues } from '../template-editor';
 
 interface PlatformOverridesTabProps {
-  form: UseFormReturn<any>;
+  form: UseFormReturn<TemplateFormValues>;
 }
 
 export function PlatformOverridesTab({ form }: PlatformOverridesTabProps) {

--- a/rust-srec/frontend/src/components/filters/forms/__tests__/time-based-filter-form.test.tsx
+++ b/rust-srec/frontend/src/components/filters/forms/__tests__/time-based-filter-form.test.tsx
@@ -6,11 +6,13 @@ import { useForm, type UseFormReturn } from 'react-hook-form';
 import { Form } from '@/components/ui/form';
 import { TimeBasedFilterForm } from '../TimeBasedFilterForm';
 
+type Values = { config: Record<string, unknown> };
+
 function renderForm(config?: Record<string, unknown>) {
-  let form!: UseFormReturn<any>;
+  let form!: UseFormReturn<Values>;
 
   function Harness() {
-    form = useForm<any>({
+    form = useForm<Values>({
       defaultValues: {
         config: {
           days_of_week: [],

--- a/rust-srec/frontend/src/components/logging/log-viewer.tsx
+++ b/rust-srec/frontend/src/components/logging/log-viewer.tsx
@@ -233,9 +233,7 @@ export function LogViewer() {
   const isPausedRef = useRef(false);
   const pausedLogsRef = useRef<DisplayLogEvent[]>([]);
 
-  const { user: routeUser } = useRouteContext({ from: '/_authed' }) as {
-    user?: any;
-  };
+  const { user: routeUser } = useRouteContext({ from: '/_authed' });
   const { data: sessionData } = useQuery({
     ...sessionQueryOptions,
     enabled: typeof window !== 'undefined',

--- a/rust-srec/frontend/src/components/notifications/forms/__tests__/webhook-form.test.tsx
+++ b/rust-srec/frontend/src/components/notifications/forms/__tests__/webhook-form.test.tsx
@@ -6,10 +6,12 @@ import { useForm, type UseFormReturn } from 'react-hook-form';
 import { Form } from '@/components/ui/form';
 import { WebhookForm } from '../webhook-form';
 
+type Values = { settings: Record<string, unknown> };
+
 function renderForm(headers: Array<[string, string]>) {
-  let form!: UseFormReturn<any>;
+  let form!: UseFormReturn<Values>;
   function Harness() {
-    form = useForm<any>({
+    form = useForm<Values>({
       defaultValues: {
         settings: {
           url: 'https://example.invalid/hook',

--- a/rust-srec/frontend/src/components/pipeline/presets/__tests__/preset-processor-select.test.tsx
+++ b/rust-srec/frontend/src/components/pipeline/presets/__tests__/preset-processor-select.test.tsx
@@ -6,7 +6,9 @@ import type { PropsWithChildren } from 'react';
 import { useForm } from 'react-hook-form';
 
 import { Form } from '@/components/ui/form';
+import type { JobPreset } from '@/api/schemas';
 import { PresetMetaForm } from '../editor/preset-meta-form';
+import type { PresetFormValues } from '../preset-editor';
 
 vi.mock('@tanstack/react-router', () => ({
   Link: ({ children }: PropsWithChildren) => <a href="#">{children}</a>,
@@ -18,19 +20,21 @@ vi.mock('motion/react', () => ({
   },
 }));
 
-interface PresetValues {
-  id: string;
-  name: string;
-  description: string;
-  category: string;
-  processor: string;
-  config: Record<string, unknown>;
-}
-
 const i18n = setupI18n({ locale: 'en', messages: { en: {} } });
 
+const EXISTING_PRESET: JobPreset = {
+  id: 'preset-default-metadata',
+  name: 'add_metadata',
+  description: 'Add metadata',
+  category: 'metadata',
+  processor: 'metadata',
+  config: { title: 'Example' },
+  created_at: '2024-01-01T00:00:00Z',
+  updated_at: '2024-01-01T00:00:00Z',
+};
+
 function PresetMetaFormHarness() {
-  const form = useForm<PresetValues>({
+  const form = useForm<PresetFormValues>({
     defaultValues: {
       id: '',
       name: '',
@@ -59,7 +63,7 @@ function PresetMetaFormHarness() {
         <form>
           <PresetMetaForm
             form={form}
-            initialData={{ id: 'preset-default-metadata' }}
+            initialData={EXISTING_PRESET}
             title="Edit preset"
             isUpdating={false}
           />

--- a/rust-srec/frontend/src/components/pipeline/presets/editor/preset-config-form.tsx
+++ b/rust-srec/frontend/src/components/pipeline/presets/editor/preset-config-form.tsx
@@ -4,7 +4,12 @@ import { Trans } from '@lingui/react/macro';
 import { PRESET_TEMPLATES } from '../preset-templates';
 import { ProcessorConfigManager } from '../processors/processor-config-manager';
 import { motion } from 'motion/react';
-import { UseFormReturn } from 'react-hook-form';
+import type {
+  Control,
+  FieldValues,
+  UseFormRegister,
+  UseFormReturn,
+} from 'react-hook-form';
 import { toast } from 'sonner';
 import { msg } from '@lingui/core/macro';
 import { useLingui } from '@lingui/react';
@@ -15,9 +20,10 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui/card';
+import type { PresetFormValues } from '../preset-editor';
 
 interface PresetConfigFormProps {
-  form: UseFormReturn<any>;
+  form: UseFormReturn<PresetFormValues>;
   currentProcessor: string;
 }
 
@@ -101,8 +107,12 @@ export function PresetConfigForm({
         <CardContent className="p-6 md:p-8">
           <ProcessorConfigManager
             processorType={currentProcessor}
-            control={form.control}
-            register={form.register}
+            // Each processor form in the registry is typed against its own config object and
+            // addresses it relative to `pathPrefix`. That relation between a prefix and the
+            // surrounding form is not expressible here, so the control crosses the boundary
+            // under the base form type.
+            control={form.control as unknown as Control<FieldValues>}
+            register={form.register as unknown as UseFormRegister<FieldValues>}
             pathPrefix="config"
           />
         </CardContent>

--- a/rust-srec/frontend/src/components/pipeline/presets/editor/preset-meta-form.tsx
+++ b/rust-srec/frontend/src/components/pipeline/presets/editor/preset-meta-form.tsx
@@ -1,4 +1,4 @@
-import { UseFormReturn } from 'react-hook-form';
+import type { UseFormReturn } from 'react-hook-form';
 import {
   FormControl,
   FormField,
@@ -49,10 +49,13 @@ import {
   PRESET_CATEGORY_NAMES,
 } from '../default-presets-i18n';
 import { useLingui } from '@lingui/react';
+import type { JobPreset } from '@/api/schemas';
+import type { PresetFormValues } from '../preset-editor';
 
 interface PresetMetaFormProps {
-  form: UseFormReturn<any>;
-  initialData?: any;
+  form: UseFormReturn<PresetFormValues>;
+  /** The preset being edited; absent when creating one. */
+  initialData?: JobPreset | null;
   title: React.ReactNode;
   isUpdating: boolean;
 }
@@ -93,7 +96,7 @@ export function PresetMetaForm({
   const { i18n } = useLingui();
   const currentProcessor = form.watch('processor');
   const currentId = form.watch('id');
-  const isDefault = isUpdating && currentId && isDefaultPreset(currentId);
+  const isDefault = isUpdating && !!currentId && isDefaultPreset(currentId);
   // Find selected option to get label and icon safely
   const selectedOption = PROCESSOR_OPTIONS.find(
     (opt) => opt.id === currentProcessor,

--- a/rust-srec/frontend/src/components/pipeline/presets/preset-editor.tsx
+++ b/rust-srec/frontend/src/components/pipeline/presets/preset-editor.tsx
@@ -21,7 +21,7 @@ const BasePresetFormSchema = z.object({
   config: z.any(),
 });
 
-type PresetFormValues = z.infer<typeof BasePresetFormSchema>;
+export type PresetFormValues = z.infer<typeof BasePresetFormSchema>;
 
 interface PresetEditorProps {
   initialData?: z.infer<typeof JobPresetSchema> | null;

--- a/rust-srec/frontend/src/components/pipeline/presets/processors/__tests__/metadata-custom-tags.test.tsx
+++ b/rust-srec/frontend/src/components/pipeline/presets/processors/__tests__/metadata-custom-tags.test.tsx
@@ -2,14 +2,18 @@ import { setupI18n } from '@lingui/core';
 import { I18nProvider } from '@lingui/react';
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import { useForm, type UseFormReturn } from 'react-hook-form';
+import { z } from 'zod';
 
 import { Form } from '@/components/ui/form';
+import { MetadataConfigSchema } from '../../processor-schemas';
 import { MetadataConfigForm } from '../metadata-config-form';
 
+type Values = z.infer<typeof MetadataConfigSchema>;
+
 function renderForm(custom?: Record<string, string>) {
-  let form!: UseFormReturn<any>;
+  let form!: UseFormReturn<Values>;
   function Harness() {
-    form = useForm<any>({ defaultValues: { custom } });
+    form = useForm<Values>({ defaultValues: { custom } });
     return (
       <Form {...form}>
         <MetadataConfigForm control={form.control} />

--- a/rust-srec/frontend/src/components/pipeline/presets/processors/processor-config-manager.tsx
+++ b/rust-srec/frontend/src/components/pipeline/presets/processors/processor-config-manager.tsx
@@ -1,4 +1,4 @@
-import { Control, UseFormRegister } from 'react-hook-form';
+import type { Control, FieldValues, UseFormRegister } from 'react-hook-form';
 import { Trans } from '@lingui/react/macro';
 import { Suspense } from 'react';
 import { getProcessorDefinition } from './registry';
@@ -6,8 +6,8 @@ import { Skeleton } from '@/components/ui/skeleton';
 
 interface ProcessorConfigManagerProps {
   processorType: string;
-  control: Control<any>;
-  register?: UseFormRegister<any>;
+  control: Control<FieldValues>;
+  register?: UseFormRegister<FieldValues>;
   pathPrefix?: string;
 }
 

--- a/rust-srec/frontend/src/components/shared/save-fab.tsx
+++ b/rust-srec/frontend/src/components/shared/save-fab.tsx
@@ -1,7 +1,8 @@
 import { ReactNode } from 'react';
 import { AnimatePresence, motion } from 'motion/react';
 import { Loader2, Save } from 'lucide-react';
-import { Control, useFormContext, useFormState } from 'react-hook-form';
+import { useFormContext, useFormState } from 'react-hook-form';
+import type { Control, FieldValues } from 'react-hook-form';
 import { Button } from '@/components/ui/button';
 import { usePrefersReducedMotion } from '@/hooks/use-prefers-reduced-motion';
 import { cn } from '@/lib/utils';
@@ -14,13 +15,13 @@ import { Trans } from '@lingui/react/macro';
  */
 export const FAB_ANCHOR = 'fixed bottom-6 right-6 z-50';
 
-interface SaveFabProps {
+interface SaveFabProps<TFieldValues extends FieldValues = FieldValues> {
   isSaving: boolean;
   /** Submits this form by id. Falls back to `onSubmit` when absent. */
   formId?: string;
   onSubmit?: () => void;
   /** Supply when rendering outside a `FormProvider`. */
-  control?: Control<any>;
+  control?: Control<TFieldValues>;
   /** Stay mounted while the form is clean, instead of appearing on first edit. */
   alwaysVisible?: boolean;
   /** Defaults to "Save changes". */
@@ -35,7 +36,7 @@ interface SaveFabProps {
  * One implementation so the button's size, shape and press feedback stay identical wherever it
  * appears; the pages differ only in whether it waits for a change before showing itself.
  */
-function Fab({
+function Fab<TFieldValues extends FieldValues>({
   isSaving,
   formId,
   onSubmit,
@@ -43,7 +44,7 @@ function Fab({
   alwaysVisible,
   label,
   className,
-}: SaveFabProps & { control: Control<any> }) {
+}: SaveFabProps<TFieldValues> & { control: Control<TFieldValues> }) {
   const { isDirty } = useFormState({ control });
   const reducedMotion = usePrefersReducedMotion();
   const visible = isDirty || isSaving || alwaysVisible;
@@ -105,8 +106,11 @@ function Fab({
   );
 }
 
-export function SaveFab({ control: propControl, ...props }: SaveFabProps) {
-  const formContext = useFormContext();
+export function SaveFab<TFieldValues extends FieldValues = FieldValues>({
+  control: propControl,
+  ...props
+}: SaveFabProps<TFieldValues>) {
+  const formContext = useFormContext<TFieldValues>();
   const control = propControl ?? formContext?.control;
   if (!control) return null;
   return <Fab {...props} control={control} />;

--- a/rust-srec/frontend/src/components/streamers/config/streamer-configuration.tsx
+++ b/rust-srec/frontend/src/components/streamers/config/streamer-configuration.tsx
@@ -1,13 +1,14 @@
-import { UseFormReturn, useWatch } from 'react-hook-form';
+import { useWatch } from 'react-hook-form';
+import type { UseFormReturn } from 'react-hook-form';
 import { Boxes } from 'lucide-react';
 import { Trans } from '@lingui/react/macro';
-import { EngineConfig } from '@/api/schemas';
+import { EngineConfig, StreamerFormValues } from '@/api/schemas';
 import { SharedConfigEditor } from '../../config/shared-config-editor';
 import { PlatformSpecificTab } from '../../config/platforms/tabs/platform-specific-tab';
 import { usePlatformDetection } from '@/hooks/use-platform-detection';
 
 interface StreamerConfigurationProps {
-  form: UseFormReturn<any>;
+  form: UseFormReturn<StreamerFormValues>;
   engines?: EngineConfig[];
   streamerId?: string;
   credentialPlatformNameHint?: string;

--- a/rust-srec/frontend/src/components/streamers/config/streamer-general-settings.tsx
+++ b/rust-srec/frontend/src/components/streamers/config/streamer-general-settings.tsx
@@ -1,11 +1,11 @@
-import { UseFormReturn } from 'react-hook-form';
+import type { UseFormReturn } from 'react-hook-form';
 import { Separator } from '@/components/ui/separator';
-import { Template } from '@/api/schemas';
+import { Template, StreamerFormValues } from '@/api/schemas';
 import { StreamerIdentityFields } from './streamer-identity-fields';
 import { StreamerRecordingFields } from './streamer-recording-fields';
 
 interface StreamerGeneralSettingsProps {
-  form: UseFormReturn<any>;
+  form: UseFormReturn<StreamerFormValues>;
   templates?: Template[];
   onAutofillName?: () => void;
   isAutofilling?: boolean;

--- a/rust-srec/frontend/src/components/streamers/config/streamer-identity-fields.tsx
+++ b/rust-srec/frontend/src/components/streamers/config/streamer-identity-fields.tsx
@@ -1,4 +1,5 @@
-import { UseFormReturn, useWatch } from 'react-hook-form';
+import { useWatch } from 'react-hook-form';
+import type { UseFormReturn } from 'react-hook-form';
 import {
   FormControl,
   FormDescription,
@@ -34,9 +35,10 @@ import {
   ConfigSectionHeading,
 } from '@/components/config/shared/config-field';
 import { cn } from '@/lib/utils';
+import { StreamerFormValues } from '@/api/schemas';
 
 interface StreamerIdentityFieldsProps {
-  form: UseFormReturn<any>;
+  form: UseFormReturn<StreamerFormValues>;
   onAutofillName?: () => void;
   isAutofilling?: boolean;
 }

--- a/rust-srec/frontend/src/components/streamers/config/streamer-recording-fields.tsx
+++ b/rust-srec/frontend/src/components/streamers/config/streamer-recording-fields.tsx
@@ -1,4 +1,4 @@
-import { UseFormReturn } from 'react-hook-form';
+import type { UseFormReturn } from 'react-hook-form';
 import {
   FormControl,
   FormDescription,
@@ -19,7 +19,7 @@ import { Trans } from '@lingui/react/macro';
 import { msg } from '@lingui/core/macro';
 import { useLingui } from '@lingui/react';
 import { Clapperboard } from 'lucide-react';
-import { Template } from '@/api/schemas';
+import { Template, StreamerFormValues } from '@/api/schemas';
 import {
   CONFIG_DESCRIPTION,
   CONFIG_SELECT_CONTENT,
@@ -29,7 +29,7 @@ import {
 } from '@/components/config/shared/config-field';
 
 interface StreamerRecordingFieldsProps {
-  form: UseFormReturn<any>;
+  form: UseFormReturn<StreamerFormValues>;
   templates?: Template[];
 }
 

--- a/rust-srec/frontend/src/components/ui/__tests__/number-input.test.tsx
+++ b/rust-srec/frontend/src/components/ui/__tests__/number-input.test.tsx
@@ -4,10 +4,12 @@ import { useForm, type UseFormReturn } from 'react-hook-form';
 import { Form, FormControl, FormField, FormItem } from '@/components/ui/form';
 import { NumberInput } from '../number-input';
 
+type Values = { retries?: number };
+
 function renderInput(initial?: number) {
-  let form!: UseFormReturn<any>;
+  let form!: UseFormReturn<Values>;
   function Harness() {
-    form = useForm<any>({ defaultValues: { retries: initial } });
+    form = useForm<Values>({ defaultValues: { retries: initial } });
     return (
       <Form {...form}>
         <FormField

--- a/rust-srec/frontend/src/lib/generic-component.ts
+++ b/rust-srec/frontend/src/lib/generic-component.ts
@@ -1,0 +1,40 @@
+import { lazy, memo } from 'react';
+import type { ComponentType, ReactNode } from 'react';
+
+/** A component whose props carry type parameters of their own. */
+type GenericComponent = (props: never) => ReactNode;
+
+/**
+ * Memoizes a component that has generic props.
+ *
+ * `React.memo` fixes a component's type parameters at the point it wraps the
+ * component, which would force every caller onto the constraint instead of its
+ * own concrete type. The memoized component behaves identically at runtime, so
+ * the original signature is restored on the way out.
+ */
+export function genericMemo<TComponent extends GenericComponent>(
+  component: TComponent,
+  displayName?: string,
+): TComponent {
+  const memoized = memo(component);
+  if (displayName) {
+    memoized.displayName = displayName;
+  }
+  return memoized as unknown as TComponent;
+}
+
+/**
+ * Lazily loads a component that has generic props.
+ *
+ * `React.lazy` fixes the component's type parameters the same way `React.memo`
+ * does, so the original signature is restored on the way out. The result still
+ * suspends while loading and must be rendered under a `Suspense` boundary.
+ */
+export function genericLazy<TComponent extends GenericComponent>(
+  load: () => Promise<{ default: TComponent }>,
+): TComponent {
+  const loader = load as unknown as () => Promise<{
+    default: ComponentType<unknown>;
+  }>;
+  return lazy(loader) as unknown as TComponent;
+}

--- a/rust-srec/frontend/src/providers/WebSocketProvider.tsx
+++ b/rust-srec/frontend/src/providers/WebSocketProvider.tsx
@@ -41,9 +41,7 @@ export async function handleUploadTerminal(
 
 export function WebSocketProvider({ children }: { children: ReactNode }) {
   // Auth state
-  const { user: routeUser } = useRouteContext({ from: '/_authed' }) as {
-    user?: any;
-  };
+  const { user: routeUser } = useRouteContext({ from: '/_authed' });
   const { data: sessionData } = useQuery({
     ...sessionQueryOptions,
     enabled: typeof window !== 'undefined',

--- a/rust-srec/frontend/src/routes/_authed/_dashboard/config/global.lazy.tsx
+++ b/rust-srec/frontend/src/routes/_authed/_dashboard/config/global.lazy.tsx
@@ -11,7 +11,6 @@ import { msg } from '@lingui/core/macro';
 import { useLingui } from '@lingui/react';
 import { Skeleton } from '@/components/ui/skeleton';
 import { useForm } from 'react-hook-form';
-import type { Resolver } from 'react-hook-form';
 import {
   useMemo,
   useCallback,
@@ -142,7 +141,8 @@ function GlobalConfigForm({
 }: {
   config: z.infer<typeof GlobalConfigFormSchema>;
 }) {
-  type GlobalConfigFormValues = z.infer<typeof GlobalConfigFormSchema>;
+  type GlobalConfigFormInput = z.input<typeof GlobalConfigFormSchema>;
+  type GlobalConfigFormValues = z.output<typeof GlobalConfigFormSchema>;
   const queryClient = useQueryClient();
   const { i18n } = useLingui();
 
@@ -157,13 +157,10 @@ function GlobalConfigForm({
     [config],
   );
 
-  const form = useForm<GlobalConfigFormValues>({
-    // The schema fills several fields in with defaults, so its input type makes them
-    // optional while the form binds the parsed shape; the resolver is stated against the
-    // latter.
-    resolver: zodResolver(
-      GlobalConfigFormSchema,
-    ) as Resolver<GlobalConfigFormValues>,
+  // The schema fills several fields in with defaults, so its input type leaves them
+  // optional while submit handlers receive the parsed shape.
+  const form = useForm<GlobalConfigFormInput, unknown, GlobalConfigFormValues>({
+    resolver: zodResolver(GlobalConfigFormSchema),
     defaultValues,
     values: defaultValues,
     reValidateMode: 'onBlur',

--- a/rust-srec/frontend/src/routes/_authed/_dashboard/config/global.lazy.tsx
+++ b/rust-srec/frontend/src/routes/_authed/_dashboard/config/global.lazy.tsx
@@ -11,6 +11,7 @@ import { msg } from '@lingui/core/macro';
 import { useLingui } from '@lingui/react';
 import { Skeleton } from '@/components/ui/skeleton';
 import { useForm } from 'react-hook-form';
+import type { Resolver } from 'react-hook-form';
 import {
   useMemo,
   useCallback,
@@ -157,9 +158,12 @@ function GlobalConfigForm({
   );
 
   const form = useForm<GlobalConfigFormValues>({
-    // Work around a react-hook-form resolver type incompatibility (often caused by
-    // `exactOptionalPropertyTypes` + resolver type definitions).
-    resolver: zodResolver(GlobalConfigFormSchema) as any,
+    // The schema fills several fields in with defaults, so its input type makes them
+    // optional while the form binds the parsed shape; the resolver is stated against the
+    // latter.
+    resolver: zodResolver(
+      GlobalConfigFormSchema,
+    ) as Resolver<GlobalConfigFormValues>,
     defaultValues,
     values: defaultValues,
     reValidateMode: 'onBlur',


### PR DESCRIPTION
## What changed?

Frontend review finding A–L 16: `UseFormReturn<any>` appeared 44 times across 41 files, so every config, template, streamer and preset form component accepted any form and lost all field-name checking. This types those props instead.

- Components used with a single form now name it: the template override tabs bind `TemplateFormValues`, the streamer config components bind `StreamerFormValues`, and the preset editor forms bind `PresetFormValues` (now exported).
- Components shared across several forms are generic over `TFieldValues extends FieldValues`, with field names typed as `Path<TFieldValues>`: the shared config cards, the platform tabs, and the per-platform field groups, which sit under different prefixes (`platform_specific_config` for platforms and templates, `streamer_specific_config.platform_extras` for streamers).
- `SharedConfigPaths` is generic, so the paths each editor hands the shared cards are now checked against that editor's own form.
- Two small helpers back this: `configPath` joins a runtime prefix with a field key, and `genericMemo` / `genericLazy` keep a component's type parameters through `React.memo` and `React.lazy`, which otherwise resolve them at the wrapping site.
- The route context casts in the log viewer and the WebSocket provider are gone; `useRouteContext({ from: '/_authed' })` already carries the session type.
- Test harnesses build the same form type as the component they drive.

Typing only — no rendered output, field name, or stored value changes. One type-level wart surfaced and was tightened: the preset meta form's `isDefault` was `'' | boolean` when the id was empty, which React already rendered as "not disabled"; it is now a boolean.

Casts that remain, each narrow and commented where it sits:

- `configPath` asserts the joined path, because a prefix known only at runtime cannot be resolved to a member of `Path<T>`.
- `setConfigValue` asserts the written value for fields that hold either an object or its serialized form depending on the entity.
- `genericMemo` / `genericLazy` restore the signature React's wrappers erase.
- The preset config form passes its control and register to the processor registry under the base form type, because each registry form is typed against its own processor config and addresses it relative to a path prefix.
- The global settings page states its resolver against the parsed shape, since the schema's defaults make those fields optional on input.

## Scope

- Affected components (backend / frontend / desktop / CLI / crates / docs): frontend
- Breaking change: no

## How to test

Run from `rust-srec/frontend`:

- `pnpm fmt:check` — passed
- `pnpm lint` — passed (one pre-existing warning in `platform-editor.tsx`, untouched here)
- `pnpm typecheck` — passed
- `pnpm test` — passed, 79 files / 681 tests
- `pnpm build` — passed
- `pnpm build:desktop` — passed

`grep -rn 'UseFormReturn<any>' src` now returns nothing (was 44 hits). `any` occurrences outside `proto/gen` drop from 342 to 278; the remainder is in areas outside this finding (the engine forms, the processor config forms, and the session/streamer display components).

## Checklist

- Formatting for affected files: passed
- Lint and relevant tests for affected behavior: passed
- Additional checks for affected interfaces, builds, migrations, or releases: passed (typecheck, web build, desktop build)
- Related docs, config examples, and generated outputs: N/A
- Final diff reviewed; unrelated changes excluded and shared logs/screenshots redacted: done

## Related issues

Frontend review finding A–L 16.
