### PR TITLE
fix(pipeline): wire throttling without overwriting live limits

### DIFF
--- a/rust-srec/src/downloader/manager.rs
+++ b/rust-srec/src/downloader/manager.rs
@@ -185,6 +185,8 @@ impl AttemptPhase {
 pub struct DownloadManager {
     /// Configuration.
     config: RwLock<DownloadManagerConfig>,
+    /// Serializes configured-limit updates and temporary throttle changes through queue publication.
+    throttle_factor: Mutex<Option<f32>>,
     /// Priority-aware queue managing concurrency across both
     /// normal-priority and high-priority extra slots.
     queue: Arc<DownloadQueue>,
@@ -275,7 +277,8 @@ impl DownloadManager {
     }
 
     /// Create a new Download Manager with custom configuration.
-    pub fn with_config(config: DownloadManagerConfig) -> Self {
+    pub fn with_config(mut config: DownloadManagerConfig) -> Self {
+        config.max_concurrent_downloads = config.max_concurrent_downloads.max(1);
         // Use broadcast channel to support multiple subscribers
         let (event_tx, _) = broadcast::channel(256);
 
@@ -293,6 +296,7 @@ impl DownloadManager {
 
         let manager = Self {
             config: RwLock::new(config),
+            throttle_factor: Mutex::new(None),
             queue,
             active_downloads: Arc::new(DashMap::new()),
             attempts: AttemptSupervisor::new(),
@@ -917,24 +921,53 @@ impl DownloadManager {
             .saturating_add(config.high_priority_extra_slots)
     }
 
-    /// Adjust the normal-priority concurrency limit at runtime.
+    /// Adjust the configured normal-priority concurrency limit at runtime.
+    /// A temporary throttle is reapplied to this new base before publishing queue capacity.
     ///
     /// Increasing capacity wakes any waiters that fit. Decreasing keeps
     /// in-flight downloads running until they release naturally; new
     /// acquires beyond the new limit queue.
     pub fn set_max_concurrent_downloads(&self, limit: usize) -> usize {
         let limit = limit.max(1);
+        let factor = self.throttle_factor.lock();
+        let mut config = self.config.write();
+        config.max_concurrent_downloads = limit;
+        self.apply_download_capacity(&config, *factor);
+        limit
+    }
 
-        {
-            let mut config = self.config.write();
-            config.max_concurrent_downloads = limit;
-        }
+    /// Set/release the pipeline's temporary reduction without changing configured capacity.
+    /// Returns the configured and effective normal limits from the same mutation.
+    pub(crate) fn set_download_throttle(&self, factor: Option<f32>) -> (usize, usize) {
+        let mut throttle = self.throttle_factor.lock();
+        *throttle = factor.map(|factor| {
+            if factor.is_finite() {
+                factor.clamp(0.0, 1.0)
+            } else {
+                1.0
+            }
+        });
+        let config = self.config.read();
+        let applied = self.apply_download_capacity(&config, *throttle);
+        (config.max_concurrent_downloads, applied)
+    }
 
+    /// Caller holds throttle_factor and config, in that order, until publication completes.
+    fn apply_download_capacity(
+        &self,
+        config: &DownloadManagerConfig,
+        factor: Option<f32>,
+    ) -> usize {
+        let configured = config.max_concurrent_downloads;
+        let effective = factor.map_or(configured, |factor| {
+            ((configured as f64 * f64::from(factor)) as usize).clamp(1, configured)
+        });
         if let Some(feedback) = self.events.feedback.get() {
-            feedback
-                .ensure_attempt_capacity(limit.saturating_add(self.high_priority_extra_slots()));
+            feedback.ensure_attempt_capacity(
+                configured.saturating_add(config.high_priority_extra_slots),
+            );
         }
-        self.queue.set_normal_capacity(limit)
+        self.queue.set_normal_capacity(effective)
     }
 
     /// Current queue-wait freshness threshold in milliseconds.

--- a/rust-srec/src/downloader/manager/tests.rs
+++ b/rust-srec/src/downloader/manager/tests.rs
@@ -1196,6 +1196,91 @@ async fn test_runtime_reconfigure_max_concurrent_downloads() {
     assert_eq!(q.in_flight(), 2);
 }
 
+#[test]
+fn throttle_capacity_is_bounded_without_mutating_configured_limits() {
+    for (configured, factor, effective) in [
+        (10, 0.5, 5),
+        (6, 0.5, 3),
+        (1, 0.5, 1),
+        (0, 0.5, 1),
+        (6, 0.0, 1),
+        (6, -1.0, 1),
+        (6, 2.0, 6),
+        (6, f32::NAN, 6),
+    ] {
+        let manager = DownloadManager::with_config(DownloadManagerConfig {
+            max_concurrent_downloads: configured,
+            high_priority_extra_slots: 2,
+            ..Default::default()
+        });
+        assert_eq!(
+            manager.set_download_throttle(Some(factor)),
+            (configured.max(1), effective)
+        );
+        assert_eq!(manager.max_concurrent_downloads(), configured.max(1));
+        assert_eq!(manager.queue.normal_capacity(), effective);
+        assert_eq!(manager.queue.high_extra_capacity(), 2);
+        assert_eq!(
+            manager.set_download_throttle(None),
+            (configured.max(1), configured.max(1))
+        );
+        assert_eq!(manager.queue.normal_capacity(), configured.max(1));
+    }
+}
+
+#[tokio::test]
+async fn throttle_monitor_teardown_restores_latest_configured_capacity() {
+    use crate::pipeline::{Job, JobQueue, ThrottleConfig, ThrottleController};
+
+    for abort in [false, true] {
+        let manager = Arc::new(DownloadManager::with_config(DownloadManagerConfig {
+            max_concurrent_downloads: 10,
+            high_priority_extra_slots: 1,
+            ..Default::default()
+        }));
+        let controller = Arc::new(ThrottleController::new(ThrottleConfig {
+            enabled: true,
+            critical_threshold: 1,
+            warning_threshold: 1,
+            check_interval_ms: 10,
+            ..Default::default()
+        }));
+        let queue = Arc::new(JobQueue::new());
+        for _ in 0..2 {
+            queue
+                .enqueue(Job::new("held", vec![], vec![], "", ""))
+                .await
+                .unwrap();
+        }
+        let cancel = CancellationToken::new();
+        let mut events = controller.subscribe();
+        let task = controller
+            .clone()
+            .start_monitoring(queue, manager.clone(), cancel.clone());
+        tokio::time::timeout(Duration::from_secs(1), events.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(manager.queue.normal_capacity(), 5);
+        assert_eq!(manager.set_max_concurrent_downloads(8), 8);
+        assert_eq!(manager.queue.normal_capacity(), 4);
+        if abort {
+            task.abort();
+            assert!(task.await.unwrap_err().is_cancelled());
+        } else {
+            cancel.cancel();
+            tokio::time::timeout(Duration::from_secs(1), task)
+                .await
+                .unwrap()
+                .unwrap();
+        }
+        assert!(!controller.is_throttled());
+        assert_eq!(manager.max_concurrent_downloads(), 8);
+        assert_eq!(manager.queue.normal_capacity(), 8);
+        assert_eq!(manager.queue.high_extra_capacity(), 1);
+    }
+}
+
 #[tokio::test]
 async fn queued_slot_abandoned_after_acquire_emits_dequeued() {
     let config = DownloadManagerConfig {

--- a/rust-srec/src/pipeline/manager.rs
+++ b/rust-srec/src/pipeline/manager.rs
@@ -296,6 +296,7 @@ pub(crate) struct PipelineRuntimeDependencies<
     pub(crate) dag_repository: Arc<dyn DagRepository>,
     pub(crate) upload_record_repository: Arc<dyn UploadRecordRepository>,
     pub(crate) upload_broadcaster: UploadStatusBroadcaster,
+    pub(crate) download_limit_adjuster: Arc<dyn DownloadLimitAdjuster>,
 }
 
 impl<CR, SR> PipelineManager<CR, SR>
@@ -444,6 +445,7 @@ where
             dag_repository,
             upload_record_repository,
             upload_broadcaster,
+            download_limit_adjuster,
         } = dependencies;
 
         Self::with_repository(config, job_repository)
@@ -455,6 +457,7 @@ where
             .with_dag_repository(dag_repository)
             .with_upload_record_repository(upload_record_repository)
             .with_upload_broadcaster(upload_broadcaster)
+            .with_download_adjuster(download_limit_adjuster)
     }
 
     /// Set the session repository for persistence.

--- a/rust-srec/src/pipeline/throttle.rs
+++ b/rust-srec/src/pipeline/throttle.rs
@@ -28,7 +28,7 @@ pub struct ThrottleConfig {
     /// When queue depth falls below this value, throttling is deactivated.
     pub warning_threshold: usize,
     /// Factor to reduce max_concurrent_downloads by when throttling (0.0-1.0).
-    /// A value of 0.5 means reduce to 50% of original.
+    /// A value of 0.5 uses 50% of the latest configured normal-slot limit.
     #[serde(default = "default_reduction_factor")]
     pub reduction_factor: f32,
     /// Interval in milliseconds between queue depth checks.
@@ -56,6 +56,30 @@ impl Default for ThrottleConfig {
     }
 }
 
+impl ThrottleConfig {
+    pub(crate) fn validate(&self) -> crate::Result<()> {
+        if !self.enabled {
+            return Ok(());
+        }
+        if self.warning_threshold == 0 || self.warning_threshold > self.critical_threshold {
+            return Err(crate::Error::config(
+                "Throttle warning threshold must be positive and no greater than the critical threshold",
+            ));
+        }
+        if !self.reduction_factor.is_finite() || !(0.0..=1.0).contains(&self.reduction_factor) {
+            return Err(crate::Error::config(
+                "Throttle reduction factor must be finite and between 0 and 1",
+            ));
+        }
+        if self.check_interval_ms == 0 {
+            return Err(crate::Error::config(
+                "Throttle check interval must be positive",
+            ));
+        }
+        Ok(())
+    }
+}
+
 /// Events emitted by the throttle controller.
 #[derive(Debug, Clone)]
 pub enum ThrottleEvent {
@@ -77,14 +101,35 @@ pub enum ThrottleEvent {
     },
 }
 
-/// Callback trait for adjusting download limits.
-/// Implementations should adjust the actual download manager's concurrent limit.
+/// Applies a temporary reduction while preserving the configured download limit.
 pub trait DownloadLimitAdjuster: Send + Sync {
-    /// Set the maximum concurrent downloads limit.
-    fn set_max_concurrent_downloads(&self, limit: usize);
+    /// Apply a factor, or release the reduction with None. Return the configured
+    /// and effective normal-slot limits from the same serialized update.
+    fn set_throttle_factor(&self, factor: Option<f32>) -> (usize, usize);
+}
 
-    /// Get the current maximum concurrent downloads limit.
-    fn get_max_concurrent_downloads(&self) -> usize;
+impl DownloadLimitAdjuster for crate::downloader::DownloadManager {
+    fn set_throttle_factor(&self, factor: Option<f32>) -> (usize, usize) {
+        self.set_download_throttle(factor)
+    }
+}
+
+/// Forced task aborts must release the reduction just like cooperative shutdown.
+struct ThrottleReset<'a> {
+    controller: &'a ThrottleController,
+    adjuster: &'a dyn DownloadLimitAdjuster,
+}
+
+impl Drop for ThrottleReset<'_> {
+    fn drop(&mut self) {
+        if self.controller.is_throttled.swap(false, Ordering::SeqCst) {
+            let (_, restored) = self.adjuster.set_throttle_factor(None);
+            info!(
+                restored_limit = restored,
+                "Released download throttle on monitor shutdown"
+            );
+        }
+    }
 }
 
 /// The Throttle Controller service.
@@ -138,16 +183,9 @@ impl ThrottleController {
         &self.config
     }
 
-    /// Get the original max downloads value (before throttling).
+    /// Configured normal-slot limit at the most recent activation (a historical snapshot).
     pub fn original_max_downloads(&self) -> usize {
         self.original_max_downloads.load(Ordering::SeqCst)
-    }
-
-    /// Calculate the throttled limit based on the original limit.
-    pub fn calculate_throttled_limit(&self, original: usize) -> usize {
-        let reduced = (original as f32 * self.config.reduction_factor) as usize;
-        // Ensure at least 1 concurrent download
-        reduced.max(1)
     }
 
     /// Check queue depth and update throttle state.
@@ -166,12 +204,11 @@ impl ThrottleController {
 
         if !currently_throttled && queue_depth > self.config.critical_threshold {
             // Activate throttling
-            let original = adjuster.get_max_concurrent_downloads();
+            let (original, new_limit) =
+                adjuster.set_throttle_factor(Some(self.config.reduction_factor));
             self.original_max_downloads
                 .store(original, Ordering::SeqCst);
 
-            let new_limit = self.calculate_throttled_limit(original);
-            adjuster.set_max_concurrent_downloads(new_limit);
             self.is_throttled.store(true, Ordering::SeqCst);
 
             // Log the transition
@@ -189,19 +226,18 @@ impl ThrottleController {
             return Some(event);
         } else if currently_throttled && queue_depth < self.config.warning_threshold {
             // Deactivate throttling
-            let original = self.original_max_downloads.load(Ordering::SeqCst);
-            adjuster.set_max_concurrent_downloads(original);
+            let (_, restored) = adjuster.set_throttle_factor(None);
             self.is_throttled.store(false, Ordering::SeqCst);
 
             // Log the transition
             info!(
                 "Throttling deactivated: queue_depth={}, restoring max_concurrent_downloads to {}",
-                queue_depth, original
+                queue_depth, restored
             );
 
             let event = ThrottleEvent::ThrottleDeactivated {
                 queue_depth,
-                restored_limit: original,
+                restored_limit: restored,
             };
             let _ = self.event_tx.send(event.clone());
             return Some(event);
@@ -233,7 +269,11 @@ impl ThrottleController {
             return;
         }
 
-        let check_interval = Duration::from_millis(self.config.check_interval_ms);
+        let _reset = ThrottleReset {
+            controller: &self,
+            adjuster: adjuster.as_ref(),
+        };
+        let check_interval = Duration::from_millis(self.config.check_interval_ms.max(1));
 
         info!("Throttle controller monitoring started");
 
@@ -242,12 +282,6 @@ impl ThrottleController {
                 _ = cancellation_token.cancelled() => {
                     debug!("Throttle controller monitoring shutting down");
 
-                    // Restore original limit if we're currently throttled
-                    if self.is_throttled.load(Ordering::SeqCst) {
-                        let original = self.original_max_downloads.load(Ordering::SeqCst);
-                        adjuster.set_max_concurrent_downloads(original);
-                        info!("Restored max_concurrent_downloads to {} on shutdown", original);
-                    }
                     break;
                 }
                 _ = tokio::time::sleep(check_interval) => {
@@ -274,24 +308,30 @@ mod tests {
 
     /// Mock adjuster for testing.
     struct MockAdjuster {
+        configured: usize,
         limit: AtomicUsize,
     }
 
     impl MockAdjuster {
         fn new(initial: usize) -> Self {
             Self {
+                configured: initial,
                 limit: AtomicUsize::new(initial),
             }
-        }
-    }
-
-    impl DownloadLimitAdjuster for MockAdjuster {
-        fn set_max_concurrent_downloads(&self, limit: usize) {
-            self.limit.store(limit, Ordering::SeqCst);
         }
 
         fn get_max_concurrent_downloads(&self) -> usize {
             self.limit.load(Ordering::SeqCst)
+        }
+    }
+
+    impl DownloadLimitAdjuster for MockAdjuster {
+        fn set_throttle_factor(&self, factor: Option<f32>) -> (usize, usize) {
+            let limit = factor.map_or(self.configured, |factor| {
+                ((self.configured as f32 * factor) as usize).max(1)
+            });
+            self.limit.store(limit, Ordering::SeqCst);
+            (self.configured, limit)
         }
     }
 
@@ -303,18 +343,48 @@ mod tests {
     }
 
     #[test]
-    fn test_calculate_throttled_limit() {
-        let config = ThrottleConfig {
+    fn enabled_throttle_config_rejects_unrecoverable_or_expanding_limits() {
+        let valid = ThrottleConfig {
             enabled: true,
-            reduction_factor: 0.5,
             ..Default::default()
         };
-        let controller = ThrottleController::new(config);
-
-        assert_eq!(controller.calculate_throttled_limit(10), 5);
-        assert_eq!(controller.calculate_throttled_limit(6), 3);
-        assert_eq!(controller.calculate_throttled_limit(1), 1); // Minimum of 1
-        assert_eq!(controller.calculate_throttled_limit(0), 1); // Minimum of 1
+        assert!(valid.validate().is_ok());
+        for invalid in [
+            ThrottleConfig {
+                warning_threshold: 0,
+                ..valid.clone()
+            },
+            ThrottleConfig {
+                warning_threshold: valid.critical_threshold + 1,
+                ..valid.clone()
+            },
+            ThrottleConfig {
+                reduction_factor: -0.1,
+                ..valid.clone()
+            },
+            ThrottleConfig {
+                reduction_factor: 1.1,
+                ..valid.clone()
+            },
+            ThrottleConfig {
+                reduction_factor: f32::NAN,
+                ..valid.clone()
+            },
+            ThrottleConfig {
+                check_interval_ms: 0,
+                ..valid.clone()
+            },
+        ] {
+            assert!(invalid.validate().is_err());
+            assert!(
+                ThrottleConfig {
+                    enabled: false,
+                    ..invalid
+                }
+                .validate()
+                .is_ok()
+            );
+        }
     }
 
     #[test]
@@ -545,5 +615,42 @@ mod tests {
             }
             _ => panic!("Expected ThrottleActivated event"),
         }
+    }
+
+    #[tokio::test]
+    async fn aborted_throttle_monitor_releases_its_reduction() {
+        let controller = Arc::new(ThrottleController::new(ThrottleConfig {
+            enabled: true,
+            critical_threshold: 1,
+            warning_threshold: 1,
+            check_interval_ms: 10,
+            ..Default::default()
+        }));
+        let queue = Arc::new(JobQueue::new());
+        for _ in 0..2 {
+            queue
+                .enqueue(crate::pipeline::Job::new("held", vec![], vec![], "", ""))
+                .await
+                .unwrap();
+        }
+        let adjuster = Arc::new(MockAdjuster::new(10));
+        let mut events = controller.subscribe();
+        let monitor =
+            controller
+                .clone()
+                .start_monitoring(queue, adjuster.clone(), CancellationToken::new());
+        tokio::time::timeout(Duration::from_secs(1), events.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        monitor.abort();
+        assert!(monitor.await.unwrap_err().is_cancelled());
+        assert_eq!(
+            (
+                controller.is_throttled(),
+                adjuster.get_max_concurrent_downloads()
+            ),
+            (false, 10)
+        );
     }
 }

--- a/rust-srec/src/services/container.rs
+++ b/rust-srec/src/services/container.rs
@@ -60,6 +60,8 @@ mod shutdown_tests;
 mod streamer_retirement_tests;
 #[cfg(test)]
 mod tests;
+#[cfg(test)]
+mod throttle_tests;
 
 /// Default cache TTL (1 hour).
 const DEFAULT_CACHE_TTL: Duration = Duration::from_secs(3600);

--- a/rust-srec/src/services/container/builder.rs
+++ b/rust-srec/src/services/container/builder.rs
@@ -101,6 +101,8 @@ impl ServiceContainer {
             api_config,
         } = options;
 
+        pipeline_config.throttle.validate()?;
+
         crate::i18n::init_from_env();
 
         let overall = Instant::now();
@@ -339,6 +341,7 @@ impl ServiceContainer {
                 dag_repository: Arc::new(SqlxDagRepository::new(pool.clone(), write_pool.clone())),
                 upload_record_repository: upload_record_repo.clone(),
                 upload_broadcaster: upload_status_broadcaster.clone(),
+                download_limit_adjuster: download_manager.clone(),
             },
         ));
 

--- a/rust-srec/src/services/container/throttle_tests.rs
+++ b/rust-srec/src/services/container/throttle_tests.rs
@@ -1,0 +1,188 @@
+use std::time::Duration;
+
+use tokio_util::sync::CancellationToken;
+
+use super::{DEFAULT_CACHE_TTL, DEFAULT_EVENT_CAPACITY, ServiceContainer, ServiceContainerConfig};
+use crate::config::ConfigUpdateEvent;
+use crate::database::models::{LiveSessionDbModel, StreamerDbModel};
+use crate::database::repositories::{
+    SessionRepository, SqlxSessionRepository, SqlxStreamerRepository, StreamerRepository,
+};
+use crate::downloader::engine::EngineType;
+use crate::downloader::queue::{AcquireRequest, Priority};
+use crate::pipeline::{Job, ThrottleConfig, ThrottleEvent};
+
+fn request(id: &str, priority: Priority) -> AcquireRequest {
+    AcquireRequest {
+        session_id: id.into(),
+        streamer_id: id.into(),
+        streamer_name: id.into(),
+        engine_type: EngineType::Ffmpeg,
+        priority,
+    }
+}
+
+#[tokio::test]
+async fn runtime_throttle_preserves_live_limits_and_queue_ownership() {
+    tokio::time::timeout(Duration::from_secs(10), async {
+        let pool = crate::database::init_pool_with_size("sqlite::memory:", 1)
+            .await
+            .unwrap();
+        crate::database::run_migrations(&pool).await.unwrap();
+        let streamer =
+            StreamerDbModel::new("Backlog", "https://example.test/backlog", "platform-huya");
+        SqlxStreamerRepository::new(pool.clone(), pool.clone())
+            .create_streamer(&streamer)
+            .await
+            .unwrap();
+        let session = LiveSessionDbModel::new(&streamer.id);
+        SqlxSessionRepository::new(pool.clone(), pool.clone())
+            .create_session(&session)
+            .await
+            .unwrap();
+        let mut options =
+            ServiceContainerConfig::standard(DEFAULT_CACHE_TTL, DEFAULT_EVENT_CAPACITY);
+        options.download_config.high_priority_extra_slots = 1;
+        options.pipeline_config.throttle = ThrottleConfig {
+            enabled: true,
+            critical_threshold: 1,
+            warning_threshold: 1,
+            reduction_factor: 0.5,
+            check_interval_ms: 10,
+        };
+        let container = ServiceContainer::with_full_config(pool.clone(), pool, options)
+            .await
+            .unwrap();
+        let mut global = container.config_service.get_global_config().await.unwrap();
+        global.max_concurrent_downloads = 6;
+        global.max_concurrent_cpu_jobs = 1;
+        global.max_concurrent_io_jobs = 1;
+        container
+            .config_service
+            .update_global_config(&global)
+            .await
+            .unwrap();
+        container
+            .apply_config_event_for_test(ConfigUpdateEvent::GlobalUpdated)
+            .await;
+        let pipeline = container.pipeline_manager.clone();
+        let downloads = &container.download_manager;
+        let mut events = pipeline.subscribe_throttle_events().unwrap();
+        let mut jobs = Vec::new();
+        for _ in 0..2 {
+            // No processor claims this synthetic backlog; no external commands run.
+            jobs.push(
+                pipeline
+                    .enqueue(Job::new(
+                        "held-backlog",
+                        vec![],
+                        vec![],
+                        &streamer.id,
+                        &session.id,
+                    ))
+                    .await
+                    .unwrap(),
+            );
+        }
+        pipeline.clone().start();
+        let event = tokio::time::timeout(Duration::from_secs(2), events.recv())
+            .await
+            .expect("enabled production throttle must start")
+            .unwrap();
+        assert!(matches!(
+            event,
+            ThrottleEvent::ThrottleActivated {
+                original_limit: 6,
+                new_limit: 3,
+                ..
+            }
+        ));
+        assert_eq!(downloads.max_concurrent_downloads(), 6);
+        let mut slots = Vec::new();
+        for id in ["normal-1", "normal-2", "normal-3"] {
+            slots.push(
+                downloads
+                    .acquire_slot(request(id, Priority::Normal), CancellationToken::new())
+                    .await
+                    .unwrap(),
+            );
+        }
+        let high = downloads
+            .acquire_slot(
+                request("priority", Priority::High),
+                CancellationToken::new(),
+            )
+            .await
+            .unwrap();
+        let fourth = downloads.acquire_slot(
+            request("normal-4", Priority::Normal),
+            CancellationToken::new(),
+        );
+        tokio::pin!(fourth);
+        assert!(futures::poll!(fourth.as_mut()).is_pending());
+
+        global.max_concurrent_downloads = 8;
+        container
+            .config_service
+            .update_global_config(&global)
+            .await
+            .unwrap();
+        container
+            .apply_config_event_for_test(ConfigUpdateEvent::GlobalUpdated)
+            .await;
+        assert_eq!(downloads.max_concurrent_downloads(), 8);
+        slots.push(
+            tokio::time::timeout(Duration::from_secs(1), fourth)
+                .await
+                .unwrap()
+                .unwrap(),
+        );
+
+        let next = downloads.acquire_slot(
+            request("normal-5", Priority::Normal),
+            CancellationToken::new(),
+        );
+        tokio::pin!(next);
+        assert!(futures::poll!(next.as_mut()).is_pending());
+
+        global.max_concurrent_downloads = 2;
+        container
+            .config_service
+            .update_global_config(&global)
+            .await
+            .unwrap();
+        container
+            .apply_config_event_for_test(ConfigUpdateEvent::GlobalUpdated)
+            .await;
+        assert!(futures::poll!(next.as_mut()).is_pending());
+        for id in jobs {
+            pipeline.cancel_job(&id).await.unwrap();
+        }
+        let event = tokio::time::timeout(Duration::from_secs(2), events.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(matches!(
+            event,
+            ThrottleEvent::ThrottleDeactivated {
+                restored_limit: 2,
+                ..
+            }
+        ));
+        assert_eq!(downloads.max_concurrent_downloads(), 2);
+        assert!(futures::poll!(next.as_mut()).is_pending());
+        drop(slots.pop());
+        drop(slots.pop());
+        assert!(futures::poll!(next.as_mut()).is_pending());
+        drop(slots.pop());
+        let next = tokio::time::timeout(Duration::from_secs(1), next)
+            .await
+            .unwrap()
+            .unwrap();
+        drop((slots, high, next));
+        pipeline.stop().await;
+        assert!(!pipeline.is_throttled());
+    })
+    .await
+    .expect("throttle lifecycle must settle");
+}


### PR DESCRIPTION
## What changed?

Enabling pipeline throttling did not start its monitor because production construction omitted the download-limit adjuster. Wire the real DownloadManager into the pipeline runtime and apply throttling as a temporary factor on the latest configured normal-slot limit.

For example, a configured limit of 6 becomes 3 under a 50% throttle. Changing the configured limit to 8 immediately permits 4 normal slots; changing it to 2 and then draining the backlog restores 2, rather than the activation-time value of 6. Existing slots finish naturally, high-priority extra slots remain available, and queued requests wake when capacity permits.

A drop guard releases the factor and clears throttle status on cooperative shutdown or forced monitor abort. Enabled subsystem configuration rejects invalid thresholds, non-finite/out-of-range factors, and zero polling intervals.

Throttling remains opt-in through `ServiceContainer::with_full_config`; the standalone server defaults it off. No UI control is introduced.

## Scope

- Affected components: backend pipeline, download manager, service composition and regression tests.
- Breaking change: Rust source API only. `DownloadLimitAdjuster` now exposes one factor update returning configured/effective limits, and the unused `ThrottleController::calculate_throttled_limit` helper is removed. Repository callers are updated. No HTTP payload, database schema or default enablement change.

## How to test

Both baseline reproductions failed before the fix: the real container never activated throttling, and abort left `(throttled=true, limit=5)` instead of `(false, 10)`.

**656 focused tests passed**, including five new contract tests covering real queue admission, live limit changes, priority slots, recovery, teardown and numeric bounds. The old arithmetic-only controller test is replaced with manager-capacity coverage.

Checks run on Windows with default features:

```sh
cargo nextest run --locked -p rust-srec --lib --build-jobs 1 --test-threads 4 -E 'test(pipeline::) | test(downloader::manager) | test(downloader::queue) | test(services::container) | test(shutdown)' --no-fail-fast --status-level fail --final-status-level fail
cargo clippy --locked -p rust-srec --all-targets --jobs 1 -- -D warnings
cargo fmt --all -- --check
git diff --check
```

All checks passed. Integration test binaries and the full platform matrix were not executed locally; CI remains the integration gate.

## Checklist

- Formatting for affected files: passed.
- Lint and relevant tests for affected behavior: passed.
- Additional checks for affected interfaces, builds, migrations, or releases: affected consumers covered by focused tests and all-target Clippy; migrations/releases N/A.
- Related docs, config examples, and generated outputs: internal contract comments updated; generated outputs N/A.
- Final diff reviewed; unrelated changes excluded and shared logs/screenshots redacted: done; regression inputs are synthetic.

## Related issues

None.
