### PR TITLE
test(web): pin the API base in the media download URL tests

### DIFF
--- a/rust-srec/frontend/src/lib/__tests__/url.test.ts
+++ b/rust-srec/frontend/src/lib/__tests__/url.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { getMediaDownloadUrl, isSameOriginUrl, safeRedirectPath } from '../url';
 
@@ -63,7 +63,16 @@ describe('safeRedirectPath', () => {
 });
 
 describe('getMediaDownloadUrl', () => {
+  // The same-origin cases need a relative API base; a developer's `.env` or
+  // shell may point the build at another origin.
+  beforeEach(() => {
+    vi.stubEnv('VITE_API_BASE_URL', '');
+    vi.stubEnv('API_BASE_URL', '');
+    vi.stubEnv('BACKEND_URL', '');
+  });
+
   afterEach(() => {
+    vi.unstubAllEnvs();
     delete (globalThis as { __RUST_SREC_BACKEND_URL__?: unknown })
       .__RUST_SREC_BACKEND_URL__;
   });


### PR DESCRIPTION
## What changed?

The `getMediaDownloadUrl` tests added in #928 assumed a relative API base. With a developer `.env` (or shell) that sets `VITE_API_BASE_URL` / `API_BASE_URL` / `BACKEND_URL` to an absolute URL, the same-origin cases resolved cross-origin and failed locally while passing in clean checkouts and CI. The describe block now stubs those variables to empty for its duration and restores them afterwards.

## Scope

- Affected components: frontend tests only
- Breaking change: no

## How to test

From `rust-srec/frontend` with `VITE_API_BASE_URL=https://example.test/api` in `.env`: `pnpm test src/lib/__tests__/url.test.ts` passes (19 tests). Full suite: 83 files / 707 tests; fmt, lint and typecheck clean.

## Checklist

- [x] Tests pass locally with and without an absolute API base
- [x] No runtime code changed

## Related issues

Follow-up to #928.
