### PR TITLE
fix(storage): avoid false startup warnings for missing streamer folders

### DIFF
--- a/rust-srec/src/services/container/config_refresh_tests.rs
+++ b/rust-srec/src/services/container/config_refresh_tests.rs
@@ -316,6 +316,9 @@ async fn startup_probe_and_health_registration_reuse_the_collected_root_input_wi
         .await
         .unwrap();
     std::fs::remove_dir(&original_root).unwrap();
+    // Missing recording folders are valid when an ancestor is writable. A file
+    // in place of the collected directory guarantees a failure on every platform.
+    std::fs::write(&original_root, b"not a directory").unwrap();
     queries.store(0, Ordering::SeqCst);
     container.register_health_checks(&roots).await;
     container.run_output_root_startup_probe(&roots).await;
@@ -326,10 +329,11 @@ async fn startup_probe_and_health_registration_reuse_the_collected_root_input_wi
     );
     let state = container.output_root_gate.snapshot();
     assert!(
-        state
-            .iter()
-            .any(|root| root.root == container.output_root_gate.resolve_path(&original_root)),
-        "the original missing root must be probed instead of the newly configured healthy root"
+        state.iter().any(|root| {
+            root.root == container.output_root_gate.resolve_path(&original_root)
+                && root.state == crate::downloader::RootHealthState::Degraded
+        }),
+        "the original invalid path must be probed instead of the newly configured healthy directory"
     );
     container.cancellation_token.cancel();
 }

--- a/rust-srec/src/services/container/health.rs
+++ b/rust-srec/src/services/container/health.rs
@@ -402,23 +402,47 @@ impl HealthProbe for StaticHealthyProbe {
 
 /// Synchronous writability probe used by `run_output_root_startup_probe`.
 ///
-/// Creates a temp file inside `root` with restrictive permissions, writes
-/// zero bytes, and drops it (RAII unlink via the `tempfile` crate). Returns
-/// the underlying `io::Error` on any failure so the gate can classify via
-/// `IoErrorKindSer::from_io_kind`.
+/// Probes the destination if it exists, otherwise its nearest existing ancestor
+/// within the same gate root. Recording startup creates missing subdirectories;
+/// an offline streamer's absent directory does not make its storage unwritable.
+/// Missing gate roots and dangling symlinks still fail instead of falling back
+/// to a different root. No recording directories are created by this probe.
+///
+/// Creates a temporary file with restrictive permissions and removes it on drop.
+/// Returns the underlying `io::Error` so the gate can classify the failure.
 ///
 /// Kept separate from `OutputRootGate::record_failure` so the gate itself
 /// stays ignorant of how failures are discovered — it just accepts an
 /// `io::Error` from any caller.
-fn probe_root_writable(root: &std::path::Path) -> std::io::Result<()> {
-    // Ensure the root itself is a directory. `std::fs::metadata` follows
-    // symlinks, which is what we want — a dangling symlink would trip the
-    // gate with ENOENT, correctly.
-    let meta = std::fs::metadata(root)?;
+fn probe_root_writable(output_dir: &std::path::Path, gate: &OutputRootGate) -> std::io::Result<()> {
+    let gate_root = gate.resolve_path(output_dir);
+    let mut probe_dir = output_dir;
+    let meta = loop {
+        match std::fs::metadata(probe_dir) {
+            Ok(meta) => break meta,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                // A dangling symlink also returns NotFound from metadata, but is
+                // a broken destination, not a directory recording startup can create.
+                match std::fs::symlink_metadata(probe_dir) {
+                    Err(missing) if missing.kind() == std::io::ErrorKind::NotFound => {}
+                    Ok(_) => return Err(error),
+                    Err(error) => return Err(error),
+                }
+                let Some(parent) = probe_dir
+                    .parent()
+                    .filter(|parent| gate.resolve_path(parent) == gate_root)
+                else {
+                    return Err(error);
+                };
+                probe_dir = parent;
+            }
+            Err(error) => return Err(error),
+        }
+    };
     if !meta.is_dir() {
         return Err(std::io::Error::other(format!(
-            "root path {} is not a directory",
-            root.display()
+            "output path {} is not a directory",
+            probe_dir.display()
         )));
     }
 
@@ -427,7 +451,7 @@ fn probe_root_writable(root: &std::path::Path) -> std::io::Result<()> {
     // and no leftover probe file even if the process is killed.
     let mut file = tempfile::Builder::new()
         .prefix(".rust-srec-probe-")
-        .tempfile_in(root)?;
+        .tempfile_in(probe_dir)?;
     std::io::Write::write_all(&mut file, b"")?;
     // `file` drops here and the tempfile crate unlinks it.
     Ok(())
@@ -546,7 +570,7 @@ fn bounded_output_probe_paths(
 impl ServiceContainer {
     /// Concrete directories safe to probe, each resolving to the runtime gate key.
     /// Sorted and capped once for startup. Disk registrations and the write probe
-    /// share this exact input, without testing write access to ancestor keys.
+    /// share this exact input. Missing subdirectories fall back within their key.
     pub(super) async fn collect_output_roots(&self) -> Vec<std::path::PathBuf> {
         let roots = discover_output_probe_paths(
             &self.config_service,
@@ -588,7 +612,8 @@ impl ServiceContainer {
                         Duration::from_secs(5),
                         tokio::task::spawn_blocking({
                             let root = root.clone();
-                            move || probe_root_writable(&root)
+                            let gate = gate.clone();
+                            move || probe_root_writable(&root, &gate)
                         }),
                     )
                     .await;

--- a/rust-srec/src/services/container/health/output_root_tests.rs
+++ b/rust-srec/src/services/container/health/output_root_tests.rs
@@ -122,7 +122,136 @@ fn writable_child_is_probed_instead_of_ancestor_gate_key() {
         .unwrap();
     assert_eq!(probe, child);
     assert_ne!(gate.resolve_path(&probe), probe);
-    assert!(probe_root_writable(&probe).is_ok());
+    assert!(probe_root_writable(&probe, &gate).is_ok());
+}
+
+#[tokio::test]
+async fn offline_streamer_missing_directory_does_not_fail_startup_probe() {
+    let dir = tempfile::tempdir().unwrap();
+    let output = dir.path().join("output");
+    std::fs::create_dir(&output).unwrap();
+    let pool = crate::database::init_pool_with_size("sqlite::memory:", 1)
+        .await
+        .unwrap();
+    crate::database::run_migrations(&pool).await.unwrap();
+    let configs = Arc::new(SqlxConfigRepository::new(pool.clone(), pool.clone()));
+    let streamers = Arc::new(SqlxStreamerRepository::new(pool.clone(), pool.clone()));
+    let service = ConfigService::new(configs.clone(), streamers.clone());
+    let manager = StreamerManager::new(streamers, ConfigEventBroadcaster::new());
+    let platform = configs.get_platform_config_by_name("huya").await.unwrap();
+    let streamer = StreamerDbModel::new("0601", "https://www.huya.com/0601", platform.id);
+    let metadata = StreamerMetadata::from_db_model(&streamer);
+    assert_eq!(metadata.state, crate::domain::StreamerState::NotLive);
+    manager.create_streamer(metadata).await.unwrap();
+    let mut global = service.get_global_config().await.unwrap();
+    global.output_folder = output
+        .join("{streamer}/%Y/%m/%d")
+        .to_string_lossy()
+        .into_owned();
+    service.update_global_config(&global).await.unwrap();
+
+    let gate = gate(vec![]);
+    let paths = discover_output_probe_paths(&service, &manager, &gate).await;
+    let probe = output.join("0601");
+    assert_eq!(paths, HashSet::from([probe.clone()]));
+    assert!(probe_root_writable(&probe, &gate).is_ok());
+    assert_eq!(std::fs::read_dir(&output).unwrap().count(), 0);
+
+    let recording_dir = probe.join("2026/09/10");
+    crate::downloader::engine::utils::ensure_output_dir(&recording_dir)
+        .await
+        .unwrap();
+    assert!(recording_dir.is_dir());
+}
+
+#[test]
+fn missing_nested_directories_probe_existing_ancestor_without_creating_folders() {
+    let dir = tempfile::tempdir().unwrap();
+    let gate = gate(vec![dir.path().to_path_buf()]);
+    let output = dir.path().join("0601/2026/09/10");
+    assert!(probe_root_writable(&output, &gate).is_ok());
+    assert_eq!(std::fs::read_dir(dir.path()).unwrap().count(), 0);
+}
+
+#[test]
+fn missing_explicit_root_does_not_fall_back_to_writable_outer_root() {
+    let dir = tempfile::tempdir().unwrap();
+    let missing_root = dir.path().join("missing-mount");
+    let gate = gate(vec![dir.path().to_path_buf(), missing_root.clone()]);
+    for output in [&missing_root, &missing_root.join("0601/2026")] {
+        assert_eq!(
+            probe_root_writable(output, &gate).unwrap_err().kind(),
+            std::io::ErrorKind::NotFound
+        );
+    }
+    assert_eq!(std::fs::read_dir(dir.path()).unwrap().count(), 0);
+}
+
+#[test]
+fn file_in_output_path_does_not_fall_back_to_writable_parent() {
+    let dir = tempfile::tempdir().unwrap();
+    let output = dir.path().join("0601");
+    std::fs::write(&output, b"existing file").unwrap();
+    let gate = gate(vec![dir.path().to_path_buf()]);
+    assert!(probe_root_writable(&output, &gate).is_err());
+    assert!(probe_root_writable(&output.join("2026"), &gate).is_err());
+    assert_eq!(std::fs::read(&output).unwrap(), b"existing file");
+}
+
+#[cfg(unix)]
+#[test]
+fn dangling_output_symlinks_do_not_fall_back_to_writable_parent() {
+    let dir = tempfile::tempdir().unwrap();
+    let output = dir.path().join("0601");
+    std::os::unix::fs::symlink(dir.path().join("missing-target"), &output).unwrap();
+    let gate = gate(vec![dir.path().to_path_buf()]);
+    for path in [&output, &output.join("2026/09/10")] {
+        assert_eq!(
+            probe_root_writable(path, &gate).unwrap_err().kind(),
+            std::io::ErrorKind::NotFound
+        );
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn missing_subdirectories_under_valid_symlink_can_be_probed() {
+    let dir = tempfile::tempdir().unwrap();
+    let target = tempfile::tempdir().unwrap();
+    let output = dir.path().join("0601");
+    std::os::unix::fs::symlink(target.path(), &output).unwrap();
+    let gate = gate(vec![dir.path().to_path_buf()]);
+    assert!(probe_root_writable(&output.join("2026/09/10"), &gate).is_ok());
+    assert_eq!(std::fs::read_dir(target.path()).unwrap().count(), 0);
+}
+
+#[cfg(unix)]
+#[test]
+fn unwritable_destination_does_not_fall_back_to_writable_parent() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let dir = tempfile::tempdir().unwrap();
+    let output = dir.path().join("0601");
+    std::fs::create_dir(&output).unwrap();
+    let previous = std::fs::metadata(&output).unwrap().permissions();
+    std::fs::set_permissions(&output, std::fs::Permissions::from_mode(0o555)).unwrap();
+    // Privileged users can bypass mode bits, so first check that this environment
+    // can exercise permission failures. Restore permissions before any assertion.
+    let permissions_enforced = tempfile::tempfile_in(&output).is_err();
+    let gate = gate(vec![dir.path().to_path_buf()]);
+    let existing_result = probe_root_writable(&output, &gate);
+    let missing_result = probe_root_writable(&output.join("2026/09"), &gate);
+    std::fs::set_permissions(&output, previous).unwrap();
+    if permissions_enforced {
+        assert_eq!(
+            existing_result.unwrap_err().kind(),
+            std::io::ErrorKind::PermissionDenied
+        );
+        assert_eq!(
+            missing_result.unwrap_err().kind(),
+            std::io::ErrorKind::PermissionDenied
+        );
+    }
 }
 
 #[cfg(unix)]
@@ -134,10 +263,11 @@ fn read_only_parent_does_not_prevent_probing_writable_child() {
     std::fs::create_dir_all(&child).unwrap();
     let previous = std::fs::metadata(dir.path()).unwrap().permissions();
     std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o555)).unwrap();
-    let probe = gate(vec![])
+    let gate = gate(vec![]);
+    let probe = gate
         .probe_path_for_template(child.to_str().unwrap())
         .unwrap();
-    let result = probe_root_writable(&probe);
+    let result = probe_root_writable(&probe, &gate);
     std::fs::set_permissions(dir.path(), previous).unwrap();
     assert!(
         result.is_ok(),


### PR DESCRIPTION
## What changed?

With an output template such as `/app/output/{streamer}/%Y/%m/%d`, startup probes a concrete streamer directory even when that streamer is offline and has never recorded. An absent `/app/output/0601` therefore marks `/app/output` unwritable despite healthy storage.

The startup write probe now walks missing destination directories back to the nearest existing ancestor within the same output-root gate key. It tests that directory without creating recording folders. Existing destinations are tested directly; missing gate roots, dangling symlinks, non-directory paths, and permission failures still fail. Recording preparation creates the streamer/date folders when needed.

Regression coverage includes configuration discovery for an offline `0601` streamer, missing nested folders, explicit root boundaries, non-directory paths, and Unix symlink and permission behavior. The startup input-reuse test uses a file in place of the collected directory to verify a genuine failure while preserving its assertion that startup does not query configuration again.

## Scope

- Affected components: backend startup storage health probe and tests.
- Breaking change: no.

## How to test

- `cargo fmt --all -- --check`: passed.
- Linux (WSL Ubuntu 24.04, unprivileged user): `cargo nextest run --locked -p rust-srec --features tls-native-fallback --no-fail-fast`: the full backend suite passed, 2,327 tests across 15 binaries with 4 intentionally skipped.
- Windows: `cargo clippy --locked -p rust-srec --all-targets -- -D warnings`: passed.
- Windows: `cargo nextest run --locked -p rust-srec --lib -E 'test(output_root) | test(config_refresh_tests)'`: 42 passed, including the startup input-reuse test.

Checks use `CARGO_PROFILE_DEV_DEBUG=0` and `CARGO_PROFILE_TEST_DEBUG=0`, with separate Windows and Linux target directories and bounded build parallelism. The full CI matrix remains the integration gate.

## Checklist

- Formatting for affected files: passed.
- Lint and relevant tests for affected behavior: passed; the full Linux backend suite and 42 related Windows tests.
- Additional checks for affected interfaces, builds, migrations, or releases: platform checks listed above; interface, migration, and release checks N/A.
- Related docs, config examples, and generated outputs: probe documentation updated; other outputs N/A.
- Final diff reviewed; unrelated changes excluded and shared logs/screenshots redacted: done.

## Related issues

No linked issue.
