### PR TITLE
test(database): cover account queries and timestamp storage contracts

### DIFF
--- a/rust-srec/tests/account_token_contracts.rs
+++ b/rust-srec/tests/account_token_contracts.rs
@@ -1,0 +1,424 @@
+//! Public query projections and storage contracts, independent of rotation policy.
+
+use serde::Serialize;
+use sqlx::{SqlitePool, sqlite::SqlitePoolOptions};
+
+use rust_srec::database::models::{
+    ApiKeyAccessLevel, ApiKeyDbModel, RefreshTokenDbModel, UserDbModel,
+};
+use rust_srec::database::repositories::{
+    ApiKeyRepository, RefreshTokenRepository, SqlxApiKeyRepository, SqlxRefreshTokenRepository,
+    SqlxUserRepository, UserRepository,
+};
+use rust_srec::database::time::now_ms;
+
+const CREATED: i64 = 1_788_784_496_123;
+
+async fn database() -> SqlitePool {
+    let pool = SqlitePoolOptions::new()
+        .max_connections(1)
+        .connect("sqlite::memory:")
+        .await
+        .unwrap();
+    sqlx::migrate!("./migrations").run(&pool).await.unwrap();
+    sqlx::query("DELETE FROM users")
+        .execute(&pool)
+        .await
+        .unwrap();
+    pool
+}
+
+fn user(id: &str, created_at: i64) -> UserDbModel {
+    UserDbModel {
+        id: id.into(),
+        username: format!("name-{id}"),
+        password_hash: format!("hash-{id}"),
+        email: Some(format!("{id}@example.test")),
+        roles: r#"["admin","viewer"]"#.into(),
+        is_active: true,
+        must_change_password: true,
+        last_login_at: Some(created_at - 321),
+        created_at,
+        updated_at: created_at + 123,
+    }
+}
+
+fn same<T: Serialize>(actual: &T, expected: &T) {
+    assert_eq!(
+        serde_json::to_value(actual).unwrap(),
+        serde_json::to_value(expected).unwrap()
+    );
+}
+
+async fn account_storage(pool: &SqlitePool) {
+    for (table, columns) in [
+        ("users", &["created_at", "updated_at", "last_login_at"][..]),
+        (
+            "refresh_tokens",
+            &["created_at", "expires_at", "revoked_at"][..],
+        ),
+        (
+            "auth_sessions",
+            &["created_at", "expires_at", "revoked_at"][..],
+        ),
+        (
+            "api_keys",
+            &["created_at", "expires_at", "last_used_at", "revoked_at"][..],
+        ),
+    ] {
+        for column in columns {
+            let types: Vec<String> = sqlx::query_scalar(sqlx::AssertSqlSafe(format!(
+                "SELECT typeof({column}) FROM {table} WHERE {column} IS NOT NULL"
+            )))
+            .fetch_all(pool)
+            .await
+            .unwrap();
+            // Each caller seeds populated clocks before using this helper.
+            assert!(
+                !types.is_empty(),
+                "missing repository-write coverage for {table}.{column}"
+            );
+            assert!(
+                types.iter().all(|kind| kind == "integer"),
+                "{table}.{column}: {types:?}"
+            );
+        }
+    }
+}
+
+#[tokio::test]
+async fn user_list_count_and_lookup_preserve_full_projection_across_updates() {
+    let pool = database().await;
+    let users = SqlxUserRepository::new(pool.clone(), pool.clone());
+    assert_eq!(users.count().await.unwrap(), 0);
+    assert!(users.list(10, 0).await.unwrap().is_empty());
+    let first = user("older", CREATED);
+    let mut second = user("newer", CREATED + 1000);
+    second.is_active = false;
+    second.email = None;
+    second.last_login_at = None;
+    users.create(&first).await.unwrap();
+    users.create(&second).await.unwrap();
+    let all = users.list(10, 0).await.unwrap();
+    assert_eq!(users.count().await.unwrap(), all.len() as i64);
+    same(&all, &vec![second.clone(), first.clone()]);
+    same(&users.list(1, 0).await.unwrap(), &vec![second.clone()]);
+    same(&users.list(1, 1).await.unwrap(), &vec![first.clone()]);
+    assert!(users.list(1, 2).await.unwrap().is_empty());
+    assert!(users.list(0, 0).await.unwrap().is_empty());
+    for expected in [&first, &second] {
+        same(
+            &users.find_by_id(&expected.id).await.unwrap().unwrap(),
+            expected,
+        );
+        same(
+            &users
+                .find_by_username(&expected.username)
+                .await
+                .unwrap()
+                .unwrap(),
+            expected,
+        );
+        if let Some(email) = &expected.email {
+            same(
+                &users.find_by_email(email).await.unwrap().unwrap(),
+                expected,
+            );
+        }
+    }
+    assert!(users.find_by_id("missing").await.unwrap().is_none());
+    assert!(users.find_by_username("missing").await.unwrap().is_none());
+    assert!(users.find_by_email("missing").await.unwrap().is_none());
+
+    let mut changed = first.clone();
+    changed.username = "renamed".into();
+    changed.password_hash = "new-hash".into();
+    changed.email = None;
+    changed.roles = r#"["viewer"]"#.into();
+    changed.is_active = false;
+    changed.must_change_password = false;
+    changed.last_login_at = None;
+    changed.created_at = 7; // Updates retain the original creation time.
+    let before = now_ms();
+    users.update(&changed).await.unwrap();
+    let stored = users.find_by_id(&first.id).await.unwrap().unwrap();
+    assert!((before..=now_ms()).contains(&stored.updated_at));
+    changed.created_at = first.created_at;
+    changed.updated_at = stored.updated_at;
+    same(&stored, &changed);
+    same(
+        &users.find_by_username("renamed").await.unwrap().unwrap(),
+        &changed,
+    );
+    same(&users.list(1, 1).await.unwrap(), &vec![changed.clone()]);
+    assert!(
+        users
+            .find_by_username(&first.username)
+            .await
+            .unwrap()
+            .is_none()
+    );
+    assert!(
+        users
+            .find_by_email(first.email.as_deref().unwrap())
+            .await
+            .unwrap()
+            .is_none()
+    );
+
+    users
+        .update_last_login(&first.id, CREATED + 777)
+        .await
+        .unwrap();
+    let logged_in = users.find_by_id(&first.id).await.unwrap().unwrap();
+    assert_eq!(logged_in.last_login_at, Some(CREATED + 777));
+    users
+        .update_password(&second.id, "hash-retain", false)
+        .await
+        .unwrap();
+    let password = users.find_by_id(&second.id).await.unwrap().unwrap();
+    assert!(password.must_change_password);
+    assert_eq!(password.password_hash, "hash-retain");
+    users
+        .update_password(&second.id, "hash-clear", true)
+        .await
+        .unwrap();
+    let password = users.find_by_id(&second.id).await.unwrap().unwrap();
+    assert!(!password.must_change_password);
+    assert_eq!(password.password_hash, "hash-clear");
+    let types: (String, String, String) = sqlx::query_as("SELECT typeof(created_at), typeof(updated_at), typeof(last_login_at) FROM users WHERE id = 'older'").fetch_one(&pool).await.unwrap();
+    assert_eq!(
+        types,
+        ("integer".into(), "integer".into(), "integer".into())
+    );
+    users.delete(&first.id).await.unwrap();
+    users.delete("missing").await.unwrap();
+    assert_eq!(users.count().await.unwrap(), 1);
+    assert!(users.find_by_id(&first.id).await.unwrap().is_none());
+    assert_eq!(users.list(10, 0).await.unwrap()[0].id, second.id);
+}
+
+fn token(
+    id: &str,
+    owner: &str,
+    created_at: i64,
+    expires_at: i64,
+    revoked_at: Option<i64>,
+) -> RefreshTokenDbModel {
+    RefreshTokenDbModel {
+        id: id.into(),
+        user_id: owner.into(),
+        token_hash: format!("hash-{id}"),
+        expires_at,
+        created_at,
+        revoked_at,
+        device_info: Some(format!("device-{id}")),
+        session_id: Some(format!("session-{id}")),
+    }
+}
+
+async fn active_tokens(
+    repo: &SqlxRefreshTokenRepository,
+    owner: &str,
+    expected: &[RefreshTokenDbModel],
+) {
+    let list = repo.find_active_by_user(owner).await.unwrap();
+    assert_eq!(
+        repo.count_active_by_user(owner).await.unwrap(),
+        list.len() as i64
+    );
+    same(&list, &expected.to_vec());
+    for item in &list {
+        same(
+            &repo
+                .find_by_token_hash(&item.token_hash)
+                .await
+                .unwrap()
+                .unwrap(),
+            item,
+        );
+    }
+}
+
+#[tokio::test]
+async fn token_and_key_queries_agree_on_owners_expiry_revocation_and_storage() {
+    let pool = database().await;
+    let users = SqlxUserRepository::new(pool.clone(), pool.clone());
+    let tokens = SqlxRefreshTokenRepository::new(pool.clone(), pool.clone());
+    let keys = SqlxApiKeyRepository::new(pool.clone(), pool.clone());
+    for id in ["alice", "bob"] {
+        users.create(&user(id, CREATED)).await.unwrap();
+    }
+    let future = now_ms() + 86_400_000;
+    let older = token("older", "alice", CREATED, future, None);
+    let newer = token("newer", "alice", CREATED + 1000, future, None);
+    // Zero is certainly expired without relying on sleeps or a moving equality boundary.
+    let expired = token("expired", "alice", CREATED + 2000, 0, None);
+    let revoked = token(
+        "revoked",
+        "alice",
+        CREATED + 3000,
+        future,
+        Some(CREATED + 4000),
+    );
+    let other = token("other", "bob", CREATED + 4000, future, None);
+    for value in [&older, &newer, &expired, &revoked, &other] {
+        tokens.create(value).await.unwrap();
+        same(
+            &tokens
+                .find_by_token_hash(&value.token_hash)
+                .await
+                .unwrap()
+                .unwrap(),
+            value,
+        );
+    }
+    active_tokens(&tokens, "alice", &[newer.clone(), older.clone()]).await;
+    active_tokens(&tokens, "bob", std::slice::from_ref(&other)).await;
+    active_tokens(&tokens, "missing", &[]).await;
+    assert!(
+        tokens
+            .find_by_token_hash("missing")
+            .await
+            .unwrap()
+            .is_none()
+    );
+    assert!(
+        tokens
+            .find_session("bob", older.session_id.as_deref().unwrap())
+            .await
+            .unwrap()
+            .is_none()
+    );
+    let session = tokens
+        .find_session("alice", older.session_id.as_deref().unwrap())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        (session.created_at, session.expires_at, session.revoked_at),
+        (CREATED, future, None)
+    );
+    let before_revoke = now_ms();
+    tokens.revoke(&newer.id).await.unwrap();
+    let revoked_newer = tokens
+        .find_by_token_hash(&newer.token_hash)
+        .await
+        .unwrap()
+        .unwrap();
+    assert!((before_revoke..=now_ms()).contains(&revoked_newer.revoked_at.unwrap()));
+    tokens.revoke(&newer.id).await.unwrap();
+    same(
+        &tokens
+            .find_by_token_hash(&newer.token_hash)
+            .await
+            .unwrap()
+            .unwrap(),
+        &revoked_newer,
+    );
+    tokens.revoke("missing").await.unwrap();
+    active_tokens(&tokens, "alice", std::slice::from_ref(&older)).await;
+    let before_revoke_all = now_ms();
+    tokens.revoke_all_for_user("alice").await.unwrap();
+    active_tokens(&tokens, "alice", &[]).await;
+    active_tokens(&tokens, "bob", std::slice::from_ref(&other)).await;
+    let revoked_session = tokens
+        .find_session("alice", older.session_id.as_deref().unwrap())
+        .await
+        .unwrap()
+        .unwrap();
+    assert!((before_revoke_all..=now_ms()).contains(&revoked_session.revoked_at.unwrap()));
+    let revoked_older = tokens
+        .find_by_token_hash(&older.token_hash)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(revoked_older.revoked_at, revoked_session.revoked_at);
+    assert_eq!(
+        tokens
+            .find_by_token_hash(&revoked.token_hash)
+            .await
+            .unwrap()
+            .unwrap()
+            .revoked_at,
+        revoked.revoked_at
+    );
+
+    let mut alice_keys = Vec::new();
+    for (index, (expires, revoked_at)) in [
+        (None, None),
+        (Some(0), None),
+        (Some(future), Some(CREATED + 1)),
+    ]
+    .into_iter()
+    .enumerate()
+    {
+        let mut key = ApiKeyDbModel::new(
+            "alice",
+            format!("key-{index}"),
+            format!("key-hash-{index}"),
+            "srec_test",
+            ApiKeyAccessLevel::Full,
+            expires,
+        );
+        key.created_at = CREATED + index as i64;
+        key.revoked_at = revoked_at;
+        keys.create(&key).await.unwrap();
+        alice_keys.push(key);
+    }
+    let other_key = ApiKeyDbModel::new(
+        "bob",
+        "other",
+        "other-key-hash",
+        "srec_other",
+        ApiKeyAccessLevel::ReadOnly,
+        None,
+    );
+    keys.create(&other_key).await.unwrap();
+    alice_keys.reverse();
+    same(&keys.list_by_user("alice").await.unwrap(), &alice_keys);
+    same(
+        &keys.list_by_user("bob").await.unwrap(),
+        &vec![other_key.clone()],
+    );
+    assert!(keys.list_by_user("missing").await.unwrap().is_empty());
+    for key in &alice_keys {
+        same(
+            &keys.find_by_key_hash(&key.key_hash).await.unwrap().unwrap(),
+            key,
+        );
+        same(
+            &keys.find_by_id("alice", &key.id).await.unwrap().unwrap(),
+            key,
+        );
+        assert!(keys.find_by_id("bob", &key.id).await.unwrap().is_none());
+        assert!(!keys.revoke("bob", &key.id).await.unwrap());
+    }
+    assert!(keys.find_by_key_hash("missing").await.unwrap().is_none());
+    assert!(keys.find_by_id("alice", "missing").await.unwrap().is_none());
+    assert!(!keys.revoke("alice", "missing").await.unwrap());
+    let key = alice_keys.last_mut().unwrap();
+    keys.update_last_used(&key.id, CREATED + 987).await.unwrap();
+    key.last_used_at = Some(CREATED + 987);
+    same(
+        &keys.find_by_id("alice", &key.id).await.unwrap().unwrap(),
+        key,
+    );
+    let before_key_revoke = now_ms();
+    assert!(keys.revoke("alice", &key.id).await.unwrap());
+    let stored = keys.find_by_id("alice", &key.id).await.unwrap().unwrap();
+    assert!((before_key_revoke..=now_ms()).contains(&stored.revoked_at.unwrap()));
+    key.revoked_at = stored.revoked_at;
+    same(&stored, key);
+    assert!(!keys.revoke("alice", &key.id).await.unwrap());
+    same(&keys.list_by_user("alice").await.unwrap(), &alice_keys);
+    same(
+        &keys
+            .find_by_id("bob", &other_key.id)
+            .await
+            .unwrap()
+            .unwrap(),
+        &other_key,
+    );
+    account_storage(&pool).await;
+}

--- a/rust-srec/tests/fixtures/timestamp_contract_inventory.json
+++ b/rust-srec/tests/fixtures/timestamp_contract_inventory.json
@@ -1,0 +1,570 @@
+{
+  "api_keys": {
+    "required_epoch_ms": [
+      "created_at"
+    ],
+    "nullable_epoch_ms": [
+      "expires_at",
+      "last_used_at",
+      "revoked_at"
+    ],
+    "non_timestamp_columns": [
+      "id",
+      "user_id",
+      "name",
+      "key_hash",
+      "key_prefix",
+      "access_level"
+    ]
+  },
+  "auth_sessions": {
+    "required_epoch_ms": [
+      "created_at",
+      "expires_at"
+    ],
+    "nullable_epoch_ms": [
+      "revoked_at"
+    ],
+    "non_timestamp_columns": [
+      "id",
+      "user_id"
+    ]
+  },
+  "dag_execution": {
+    "required_epoch_ms": [
+      "created_at",
+      "updated_at"
+    ],
+    "nullable_epoch_ms": [
+      "completed_at"
+    ],
+    "non_timestamp_columns": [
+      "id",
+      "dag_definition",
+      "status",
+      "streamer_id",
+      "session_id",
+      "segment_index",
+      "segment_source",
+      "error",
+      "total_steps",
+      "completed_steps",
+      "failed_steps"
+    ]
+  },
+  "dag_step_execution": {
+    "required_epoch_ms": [
+      "created_at",
+      "updated_at"
+    ],
+    "nullable_epoch_ms": [],
+    "non_timestamp_columns": [
+      "id",
+      "dag_id",
+      "step_id",
+      "job_id",
+      "status",
+      "depends_on_step_ids",
+      "outputs"
+    ]
+  },
+  "danmu_aggregator_state": {
+    "required_epoch_ms": [
+      "updated_at"
+    ],
+    "nullable_epoch_ms": [],
+    "non_timestamp_columns": [
+      "session_id",
+      "version",
+      "state"
+    ]
+  },
+  "danmu_statistics": {
+    "required_epoch_ms": [],
+    "nullable_epoch_ms": [
+      "start_time",
+      "end_time"
+    ],
+    "non_timestamp_columns": [
+      "id",
+      "session_id",
+      "total_danmus",
+      "danmu_rate_timeseries",
+      "top_talkers",
+      "word_frequency",
+      "unique_talkers",
+      "top_gifters",
+      "top_gifts",
+      "chat_count",
+      "gift_count",
+      "duration_secs",
+      "rate_bucket_secs"
+    ]
+  },
+  "engine_configuration": {
+    "required_epoch_ms": [],
+    "nullable_epoch_ms": [],
+    "non_timestamp_columns": [
+      "id",
+      "name",
+      "engine_type",
+      "config"
+    ]
+  },
+  "filters": {
+    "required_epoch_ms": [],
+    "nullable_epoch_ms": [],
+    "non_timestamp_columns": [
+      "id",
+      "streamer_id",
+      "filter_type",
+      "config"
+    ]
+  },
+  "global_config": {
+    "required_epoch_ms": [],
+    "nullable_epoch_ms": [],
+    "non_timestamp_columns": [
+      "id",
+      "output_folder",
+      "output_filename_template",
+      "output_file_format",
+      "min_segment_size_bytes",
+      "max_download_duration_secs",
+      "max_part_size_bytes",
+      "record_danmu",
+      "max_concurrent_downloads",
+      "max_concurrent_uploads",
+      "streamer_check_delay_ms",
+      "proxy_config",
+      "offline_check_delay_ms",
+      "offline_check_count",
+      "default_download_engine",
+      "max_concurrent_cpu_jobs",
+      "max_concurrent_io_jobs",
+      "job_history_retention_days",
+      "notification_event_log_retention_days",
+      "pipeline",
+      "log_filter_directive",
+      "session_complete_pipeline",
+      "paired_segment_pipeline",
+      "auto_thumbnail",
+      "pipeline_cpu_job_timeout_secs",
+      "pipeline_io_job_timeout_secs",
+      "pipeline_execute_timeout_secs",
+      "queue_freshness_threshold_ms",
+      "gpu_health_probe_interval_secs",
+      "stream_proxy_allow_private_targets",
+      "default_extractor",
+      "danmu_statistics"
+    ]
+  },
+  "job": {
+    "required_epoch_ms": [
+      "created_at",
+      "updated_at"
+    ],
+    "nullable_epoch_ms": [
+      "started_at",
+      "completed_at"
+    ],
+    "non_timestamp_columns": [
+      "id",
+      "job_type",
+      "status",
+      "config",
+      "state",
+      "input",
+      "outputs",
+      "priority",
+      "streamer_id",
+      "session_id",
+      "error",
+      "retry_count",
+      "pipeline_id",
+      "execution_info",
+      "duration_secs",
+      "queue_wait_secs",
+      "dag_step_execution_id"
+    ]
+  },
+  "job_execution_logs": {
+    "required_epoch_ms": [
+      "created_at"
+    ],
+    "nullable_epoch_ms": [],
+    "non_timestamp_columns": [
+      "id",
+      "job_id",
+      "entry",
+      "level",
+      "message"
+    ]
+  },
+  "job_execution_progress": {
+    "required_epoch_ms": [
+      "updated_at"
+    ],
+    "nullable_epoch_ms": [],
+    "non_timestamp_columns": [
+      "job_id",
+      "kind",
+      "progress"
+    ]
+  },
+  "job_presets": {
+    "required_epoch_ms": [
+      "created_at",
+      "updated_at"
+    ],
+    "nullable_epoch_ms": [],
+    "non_timestamp_columns": [
+      "id",
+      "name",
+      "description",
+      "category",
+      "processor",
+      "config"
+    ]
+  },
+  "live_sessions": {
+    "required_epoch_ms": [
+      "start_time"
+    ],
+    "nullable_epoch_ms": [
+      "end_time"
+    ],
+    "non_timestamp_columns": [
+      "id",
+      "streamer_id",
+      "streamer_name",
+      "titles",
+      "danmu_statistics_id",
+      "total_size_bytes",
+      "session_complete_dispatched"
+    ]
+  },
+  "media_outputs": {
+    "required_epoch_ms": [
+      "created_at"
+    ],
+    "nullable_epoch_ms": [],
+    "non_timestamp_columns": [
+      "id",
+      "session_id",
+      "parent_media_output_id",
+      "file_path",
+      "file_type",
+      "size_bytes"
+    ]
+  },
+  "monitor_event_outbox": {
+    "required_epoch_ms": [
+      "created_at"
+    ],
+    "nullable_epoch_ms": [
+      "delivered_at"
+    ],
+    "non_timestamp_columns": [
+      "id",
+      "streamer_id",
+      "event_type",
+      "payload",
+      "attempts",
+      "last_error"
+    ]
+  },
+  "notification_channel": {
+    "required_epoch_ms": [],
+    "nullable_epoch_ms": [],
+    "non_timestamp_columns": [
+      "id",
+      "name",
+      "channel_type",
+      "settings"
+    ]
+  },
+  "notification_dead_letter": {
+    "required_epoch_ms": [
+      "first_attempt_at",
+      "last_attempt_at",
+      "created_at"
+    ],
+    "nullable_epoch_ms": [],
+    "non_timestamp_columns": [
+      "id",
+      "channel_id",
+      "event_name",
+      "event_payload",
+      "error_message",
+      "retry_count"
+    ]
+  },
+  "notification_event_log": {
+    "required_epoch_ms": [
+      "created_at"
+    ],
+    "nullable_epoch_ms": [],
+    "non_timestamp_columns": [
+      "id",
+      "event_type",
+      "priority",
+      "payload",
+      "streamer_id"
+    ]
+  },
+  "notification_subscription": {
+    "required_epoch_ms": [],
+    "nullable_epoch_ms": [],
+    "non_timestamp_columns": [
+      "channel_id",
+      "event_name"
+    ]
+  },
+  "pipeline_presets": {
+    "required_epoch_ms": [
+      "created_at",
+      "updated_at"
+    ],
+    "nullable_epoch_ms": [],
+    "non_timestamp_columns": [
+      "id",
+      "name",
+      "description",
+      "dag_definition",
+      "pipeline_type"
+    ]
+  },
+  "platform_config": {
+    "required_epoch_ms": [],
+    "nullable_epoch_ms": [],
+    "non_timestamp_columns": [
+      "id",
+      "platform_name",
+      "fetch_delay_ms",
+      "download_delay_ms",
+      "cookies",
+      "platform_specific_config",
+      "proxy_config",
+      "record_danmu",
+      "output_folder",
+      "output_filename_template",
+      "download_engine",
+      "stream_selection_config",
+      "output_file_format",
+      "min_segment_size_bytes",
+      "max_download_duration_secs",
+      "max_part_size_bytes",
+      "download_retry_policy",
+      "pipeline",
+      "session_complete_pipeline",
+      "paired_segment_pipeline",
+      "offline_check_count",
+      "offline_check_delay_ms",
+      "extractor",
+      "danmu_statistics"
+    ]
+  },
+  "refresh_tokens": {
+    "required_epoch_ms": [
+      "expires_at",
+      "created_at"
+    ],
+    "nullable_epoch_ms": [
+      "revoked_at"
+    ],
+    "non_timestamp_columns": [
+      "id",
+      "user_id",
+      "token_hash",
+      "device_info",
+      "session_id"
+    ]
+  },
+  "retirement_config_deletions": {
+    "required_epoch_ms": [],
+    "nullable_epoch_ms": [],
+    "non_timestamp_columns": [
+      "kind",
+      "config_id"
+    ]
+  },
+  "session_events": {
+    "required_epoch_ms": [
+      "occurred_at"
+    ],
+    "nullable_epoch_ms": [],
+    "non_timestamp_columns": [
+      "id",
+      "session_id",
+      "streamer_id",
+      "kind",
+      "payload"
+    ]
+  },
+  "session_segments": {
+    "required_epoch_ms": [
+      "persisted_at"
+    ],
+    "nullable_epoch_ms": [
+      "created_at",
+      "completed_at"
+    ],
+    "non_timestamp_columns": [
+      "id",
+      "session_id",
+      "segment_index",
+      "file_path",
+      "duration_secs",
+      "size_bytes",
+      "split_reason_code",
+      "split_reason_details_json"
+    ]
+  },
+  "streamer_check_history": {
+    "required_epoch_ms": [
+      "checked_at"
+    ],
+    "nullable_epoch_ms": [],
+    "non_timestamp_columns": [
+      "id",
+      "streamer_id",
+      "duration_ms",
+      "outcome",
+      "fatal_kind",
+      "filter_reason",
+      "error_message",
+      "streams_extracted",
+      "stream_selected",
+      "title",
+      "category",
+      "viewer_count",
+      "streams_extracted_json"
+    ]
+  },
+  "streamers": {
+    "required_epoch_ms": [
+      "created_at",
+      "updated_at"
+    ],
+    "nullable_epoch_ms": [
+      "last_live_time",
+      "disabled_until",
+      "deleted_at"
+    ],
+    "non_timestamp_columns": [
+      "id",
+      "name",
+      "url",
+      "platform_config_id",
+      "template_config_id",
+      "state",
+      "priority",
+      "streamer_specific_config",
+      "consecutive_error_count",
+      "last_error",
+      "avatar"
+    ]
+  },
+  "template_config": {
+    "required_epoch_ms": [
+      "created_at",
+      "updated_at"
+    ],
+    "nullable_epoch_ms": [],
+    "non_timestamp_columns": [
+      "id",
+      "name",
+      "output_folder",
+      "output_filename_template",
+      "cookies",
+      "output_file_format",
+      "min_segment_size_bytes",
+      "max_download_duration_secs",
+      "max_part_size_bytes",
+      "record_danmu",
+      "platform_overrides",
+      "download_retry_policy",
+      "download_engine",
+      "engines_override",
+      "proxy_config",
+      "stream_selection_config",
+      "pipeline",
+      "session_complete_pipeline",
+      "paired_segment_pipeline",
+      "offline_check_count",
+      "offline_check_delay_ms",
+      "extractor",
+      "danmu_statistics"
+    ]
+  },
+  "tool_credentials": {
+    "required_epoch_ms": [
+      "created_at",
+      "updated_at"
+    ],
+    "nullable_epoch_ms": [],
+    "non_timestamp_columns": [
+      "tool",
+      "account_key",
+      "payload"
+    ]
+  },
+  "upload_records": {
+    "required_epoch_ms": [
+      "created_at",
+      "updated_at"
+    ],
+    "nullable_epoch_ms": [
+      "completed_at"
+    ],
+    "non_timestamp_columns": [
+      "id",
+      "job_id",
+      "streamer_id",
+      "session_id",
+      "uploader",
+      "local_path",
+      "remote_path",
+      "status",
+      "size_bytes",
+      "error"
+    ]
+  },
+  "users": {
+    "required_epoch_ms": [
+      "created_at",
+      "updated_at"
+    ],
+    "nullable_epoch_ms": [
+      "last_login_at"
+    ],
+    "non_timestamp_columns": [
+      "id",
+      "username",
+      "password_hash",
+      "email",
+      "roles",
+      "is_active",
+      "must_change_password"
+    ]
+  },
+  "web_push_subscription": {
+    "required_epoch_ms": [
+      "created_at",
+      "updated_at"
+    ],
+    "nullable_epoch_ms": [
+      "next_attempt_at",
+      "last_429_at"
+    ],
+    "non_timestamp_columns": [
+      "id",
+      "user_id",
+      "endpoint",
+      "p256dh",
+      "auth",
+      "min_priority"
+    ]
+  }
+}

--- a/rust-srec/tests/fixtures/timestamp_contract_rows.sql
+++ b/rust-srec/tests/fixtures/timestamp_contract_rows.sql
@@ -1,0 +1,30 @@
+-- One populated row per timestamp-bearing table; nullable clocks start populated.
+-- 1788784496123 deliberately has subsecond precision.
+INSERT INTO notification_channel (id, name, channel_type, settings) VALUES ('timestamp-contract', 'timestamp-contract', 'webhook', '{}');
+INSERT INTO platform_config (id, platform_name) VALUES ('timestamp-contract', 'timestamp-contract');
+INSERT INTO users (id, username, password_hash, last_login_at, created_at, updated_at) VALUES ('timestamp-contract', 'timestamp-contract', 'test-hash', 1788784496123, 1788784496123, 1788784496123);
+INSERT INTO streamers (id, name, url, platform_config_id, state, last_live_time, disabled_until, created_at, updated_at, deleted_at) VALUES ('timestamp-contract', 'timestamp-contract', 'https://example.test/timestamp-contract', 'timestamp-contract', 'NOT_LIVE', 1788784496123, 1788784496123, 1788784496123, 1788784496123, 1788784496123);
+INSERT INTO live_sessions (id, streamer_id, start_time, end_time) VALUES ('timestamp-contract', 'timestamp-contract', 1788784496123, 1788784496123);
+INSERT INTO job (id, job_type, status, config, state, created_at, updated_at, started_at, completed_at) VALUES ('timestamp-contract', 'remux', 'PROCESSING', '{}', '{}', 1788784496123, 1788784496123, 1788784496123, 1788784496123);
+INSERT INTO dag_execution (id, dag_definition, total_steps, created_at, updated_at, completed_at) VALUES ('timestamp-contract', '{}', 1, 1788784496123, 1788784496123, 1788784496123);
+INSERT INTO dag_step_execution (id, dag_id, step_id, created_at, updated_at) VALUES ('timestamp-contract', 'timestamp-contract', 'root', 1788784496123, 1788784496123);
+INSERT INTO api_keys (id, user_id, name, key_hash, key_prefix, access_level, expires_at, last_used_at, created_at, revoked_at) VALUES ('timestamp-contract', 'timestamp-contract', 'timestamp-contract', 'timestamp-key-hash', 'srec_test', 'full', 1788784496123, 1788784496123, 1788784496123, 1788784496123);
+INSERT INTO auth_sessions (id, user_id, created_at, expires_at, revoked_at) VALUES ('timestamp-contract', 'timestamp-contract', 1788784496123, 1788784496123, 1788784496123);
+INSERT INTO refresh_tokens (id, user_id, token_hash, session_id, expires_at, created_at, revoked_at) VALUES ('timestamp-contract', 'timestamp-contract', 'timestamp-token-hash', 'timestamp-contract', 1788784496123, 1788784496123, 1788784496123);
+INSERT INTO danmu_aggregator_state (session_id, version, state, updated_at) VALUES ('timestamp-contract', 1, X'7b7d', 1788784496123);
+INSERT INTO danmu_statistics (id, session_id, total_danmus, start_time, end_time) VALUES ('timestamp-contract', 'timestamp-contract', 1, 1788784496123, 1788784496123);
+INSERT INTO job_execution_logs (id, job_id, entry, created_at) VALUES ('timestamp-contract', 'timestamp-contract', '{}', 1788784496123);
+INSERT INTO job_execution_progress (job_id, kind, progress, updated_at) VALUES ('timestamp-contract', 'test', '{}', 1788784496123);
+INSERT INTO job_presets (id, name, processor, config, created_at, updated_at) VALUES ('timestamp-contract', 'timestamp-contract', 'remux', '{}', 1788784496123, 1788784496123);
+INSERT INTO media_outputs (id, session_id, file_path, file_type, size_bytes, created_at) VALUES ('timestamp-contract', 'timestamp-contract', 'test.flv', 'video', 1, 1788784496123);
+INSERT INTO monitor_event_outbox (id, streamer_id, event_type, payload, created_at, delivered_at) VALUES (9223372036854775800, 'timestamp-contract', 'test', '{}', 1788784496123, 1788784496123);
+INSERT INTO notification_dead_letter (id, channel_id, event_name, event_payload, error_message, first_attempt_at, last_attempt_at, created_at) VALUES ('timestamp-contract', 'timestamp-contract', 'test', '{}', 'test', 1788784496123, 1788784496123, 1788784496123);
+INSERT INTO notification_event_log (id, event_type, payload, created_at) VALUES ('timestamp-contract', 'test', '{}', 1788784496123);
+INSERT INTO pipeline_presets (id, name, created_at, updated_at) VALUES ('timestamp-contract', 'timestamp-contract', 1788784496123, 1788784496123);
+INSERT INTO session_events (id, session_id, streamer_id, kind, occurred_at) VALUES (9223372036854775800, 'timestamp-contract', 'timestamp-contract', 'session_started', 1788784496123);
+INSERT INTO session_segments (id, session_id, segment_index, file_path, duration_secs, size_bytes, created_at, completed_at, persisted_at) VALUES ('timestamp-contract', 'timestamp-contract', 0, 'test.flv', 1, 1, 1788784496123, 1788784496123, 1788784496123);
+INSERT INTO streamer_check_history (id, streamer_id, duration_ms, outcome, checked_at) VALUES (9223372036854775800, 'timestamp-contract', 1, 'offline', 1788784496123);
+INSERT INTO template_config (id, name, created_at, updated_at) VALUES ('timestamp-contract', 'timestamp-contract', 1788784496123, 1788784496123);
+INSERT INTO tool_credentials (tool, account_key, payload, created_at, updated_at) VALUES ('timestamp-contract', 'default', '{}', 1788784496123, 1788784496123);
+INSERT INTO upload_records (id, uploader, local_path, status, created_at, updated_at, completed_at) VALUES ('timestamp-contract', 'test', 'test.flv', 'COMPLETED', 1788784496123, 1788784496123, 1788784496123);
+INSERT INTO web_push_subscription (id, user_id, endpoint, p256dh, auth, created_at, updated_at, next_attempt_at, last_429_at) VALUES ('timestamp-contract', 'timestamp-contract', 'https://example.test/push', 'test', 'test', 1788784496123, 1788784496123, 1788784496123, 1788784496123);

--- a/rust-srec/tests/timestamp_contract_inventory.rs
+++ b/rust-srec/tests/timestamp_contract_inventory.rs
@@ -1,0 +1,138 @@
+//! Semantic inventory of canonical SQLite clocks. JSON payload timestamps and
+//! durations are not columns in this contract. New columns require classification,
+//! regardless of their spelling (including future `*_at_ms` columns).
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use serde::Deserialize;
+use sqlx::{Row, SqlitePool, sqlite::SqlitePoolOptions};
+
+#[derive(Deserialize)]
+struct TableContract {
+    required_epoch_ms: Vec<String>,
+    nullable_epoch_ms: Vec<String>,
+    non_timestamp_columns: Vec<String>,
+}
+
+#[tokio::test]
+async fn canonical_timestamp_inventory_storage_and_nullability() {
+    let pool = SqlitePoolOptions::new()
+        .max_connections(1)
+        .connect("sqlite::memory:")
+        .await
+        .unwrap();
+    sqlx::migrate!("./migrations").run(&pool).await.unwrap();
+    let inventory: BTreeMap<String, TableContract> =
+        serde_json::from_str(include_str!("fixtures/timestamp_contract_inventory.json")).unwrap();
+    let tables: BTreeSet<String> = sqlx::query_scalar(
+        "SELECT name FROM sqlite_schema WHERE type = 'table' AND name NOT LIKE 'sqlite_%' AND name != '_sqlx_migrations'",
+    ).fetch_all(&pool).await.unwrap().into_iter().collect();
+    assert_eq!(tables, inventory.keys().cloned().collect());
+
+    // These are storage fixtures, not proof of application write bindings. Public
+    // account/token writes are checked separately in account_token_contracts;
+    // preset_template_timestamps covers the DateTime/EpochMillis adapters.
+    sqlx::raw_sql(include_str!("fixtures/timestamp_contract_rows.sql"))
+        .execute(&pool)
+        .await
+        .unwrap();
+    for (table, contract) in &inventory {
+        let columns = sqlx::query("SELECT name, type, [notnull] FROM pragma_table_info(?)")
+            .bind(table)
+            .fetch_all(&pool)
+            .await
+            .unwrap();
+        let classified: Vec<&String> = contract
+            .required_epoch_ms
+            .iter()
+            .chain(&contract.nullable_epoch_ms)
+            .chain(&contract.non_timestamp_columns)
+            .collect();
+        let expected: BTreeSet<&str> = classified.iter().map(|column| column.as_str()).collect();
+        assert_eq!(
+            expected.len(),
+            classified.len(),
+            "duplicate classification: {table}"
+        );
+        let actual: BTreeSet<&str> = columns.iter().map(|column| column.get("name")).collect();
+        assert_eq!(actual, expected, "classify every column in {table}");
+        for (nullable, timestamps) in [
+            (false, &contract.required_epoch_ms),
+            (true, &contract.nullable_epoch_ms),
+        ] {
+            for column in timestamps {
+                let metadata = columns
+                    .iter()
+                    .find(|row| row.get::<&str, _>("name") == column)
+                    .unwrap();
+                assert_eq!(
+                    metadata.get::<&str, _>("type"),
+                    "INTEGER",
+                    "{table}.{column}"
+                );
+                assert_eq!(
+                    metadata.get::<i64, _>("notnull"),
+                    i64::from(!nullable),
+                    "{table}.{column}"
+                );
+                assert_populated_integer(&pool, table, column, nullable).await;
+                let reset = sqlx::query(sqlx::AssertSqlSafe(format!(
+                    "UPDATE {table} SET {column} = NULL"
+                )))
+                .execute(&pool)
+                .await;
+                if nullable {
+                    assert!(reset.unwrap().rows_affected() > 0, "{table}.{column}");
+                    let nonnull: i64 = sqlx::query_scalar(sqlx::AssertSqlSafe(format!(
+                        "SELECT COUNT(*) FROM {table} WHERE {column} IS NOT NULL"
+                    )))
+                    .fetch_one(&pool)
+                    .await
+                    .unwrap();
+                    assert_eq!(nonnull, 0, "nullable reset: {table}.{column}");
+                } else {
+                    let error = reset.unwrap_err();
+                    assert_eq!(
+                        error.as_database_error().unwrap().kind(),
+                        sqlx::error::ErrorKind::NotNullViolation,
+                        "{table}.{column}: {error}"
+                    );
+                }
+            }
+        }
+    }
+    let violations = sqlx::query("PRAGMA foreign_key_check")
+        .fetch_all(&pool)
+        .await
+        .unwrap();
+    assert!(violations.is_empty());
+}
+
+async fn assert_populated_integer(pool: &SqlitePool, table: &str, column: &str, nullable: bool) {
+    // Inspect storage before null-reset probes; never rewrite a clock to make its
+    // type pass. Check all seeded/default rows plus the exact millisecond fixture.
+    let values: Vec<(String, Option<i64>)> = sqlx::query_as(sqlx::AssertSqlSafe(format!(
+        "SELECT typeof({column}), {column} FROM {table}"
+    )))
+    .fetch_all(pool)
+    .await
+    .unwrap();
+    assert!(!values.is_empty(), "no fixture for {table}.{column}");
+    assert!(
+        values
+            .iter()
+            .any(|(_, value)| *value == Some(1_788_784_496_123)),
+        "no populated clock fixture: {table}.{column}"
+    );
+    for (storage, value) in values {
+        assert_eq!(
+            storage,
+            if nullable && value.is_none() {
+                "null"
+            } else {
+                "integer"
+            },
+            "{table}.{column}: {value:?}"
+        );
+    }
+}


### PR DESCRIPTION
## What changed?

User and token repositories expose overlapping list, count and lookup queries whose projections and filtering need to stay consistent. Add migrated SQLite integration tests for complete user projections and pagination, refresh-token active-query parity across owner/expiry/revocation states, and API-key list/hash/owner lookup parity.

Add an explicit semantic inventory of all 33 application tables (61 timestamp columns and 271 other columns), with populated fixtures checking exact milliseconds, integer storage and nullability. Separate assertions inspect all 13 repository-written account timestamps before test SQL can alter them; existing preset/template adapter and rotation regressions remain in place. No production schema or shipped migration changes.

## Scope

- Backend SQL contract tests and fixtures.
- Breaking change: no.

## How to test

Integrated non-desktop workspace run: 3,175 passed, one import projection fixture failed, 37 skipped. Corrected the fixture's required streamer state and pipeline-type nullability; its focused rerun passed. All scheduler, credential, account/timestamp and shared-write contract tests passed in the full run. Runs: `43c20001-edba-468d-9f50-4980623dfab4` and `0d93e0f5-dff2-46f2-bdf5-97ba048a477e`.

Final workspace formatting and Clippy passed. Doctests: 23 passed, 12 ignored. Integrated EN/ZH documentation build passed. Every applicable final-head CI check passed; this PR is merged.

## Checklist

- Formatting, Clippy and relevant runtime tests: accounted for above.
- Additional checks: doctests and docs build passed; all applicable final-head CI checks passed.
- Related docs: EN/ZH guidance updated where behavior changes; local wave plans updated.
- Final diff reviewed: only this PR's owned paths on current main.
- Schema migrations and release artifacts: N/A.

## Related issues

Wave 22: account/token and timestamp portions of Database finding 13.
