### PR TITLE
fix(credentials): reject stale refresh results after login edits

### DIFF
--- a/rust-srec/src/api/routes/credentials.rs
+++ b/rust-srec/src/api/routes/credentials.rs
@@ -37,6 +37,9 @@ fn credential_failure_message(error: &CredentialError) -> &'static str {
         }
         CredentialError::RateLimited => "Credential service rate limit reached; try again later",
         CredentialError::NoCredentials => "No credentials configured for this scope",
+        CredentialError::SourceChanged => {
+            "Credentials changed during refresh; retry with the current credentials"
+        }
         _ => "Credential operation failed",
     }
 }
@@ -1222,6 +1225,7 @@ mod error_boundary_tests {
     #[test]
     fn credential_errors_preserve_relogin_signal_without_underlying_details() {
         for (source, relogin) in [
+            (CredentialError::SourceChanged, false),
             (
                 CredentialError::InvalidCredentials("private-refresh-secret".to_string()),
                 true,

--- a/rust-srec/src/credentials/error.rs
+++ b/rust-srec/src/credentials/error.rs
@@ -57,6 +57,10 @@ pub enum CredentialError {
     #[error("No credentials configured for this scope")]
     NoCredentials,
 
+    /// The credential material changed while an operation was in flight.
+    #[error("Credentials changed during the operation; retry with the current credentials")]
+    SourceChanged,
+
     /// Internal error.
     #[error("Internal error: {0}")]
     Internal(String),
@@ -79,7 +83,7 @@ impl CredentialError {
     pub fn is_transient(&self) -> bool {
         matches!(
             self,
-            Self::Network(_) | Self::RateLimited | Self::ParseError(_)
+            Self::Network(_) | Self::RateLimited | Self::ParseError(_) | Self::SourceChanged
         )
     }
 }

--- a/rust-srec/src/credentials/service.rs
+++ b/rust-srec/src/credentials/service.rs
@@ -106,7 +106,7 @@ impl CredentialRefreshService {
         let _guard = lock.lock().await;
 
         let current = self.store.reload_source(source).await?;
-        let refreshed = if let Some(status) = self.daily_tracker.get_cached_status(&source.scope) {
+        let refreshed = if let Some(status) = self.daily_tracker.get_cached_status(&current) {
             self.handle_cached_status(&current, status).await?
         } else {
             self.perform_check_and_refresh(&current).await?
@@ -162,23 +162,14 @@ impl CredentialRefreshService {
             }
         };
 
-        // Record the result for today
-        self.daily_tracker
-            .record_check(&source.scope, status.clone());
-
         // Also persist to DB for hydration on restart
         let result_str = match &status {
             CredentialStatus::Valid => "valid",
             CredentialStatus::NeedsRefresh { .. } => "needs_refresh",
             CredentialStatus::Invalid { .. } => "invalid",
         };
-        if let Err(e) = self
-            .store
-            .update_check_result(&source.scope, result_str)
-            .await
-        {
-            warn!(error = %e, "Failed to persist check result (non-fatal)");
-        }
+        self.persist_check_result(source, result_str).await?;
+        self.daily_tracker.record_check(source, status.clone());
 
         match status {
             CredentialStatus::Valid => {
@@ -227,6 +218,21 @@ impl CredentialRefreshService {
         }
 
         service.dispatch_notification(NotificationEvent::Credential { event });
+    }
+
+    async fn persist_check_result(
+        &self,
+        source: &CredentialSource,
+        result: &str,
+    ) -> Result<(), CredentialError> {
+        match self.store.update_check_result(source, result).await {
+            Ok(()) => Ok(()),
+            Err(e @ (CredentialError::SourceChanged | CredentialError::NoCredentials)) => Err(e),
+            Err(e) => {
+                warn!(error = %e, "Failed to persist check result (non-fatal)");
+                Ok(())
+            }
+        }
     }
 
     /// Perform credential refresh.
@@ -279,7 +285,7 @@ impl CredentialRefreshService {
 
                 // Update daily tracker with valid status
                 self.daily_tracker
-                    .record_check(&source.scope, CredentialStatus::Valid);
+                    .record_check(&source.after_refresh(&new_creds), CredentialStatus::Valid);
 
                 // Clear failure tracking
                 self.failure_tracker.clear(&source.scope);
@@ -291,6 +297,11 @@ impl CredentialRefreshService {
                 Ok(Some(new_creds.cookies))
             }
             Err(e) => {
+                // Provider failures describe the inputs it received, not a newer login.
+                let current = self.store.reload_source(source).await?;
+                if !source.same_credentials(&current) {
+                    return Err(CredentialError::SourceChanged);
+                }
                 if e.requires_relogin() {
                     let reason = match &e {
                         CredentialError::InvalidCredentials(r) => r.clone(),
@@ -299,22 +310,14 @@ impl CredentialRefreshService {
 
                     // Cache an invalid status so we don't repeatedly attempt refresh within the day
                     // when the platform indicates a manual re-login is required.
+                    self.persist_check_result(source, "invalid").await?;
                     self.daily_tracker.record_check(
-                        &source.scope,
+                        source,
                         CredentialStatus::Invalid {
                             reason: reason.clone(),
                             error_code: None,
                         },
                     );
-
-                    // Best-effort: persist invalid status for hydration on restart.
-                    if let Err(store_err) = self
-                        .store
-                        .update_check_result(&source.scope, "invalid")
-                        .await
-                    {
-                        warn!(error = %store_err, "Failed to persist invalid check result (non-fatal)");
-                    }
                 }
 
                 let failure_count = self
@@ -379,26 +382,19 @@ impl CredentialRefreshService {
 
         let lock = self.get_refresh_lock(&source.scope);
         let _guard = lock.lock().await;
-        let current = self.store.reload_source(source).await?;
         let new_creds = RefreshedCredentials {
             cookies,
-            refresh_token: current.refresh_token.clone(),
-            access_token: current.access_token.clone(),
+            refresh_token: source.refresh_token.clone(),
+            access_token: source.access_token.clone(),
             expires_at: None,
         };
 
         self.store.update_credentials(source, &new_creds).await?;
+        let current = source.after_refresh(&new_creds);
+        self.persist_check_result(&current, "valid").await?;
         self.daily_tracker
-            .record_check(&source.scope, CredentialStatus::Valid);
+            .record_check(&current, CredentialStatus::Valid);
         self.failure_tracker.clear(&source.scope);
-        if let Err(e) = self.store.update_check_result(&source.scope, "valid").await {
-            warn!(
-                platform = %source.platform_name,
-                scope = %source.scope.describe(),
-                error = %e,
-                "Failed to persist credential check status"
-            );
-        }
         info!(
             platform = %source.platform_name,
             scope = %source.scope.describe(),
@@ -523,8 +519,9 @@ mod tests {
             Some("stale-token".to_string()),
             "bilibili".to_string(),
         );
+        let cached_source = service.store.reload_source(&source).await.unwrap();
         service.daily_tracker.record_check(
-            &source.scope,
+            &cached_source,
             CredentialStatus::NeedsRefresh {
                 refresh_deadline: None,
             },

--- a/rust-srec/src/credentials/store.rs
+++ b/rust-srec/src/credentials/store.rs
@@ -7,7 +7,7 @@ use async_trait::async_trait;
 
 use super::error::CredentialError;
 use super::manager::RefreshedCredentials;
-use super::types::{CredentialScope, CredentialSource};
+use super::types::CredentialSource;
 
 #[async_trait]
 pub trait CredentialStore: Send + Sync {
@@ -23,17 +23,19 @@ pub trait CredentialStore: Send + Sync {
         source: &CredentialSource,
     ) -> Result<CredentialSource, CredentialError>;
 
-    /// Persist refreshed credentials to the correct configuration layer.
+    /// Persist only if the provider inputs in `source` still match the stored credentials.
+    /// The comparison and writes must share a transaction; unrelated config edits are allowed.
     async fn update_credentials(
         &self,
         source: &CredentialSource,
         credentials: &RefreshedCredentials,
     ) -> Result<(), CredentialError>;
 
-    /// Persist a "checked today" result for hydration on restart.
+    /// Verify `source` is current and persist a "checked today" result where supported.
+    /// A stale check must not overwrite the status of newer credentials.
     async fn update_check_result(
         &self,
-        scope: &CredentialScope,
+        source: &CredentialSource,
         result: &str,
     ) -> Result<(), CredentialError>;
 }

--- a/rust-srec/src/credentials/tracker.rs
+++ b/rust-srec/src/credentials/tracker.rs
@@ -9,7 +9,7 @@ use chrono::{DateTime, Datelike, NaiveDate, Timelike, Utc};
 use dashmap::DashMap;
 
 use super::manager::CredentialStatus;
-use super::types::CredentialScope;
+use super::types::{CredentialScope, CredentialSource};
 
 /// Tracks when each credential scope was last checked.
 ///
@@ -24,6 +24,7 @@ pub struct DailyCheckTracker {
 
 #[derive(Clone)]
 struct CachedCheckResult {
+    source: CredentialSource,
     status: CredentialStatus,
     checked_date: NaiveDate,
 }
@@ -70,14 +71,14 @@ impl DailyCheckTracker {
     /// # Returns
     /// - `Some(cached_status)` if already checked today
     /// - `None` if check is needed
-    pub fn get_cached_status(&self, scope: &CredentialScope) -> Option<CredentialStatus> {
+    pub fn get_cached_status(&self, source: &CredentialSource) -> Option<CredentialStatus> {
         self.prune_if_needed();
 
-        let key = scope.cache_key();
+        let key = source.scope.cache_key();
         let today = Utc::now().date_naive();
 
         self.cached_results.get(&key).and_then(|cached| {
-            if cached.checked_date == today {
+            if cached.checked_date == today && cached.source.same_credentials(source) {
                 Some(cached.status.clone())
             } else {
                 None
@@ -91,20 +92,21 @@ impl DailyCheckTracker {
     /// - `true` if we need to check
     /// - `false` if already checked today
     #[inline]
-    pub fn needs_check(&self, scope: &CredentialScope) -> bool {
-        self.get_cached_status(scope).is_none()
+    pub fn needs_check(&self, source: &CredentialSource) -> bool {
+        self.get_cached_status(source).is_none()
     }
 
     /// Record a check result.
-    pub fn record_check(&self, scope: &CredentialScope, status: CredentialStatus) {
+    pub fn record_check(&self, source: &CredentialSource, status: CredentialStatus) {
         self.prune_if_needed();
 
-        let key = scope.cache_key();
+        let key = source.scope.cache_key();
         let today = Utc::now().date_naive();
 
         self.cached_results.insert(
             key,
             CachedCheckResult {
+                source: source.clone(),
                 status,
                 checked_date: today,
             },
@@ -319,17 +321,19 @@ mod tests {
             platform_name: "bilibili".to_string(),
         };
 
+        let source = CredentialSource::new(scope.clone(), "cookie".into(), None, "bilibili".into());
+
         // Initially needs check
-        assert!(tracker.needs_check(&scope));
-        assert!(tracker.get_cached_status(&scope).is_none());
+        assert!(tracker.needs_check(&source));
+        assert!(tracker.get_cached_status(&source).is_none());
 
         // Record a check
-        tracker.record_check(&scope, CredentialStatus::Valid);
+        tracker.record_check(&source, CredentialStatus::Valid);
 
         // Now doesn't need check
-        assert!(!tracker.needs_check(&scope));
+        assert!(!tracker.needs_check(&source));
         assert_eq!(
-            tracker.get_cached_status(&scope),
+            tracker.get_cached_status(&source),
             Some(CredentialStatus::Valid)
         );
     }
@@ -342,12 +346,49 @@ mod tests {
             platform_name: "bilibili".to_string(),
         };
 
-        tracker.record_check(&scope, CredentialStatus::Valid);
-        assert!(!tracker.needs_check(&scope));
+        let source = CredentialSource::new(scope.clone(), "cookie".into(), None, "bilibili".into());
+        tracker.record_check(&source, CredentialStatus::Valid);
+        assert!(!tracker.needs_check(&source));
 
         // Invalidate
         tracker.invalidate(&scope);
-        assert!(tracker.needs_check(&scope));
+        assert!(tracker.needs_check(&source));
+    }
+
+    #[test]
+    fn late_status_publication_cannot_validate_different_credentials() {
+        let tracker = DailyCheckTracker::new();
+        let source = CredentialSource::new(
+            CredentialScope::Template {
+                template_id: "shared".into(),
+                template_name: "Shared".into(),
+            },
+            "old-cookie".into(),
+            Some("old-refresh".into()),
+            "bilibili".into(),
+        );
+        tracker.invalidate(&source.scope);
+        // Models an old check returning after the edit invalidated its entry.
+        tracker.record_check(&source, CredentialStatus::Valid);
+        assert!(!tracker.needs_check(&source));
+        for field in ["cookies", "refresh", "access", "reauth", "platform"] {
+            let mut changed = source.clone();
+            match field {
+                "cookies" => changed.cookies = "new-cookie".into(),
+                "refresh" => changed.refresh_token = None,
+                "access" => changed.access_token = Some("new-access".into()),
+                "reauth" => {
+                    changed.reauth_extra =
+                        Some(serde_json::json!({"username":"user","password":"new"}))
+                }
+                "platform" => changed.platform_name = "soop".into(),
+                _ => unreachable!(),
+            }
+            assert!(
+                tracker.needs_check(&changed),
+                "stale cache matched changed {field}"
+            );
+        }
     }
 
     #[test]

--- a/rust-srec/src/credentials/types.rs
+++ b/rust-srec/src/credentials/types.rs
@@ -164,6 +164,30 @@ impl std::fmt::Debug for CredentialSource {
 }
 
 impl CredentialSource {
+    /// Compare provider inputs, excluding display names and unrelated configuration.
+    pub(crate) fn same_credentials(&self, other: &Self) -> bool {
+        self.scope.cache_key() == other.scope.cache_key()
+            && self
+                .platform_name
+                .eq_ignore_ascii_case(&other.platform_name)
+            && self.cookies == other.cookies
+            && self.refresh_token == other.refresh_token
+            && self.access_token == other.access_token
+            && self.reauth_extra == other.reauth_extra
+    }
+
+    pub(crate) fn after_refresh(&self, credentials: &super::manager::RefreshedCredentials) -> Self {
+        let mut current = self.clone();
+        current.cookies = credentials.cookies.clone();
+        if let Some(token) = &credentials.refresh_token {
+            current.refresh_token = Some(token.clone());
+        }
+        if let Some(token) = &credentials.access_token {
+            current.access_token = Some(token.clone());
+        }
+        current
+    }
+
     /// Create a new credential source.
     pub fn new(
         scope: CredentialScope,

--- a/rust-srec/src/database/repositories/credential_store.rs
+++ b/rust-srec/src/database/repositories/credential_store.rs
@@ -50,14 +50,85 @@ impl SqlxCredentialStore {
         }
     }
 
+    async fn load_source_in_connection(
+        connection: &mut sqlx::SqliteConnection,
+        source: &CredentialSource,
+    ) -> Result<CredentialSource, CredentialError> {
+        let (sql, id) = match &source.scope {
+            CredentialScope::Platform { platform_id, .. } => (
+                "SELECT cookies, platform_specific_config FROM platform_config WHERE id = ?",
+                platform_id,
+            ),
+            CredentialScope::Template { template_id, .. } => (
+                "SELECT cookies, platform_overrides FROM template_config WHERE id = ? AND NOT EXISTS (SELECT 1 FROM retirement_config_deletions WHERE kind = 'template' AND config_id = template_config.id)",
+                template_id,
+            ),
+            CredentialScope::Streamer { streamer_id, .. } => (
+                "SELECT json_extract(streamer_specific_config, '$.cookies'), streamer_specific_config FROM streamers WHERE id = ? AND deleted_at IS NULL",
+                streamer_id,
+            ),
+        };
+        let (cookies, config): (Option<String>, Option<String>) = sqlx::query_as(sql)
+            .bind(id)
+            .fetch_optional(&mut *connection)
+            .await?
+            .ok_or(CredentialError::NoCredentials)?;
+        let config: serde_json::Value = config
+            .as_deref()
+            .map(serde_json::from_str)
+            .transpose()?
+            .unwrap_or_default();
+        let fields = if matches!(source.scope, CredentialScope::Template { .. }) {
+            &config[&source.platform_name]
+        } else {
+            &config
+        };
+        let mut current = source.clone();
+        current.cookies = cookies.unwrap_or_default();
+        current.refresh_token = fields["refresh_token"].as_str().map(str::to_owned);
+        current.access_token = fields["access_token"].as_str().map(str::to_owned);
+        if matches!(source.scope, CredentialScope::Platform { .. }) {
+            current.reauth_extra =
+                crate::credentials::platform_reauth_extra(&current.platform_name, Some(fields));
+        }
+        if !matches!(source.scope, CredentialScope::Platform { .. })
+            && source.platform_name.eq_ignore_ascii_case("soop")
+        {
+            let raw: Option<String> = sqlx::query_scalar(
+                "SELECT platform_specific_config FROM platform_config WHERE platform_name = ? COLLATE NOCASE",
+            ).bind(&source.platform_name).fetch_optional(&mut *connection).await?.flatten();
+            let config = raw
+                .as_deref()
+                .map(serde_json::from_str::<serde_json::Value>)
+                .transpose()?;
+            current.reauth_extra =
+                crate::credentials::platform_reauth_extra(&source.platform_name, config.as_ref());
+        }
+        Ok(current)
+    }
+
+    async fn require_current_source(
+        connection: &mut sqlx::SqliteConnection,
+        source: &CredentialSource,
+    ) -> Result<(), CredentialError> {
+        let current = Self::load_source_in_connection(connection, source).await?;
+        if source.same_credentials(&current) {
+            Ok(())
+        } else {
+            Err(CredentialError::SourceChanged)
+        }
+    }
+
     async fn update_platform_credentials(
         &self,
         platform_id: &str,
+        source: &CredentialSource,
         credentials: &RefreshedCredentials,
     ) -> Result<(), CredentialError> {
         debug!(platform_id = %platform_id, "Updating platform credentials");
 
         let mut tx = begin_immediate(&self.write_pool).await?;
+        Self::require_current_source(&mut tx, source).await?;
         if credentials.refresh_token.is_some() || credentials.access_token.is_some() {
             let raw: Option<String> = sqlx::query_scalar(
                 "SELECT platform_specific_config FROM platform_config WHERE id = ?",
@@ -127,6 +198,7 @@ impl SqlxCredentialStore {
         &self,
         template_id: &str,
         platform_name: &str,
+        source: &CredentialSource,
         credentials: &RefreshedCredentials,
     ) -> Result<(), CredentialError> {
         debug!(template_id = %template_id, "Updating template credentials");
@@ -135,6 +207,7 @@ impl SqlxCredentialStore {
         // Read the JSON only after reserving the write transaction, so a concurrent
         // template update cannot be overwritten using an earlier snapshot.
         let mut tx = begin_immediate(&self.write_pool).await?;
+        Self::require_current_source(&mut tx, source).await?;
 
         let overrides_to_store = if credentials.refresh_token.is_some()
             || credentials.access_token.is_some()
@@ -234,6 +307,7 @@ impl SqlxCredentialStore {
     async fn update_streamer_credentials(
         &self,
         streamer_id: &str,
+        source: &CredentialSource,
         credentials: &RefreshedCredentials,
     ) -> Result<(), CredentialError> {
         let now = crate::database::time::now_ms();
@@ -242,6 +316,7 @@ impl SqlxCredentialStore {
             state.writer.require_same_pool(&self.write_pool)?;
             let id = streamer_id.to_owned();
             let credentials = credentials.clone();
+            let source = source.clone();
             let cache = state.cache.clone();
             return state
                 .writer
@@ -249,7 +324,8 @@ impl SqlxCredentialStore {
                     "streamer credentials",
                     move |tx| {
                         Box::pin(async move {
-                            Self::update_streamer_in_connection(tx, &id, &credentials, now).await
+                            Self::update_streamer_in_connection(tx, &id, &source, &credentials, now)
+                                .await
                         })
                     },
                     move |row| {
@@ -263,7 +339,7 @@ impl SqlxCredentialStore {
                 .map(|_| ());
         }
         let mut tx = begin_immediate(&self.write_pool).await?;
-        Self::update_streamer_in_connection(&mut tx, streamer_id, credentials, now).await?;
+        Self::update_streamer_in_connection(&mut tx, streamer_id, source, credentials, now).await?;
         tx.commit().await?;
         Ok(())
     }
@@ -271,9 +347,11 @@ impl SqlxCredentialStore {
     async fn update_streamer_in_connection(
         tx: &mut sqlx::SqliteConnection,
         streamer_id: &str,
+        source: &CredentialSource,
         credentials: &RefreshedCredentials,
         now: i64,
     ) -> Result<StreamerDbModel, CredentialError> {
+        Self::require_current_source(tx, source).await?;
         debug!(streamer_id = %streamer_id, "Updating streamer credentials");
 
         let raw: Option<String> = sqlx::query_scalar(
@@ -356,43 +434,8 @@ impl CredentialStore for SqlxCredentialStore {
         &self,
         source: &CredentialSource,
     ) -> Result<CredentialSource, CredentialError> {
-        let (sql, id) = match &source.scope {
-            CredentialScope::Platform { platform_id, .. } => (
-                "SELECT cookies, platform_specific_config FROM platform_config WHERE id = ?",
-                platform_id,
-            ),
-            CredentialScope::Template { template_id, .. } => (
-                "SELECT cookies, platform_overrides FROM template_config WHERE id = ? AND NOT EXISTS (SELECT 1 FROM retirement_config_deletions WHERE kind = 'template' AND config_id = template_config.id)",
-                template_id,
-            ),
-            CredentialScope::Streamer { streamer_id, .. } => (
-                "SELECT json_extract(streamer_specific_config, '$.cookies'), streamer_specific_config FROM streamers WHERE id = ? AND deleted_at IS NULL",
-                streamer_id,
-            ),
-        };
-        let (cookies, config): (Option<String>, Option<String>) = sqlx::query_as(sql)
-            .bind(id)
-            .fetch_optional(&self.pool)
-            .await?
-            .ok_or(CredentialError::NoCredentials)?;
-        let config: serde_json::Value = config
-            .as_deref()
-            .map(serde_json::from_str)
-            .transpose()?
-            .unwrap_or_default();
-        let fields = if matches!(source.scope, CredentialScope::Template { .. }) {
-            &config[&source.platform_name]
-        } else {
-            &config
-        };
-        let mut current = source.clone();
-        current.cookies = cookies.unwrap_or_default();
-        current.refresh_token = fields["refresh_token"].as_str().map(str::to_owned);
-        current.access_token = fields["access_token"].as_str().map(str::to_owned);
-        if matches!(source.scope, CredentialScope::Platform { .. }) {
-            current.reauth_extra =
-                crate::credentials::platform_reauth_extra(&current.platform_name, Some(fields));
-        }
+        let mut connection = self.pool.acquire().await?;
+        let current = Self::load_source_in_connection(&mut connection, source).await?;
         if current.cookies.trim().is_empty() && !current.has_reauth_extra() {
             return Err(CredentialError::NoCredentials);
         }
@@ -410,30 +453,36 @@ impl CredentialStore for SqlxCredentialStore {
     ) -> Result<(), CredentialError> {
         match &source.scope {
             CredentialScope::Platform { platform_id, .. } => {
-                self.update_platform_credentials(platform_id, credentials)
+                self.update_platform_credentials(platform_id, source, credentials)
                     .await
             }
             CredentialScope::Template { template_id, .. } => {
-                self.update_template_credentials(template_id, &source.platform_name, credentials)
-                    .await
+                self.update_template_credentials(
+                    template_id,
+                    &source.platform_name,
+                    source,
+                    credentials,
+                )
+                .await
             }
             CredentialScope::Streamer { streamer_id, .. } => {
-                self.update_streamer_credentials(streamer_id, credentials)
+                self.update_streamer_credentials(streamer_id, source, credentials)
                     .await
             }
         }
     }
 
-    #[instrument(skip(self), fields(scope = %scope.describe()))]
+    #[instrument(skip_all, fields(scope = %source.scope.describe()))]
     async fn update_check_result(
         &self,
-        scope: &CredentialScope,
+        source: &CredentialSource,
         result: &str,
     ) -> Result<(), CredentialError> {
-        // For now, only persist check results at platform level.
-        if let CredentialScope::Platform { platform_id, .. } = scope {
+        let mut tx = begin_immediate(&self.write_pool).await?;
+        Self::require_current_source(&mut tx, source).await?;
+        // Status persistence is platform-only, but every scope must reject stale checks.
+        if let CredentialScope::Platform { platform_id, .. } = &source.scope {
             let today = chrono::Utc::now().format("%Y-%m-%d").to_string();
-            let mut tx = begin_immediate(&self.write_pool).await?;
             let raw: Option<String> = sqlx::query_scalar(
                 "SELECT platform_specific_config FROM platform_config WHERE id = ?",
             )
@@ -463,8 +512,8 @@ impl CredentialStore for SqlxCredentialStore {
             .execute(&mut *tx)
             .await?;
             require_owner(updated.rows_affected())?;
-            tx.commit().await?;
         }
+        tx.commit().await?;
         Ok(())
     }
 }

--- a/rust-srec/src/streamer/state_store/tests.rs
+++ b/rust-srec/src/streamer/state_store/tests.rs
@@ -321,6 +321,59 @@ async fn admin_patch_uses_committed_credentials_and_counters_instead_of_its_old_
     );
 }
 
+#[tokio::test]
+async fn stale_credential_refresh_cannot_publish_over_a_new_login() {
+    use crate::credentials::{
+        CredentialError, CredentialScope, CredentialSource, CredentialStore, RefreshedCredentials,
+    };
+    let f = fixture().await;
+    let credentials =
+        crate::database::repositories::SqlxCredentialStore::new(f.pool.clone(), f.pool.clone());
+    credentials.bind_committed_streamers(f.store.clone());
+    let source = CredentialSource::new(
+        CredentialScope::Streamer {
+            streamer_id: "state-test".into(),
+            streamer_name: "Original".into(),
+        },
+        "old".into(),
+        None,
+        "huya".into(),
+    );
+    let mut edit = patch();
+    edit.streamer_specific_config = Some(Some(
+        r#"{"cookies":"manual-cookie","refresh_token":"manual-refresh"}"#.into(),
+    ));
+    f.manager.partial_update_streamer(edit).await.unwrap();
+    let saved = f.repository.get_streamer("state-test").await.unwrap();
+    let result = credentials
+        .update_credentials(
+            &source,
+            &RefreshedCredentials {
+                cookies: "obsolete-cookie".into(),
+                refresh_token: Some("obsolete-refresh".into()),
+                access_token: None,
+                expires_at: None,
+            },
+        )
+        .await;
+    assert!(matches!(result, Err(CredentialError::SourceChanged)));
+    assert_eq!(
+        f.repository
+            .get_streamer("state-test")
+            .await
+            .unwrap()
+            .streamer_specific_config,
+        saved.streamer_specific_config
+    );
+    assert_eq!(
+        f.manager
+            .get_streamer("state-test")
+            .unwrap()
+            .streamer_specific_config,
+        saved.streamer_specific_config
+    );
+}
+
 fn start() -> StartSessionInputs {
     StartSessionInputs {
         streamer_id: "state-test".into(),

--- a/rust-srec/tests/credential_refresh_races.rs
+++ b/rust-srec/tests/credential_refresh_races.rs
@@ -1,0 +1,433 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use rust_srec::credentials::{
+    CredentialError, CredentialManager, CredentialRefreshService, CredentialScope,
+    CredentialSource, CredentialStatus, CredentialStore, RefreshState, RefreshedCredentials,
+};
+use rust_srec::database::repositories::SqlxCredentialStore;
+use serde_json::json;
+use tokio::sync::{Notify, Semaphore};
+
+#[derive(Clone, Copy)]
+enum Owner {
+    Platform,
+    Template,
+    Streamer,
+}
+
+struct Fixture {
+    pool: sqlx::SqlitePool,
+    store: Arc<SqlxCredentialStore>,
+    source: CredentialSource,
+    owner: Owner,
+}
+
+impl Fixture {
+    async fn new(owner: Owner) -> Self {
+        let pool = rust_srec::database::init_pool_with_size("sqlite::memory:", 1)
+            .await
+            .unwrap();
+        rust_srec::database::run_migrations(&pool).await.unwrap();
+        let scope = match owner {
+            Owner::Platform => CredentialScope::Platform {
+                platform_id: "platform-bilibili".into(),
+                platform_name: "bilibili".into(),
+            },
+            Owner::Template => {
+                sqlx::query("INSERT INTO template_config(id,name) VALUES ('race-template','Race')")
+                    .execute(&pool)
+                    .await
+                    .unwrap();
+                CredentialScope::Template {
+                    template_id: "race-template".into(),
+                    template_name: "Race".into(),
+                }
+            }
+            Owner::Streamer => {
+                use rust_srec::database::repositories::{
+                    SqlxStreamerRepository, StreamerRepository,
+                };
+                let mut row = rust_srec::database::models::StreamerDbModel::new(
+                    "Race",
+                    "https://example.test/race",
+                    "platform-bilibili",
+                );
+                row.id = "race-streamer".into();
+                SqlxStreamerRepository::new(pool.clone(), pool.clone())
+                    .create_streamer(&row)
+                    .await
+                    .unwrap();
+                CredentialScope::Streamer {
+                    streamer_id: "race-streamer".into(),
+                    streamer_name: "Race".into(),
+                }
+            }
+        };
+        let fixture = Self {
+            store: Arc::new(SqlxCredentialStore::new(pool.clone(), pool.clone())),
+            pool,
+            owner,
+            source: CredentialSource::new(
+                scope,
+                "old-cookie".into(),
+                Some("old-refresh".into()),
+                "bilibili".into(),
+            )
+            .with_access_token(Some("old-access".into())),
+        };
+        fixture
+            .save("old-cookie", "old-refresh", "old-access")
+            .await;
+        fixture
+    }
+
+    async fn save(&self, cookies: &str, refresh: &str, access: &str) {
+        let mut connection = self.pool.acquire().await.unwrap();
+        self.save_on(&mut connection, cookies, refresh, access)
+            .await;
+    }
+
+    async fn save_on(
+        &self,
+        connection: &mut sqlx::SqliteConnection,
+        cookies: &str,
+        refresh: &str,
+        access: &str,
+    ) {
+        let fields = json!({"cookies": cookies, "refresh_token": refresh, "access_token": access, "keep": 42});
+        let (sql, document) = match self.owner {
+            Owner::Platform => (
+                "UPDATE platform_config SET cookies=?, platform_specific_config=? WHERE id=?",
+                fields,
+            ),
+            Owner::Template => (
+                "UPDATE template_config SET cookies=?, platform_overrides=? WHERE id=?",
+                json!({"bilibili":fields,"unrelated":{"keep":true}}),
+            ),
+            Owner::Streamer => (
+                "UPDATE streamers SET name=?, streamer_specific_config=? WHERE id=?",
+                fields,
+            ),
+        };
+        sqlx::query(sql)
+            .bind(cookies)
+            .bind(document.to_string())
+            .bind(self.source.scope.record_id())
+            .execute(connection)
+            .await
+            .unwrap();
+    }
+
+    async fn snapshot(&self) -> (Option<String>, Option<String>) {
+        let mut connection = self.pool.acquire().await.unwrap();
+        self.snapshot_on(&mut connection).await
+    }
+
+    async fn snapshot_on(
+        &self,
+        connection: &mut sqlx::SqliteConnection,
+    ) -> (Option<String>, Option<String>) {
+        let sql = match self.owner {
+            Owner::Platform => {
+                "SELECT cookies,platform_specific_config FROM platform_config WHERE id=?"
+            }
+            Owner::Template => "SELECT cookies,platform_overrides FROM template_config WHERE id=?",
+            Owner::Streamer => "SELECT name,streamer_specific_config FROM streamers WHERE id=?",
+        };
+        sqlx::query_as(sql)
+            .bind(self.source.scope.record_id())
+            .fetch_one(connection)
+            .await
+            .unwrap()
+    }
+}
+
+struct PausedProvider {
+    pause_check: bool,
+    fail_refresh: bool,
+    started: Notify,
+    release: Semaphore,
+}
+
+impl PausedProvider {
+    async fn pause(&self) {
+        self.started.notify_one();
+        self.release.acquire().await.unwrap().forget();
+    }
+}
+
+#[async_trait]
+impl CredentialManager for PausedProvider {
+    fn platform_id(&self) -> &'static str {
+        "bilibili"
+    }
+
+    async fn check_status(&self, cookies: &str) -> Result<CredentialStatus, CredentialError> {
+        if cookies == "manual-cookie" {
+            return Ok(CredentialStatus::Valid);
+        }
+        if self.pause_check {
+            self.pause().await;
+            Ok(CredentialStatus::Invalid {
+                reason: "obsolete check".into(),
+                error_code: None,
+            })
+        } else {
+            Ok(CredentialStatus::NeedsRefresh {
+                refresh_deadline: None,
+            })
+        }
+    }
+
+    async fn refresh(&self, _: &RefreshState) -> Result<RefreshedCredentials, CredentialError> {
+        self.pause().await;
+        if self.fail_refresh {
+            return Err(CredentialError::InvalidRefreshToken);
+        }
+        Ok(RefreshedCredentials {
+            cookies: "obsolete-cookie".into(),
+            refresh_token: Some("obsolete-refresh".into()),
+            access_token: Some("obsolete-access".into()),
+            expires_at: None,
+        })
+    }
+
+    async fn validate(&self, _: &str) -> Result<bool, CredentialError> {
+        Ok(true)
+    }
+}
+
+async fn assert_new_login_survives(owner: Owner, pause_check: bool, fail_refresh: bool) {
+    tokio::time::timeout(Duration::from_secs(10), async {
+        let fixture = Fixture::new(owner).await;
+        let provider = Arc::new(PausedProvider {
+            pause_check,
+            fail_refresh,
+            started: Notify::new(),
+            release: Semaphore::new(0),
+        });
+        let mut service = CredentialRefreshService::new(fixture.store.clone());
+        service.register_manager(provider.clone());
+        let pending = service.check_and_refresh_source(&fixture.source);
+        tokio::pin!(pending);
+        tokio::select! {
+            _ = provider.started.notified() => {},
+            result = &mut pending => panic!("provider should pause: {result:?}"),
+        }
+        fixture
+            .save("manual-cookie", "manual-refresh", "manual-access")
+            .await;
+        service.invalidate(&fixture.source.scope);
+        let saved = fixture.snapshot().await;
+        provider.release.add_permits(1);
+        let result = pending.await;
+        assert_eq!(
+            fixture.snapshot().await,
+            saved,
+            "old provider result overwrote the new login"
+        );
+        assert!(
+            matches!(result, Err(CredentialError::SourceChanged)),
+            "obsolete provider result must be rejected"
+        );
+        let current = fixture.store.reload_source(&fixture.source).await.unwrap();
+        assert!(
+            service.daily_tracker().needs_check(&current),
+            "obsolete status repopulated the invalidated cache"
+        );
+        assert_eq!(
+            service
+                .failure_tracker()
+                .failure_count(&fixture.source.scope),
+            0
+        );
+        assert_eq!(
+            service
+                .check_and_refresh_source(&fixture.source)
+                .await
+                .unwrap()
+                .as_deref(),
+            Some("manual-cookie")
+        );
+        assert!(!service.daily_tracker().needs_check(&current));
+    })
+    .await
+    .expect("credential race must settle");
+}
+
+#[tokio::test]
+async fn platform_refresh_cannot_overwrite_new_login() {
+    assert_new_login_survives(Owner::Platform, false, false).await;
+}
+
+#[tokio::test]
+async fn template_refresh_cannot_overwrite_new_login() {
+    assert_new_login_survives(Owner::Template, false, false).await;
+}
+
+#[tokio::test]
+async fn streamer_refresh_cannot_overwrite_new_login() {
+    assert_new_login_survives(Owner::Streamer, false, false).await;
+}
+
+#[tokio::test]
+async fn delayed_invalid_check_cannot_poison_new_login() {
+    for owner in [Owner::Platform, Owner::Template, Owner::Streamer] {
+        assert_new_login_survives(owner, true, false).await;
+    }
+}
+
+#[tokio::test]
+async fn delayed_refresh_failure_cannot_poison_new_login() {
+    for owner in [Owner::Platform, Owner::Template, Owner::Streamer] {
+        assert_new_login_survives(owner, false, true).await;
+    }
+}
+
+fn replacement() -> RefreshedCredentials {
+    RefreshedCredentials {
+        cookies: "rotated-cookie".into(),
+        refresh_token: Some("rotated-refresh".into()),
+        access_token: None,
+        expires_at: None,
+    }
+}
+
+#[tokio::test]
+async fn extracted_cookies_require_the_original_credential_source() {
+    for owner in [Owner::Platform, Owner::Template, Owner::Streamer] {
+        let fixture = Fixture::new(owner).await;
+        let service = CredentialRefreshService::new(fixture.store.clone());
+        fixture
+            .save("manual-cookie", "manual-refresh", "manual-access")
+            .await;
+        let saved = fixture.snapshot().await;
+        assert!(matches!(
+            service
+                .persist_session_cookies(&fixture.source, "obsolete-cookie".into())
+                .await,
+            Err(CredentialError::SourceChanged)
+        ));
+        assert_eq!(fixture.snapshot().await, saved);
+        let current = fixture.store.reload_source(&fixture.source).await.unwrap();
+        service
+            .persist_session_cookies(&current, "session-cookie".into())
+            .await
+            .unwrap();
+        let persisted = fixture.store.reload_source(&current).await.unwrap();
+        assert_eq!(persisted.cookies, "session-cookie");
+        assert_eq!(persisted.refresh_token.as_deref(), Some("manual-refresh"));
+        assert_eq!(persisted.access_token.as_deref(), Some("manual-access"));
+        assert!(!service.daily_tracker().needs_check(&persisted));
+    }
+}
+
+#[tokio::test]
+async fn credential_fields_are_compared_after_writer_admission() {
+    tokio::time::timeout(Duration::from_secs(15), async {
+        for owner in [Owner::Platform, Owner::Template, Owner::Streamer] {
+            let fixture = Fixture::new(owner).await;
+            for (cookies, refresh, access) in [
+                ("manual-cookie", "old-refresh", "old-access"),
+                ("old-cookie", "manual-refresh", "old-access"),
+                ("old-cookie", "old-refresh", "manual-access"),
+                ("", "", ""),
+            ] {
+                fixture
+                    .save("old-cookie", "old-refresh", "old-access")
+                    .await;
+                let mut edit = rust_srec::database::begin_immediate(&fixture.pool)
+                    .await
+                    .unwrap();
+                fixture.save_on(&mut edit, cookies, refresh, access).await;
+                let saved = fixture.snapshot_on(&mut edit).await;
+                let replacement = replacement();
+                let update = fixture
+                    .store
+                    .update_credentials(&fixture.source, &replacement);
+                tokio::pin!(update);
+                assert!(futures::poll!(update.as_mut()).is_pending());
+                edit.commit().await.unwrap();
+                assert!(matches!(update.await, Err(CredentialError::SourceChanged)));
+                assert_eq!(fixture.snapshot().await, saved);
+            }
+        }
+    })
+    .await
+    .expect("writer contention must settle");
+}
+
+#[tokio::test]
+async fn cookie_refresh_is_allowed_after_unrelated_configuration_edits() {
+    for owner in [Owner::Platform, Owner::Template, Owner::Streamer] {
+        let fixture = Fixture::new(owner).await;
+        let sql = match owner {
+            Owner::Platform => {
+                "UPDATE platform_config SET platform_specific_config=json_set(platform_specific_config,'$.keep',99) WHERE id=?"
+            }
+            Owner::Template => {
+                "UPDATE template_config SET platform_overrides=json_set(platform_overrides,'$.unrelated.keep',99) WHERE id=?"
+            }
+            Owner::Streamer => {
+                "UPDATE streamers SET streamer_specific_config=json_set(streamer_specific_config,'$.keep',99) WHERE id=?"
+            }
+        };
+        sqlx::query(sql)
+            .bind(fixture.source.scope.record_id())
+            .execute(&fixture.pool)
+            .await
+            .unwrap();
+        fixture
+            .store
+            .update_credentials(&fixture.source, &replacement())
+            .await
+            .unwrap();
+        let current = fixture.store.reload_source(&fixture.source).await.unwrap();
+        assert_eq!(current.cookies, "rotated-cookie");
+        assert_eq!(current.access_token.as_deref(), Some("old-access"));
+        let raw: serde_json::Value =
+            serde_json::from_str(&fixture.snapshot().await.1.unwrap()).unwrap();
+        assert_eq!(
+            if matches!(owner, Owner::Template) {
+                &raw["unrelated"]["keep"]
+            } else {
+                &raw["keep"]
+            },
+            99
+        );
+    }
+}
+
+#[tokio::test]
+async fn changed_password_rejects_refresh_including_inherited_reauth() {
+    for owner in [Owner::Platform, Owner::Template, Owner::Streamer] {
+        let mut fixture = Fixture::new(owner).await;
+        fixture.source.platform_name = "soop".into();
+        if matches!(owner, Owner::Platform) {
+            fixture.source.scope = CredentialScope::Platform {
+                platform_id: "platform-soop".into(),
+                platform_name: "soop".into(),
+            };
+        }
+        fixture
+            .save("old-cookie", "old-refresh", "old-access")
+            .await;
+        sqlx::query("UPDATE platform_config SET platform_specific_config=json_set(COALESCE(platform_specific_config,'{}'),'$.username','user','$.password','old-password') WHERE id='platform-soop'")
+            .execute(&fixture.pool).await.unwrap();
+        let source = fixture.store.reload_source(&fixture.source).await.unwrap();
+        assert!(source.has_reauth_extra());
+        sqlx::query("UPDATE platform_config SET platform_specific_config=json_set(platform_specific_config,'$.password','new-password') WHERE id='platform-soop'")
+            .execute(&fixture.pool).await.unwrap();
+        let saved = fixture.snapshot().await;
+        assert!(matches!(
+            fixture
+                .store
+                .update_credentials(&source, &replacement())
+                .await,
+            Err(CredentialError::SourceChanged)
+        ));
+        assert_eq!(fixture.snapshot().await, saved);
+    }
+}

--- a/rust-srec/tests/credential_store_contracts.rs
+++ b/rust-srec/tests/credential_store_contracts.rs
@@ -77,6 +77,22 @@ impl Fixture {
         }
     }
 
+    async fn expected_source(&self) -> CredentialSource {
+        let (cookies, raw, _) = self.snapshot().await;
+        let fields: Value = raw
+            .as_deref()
+            .and_then(|raw| serde_json::from_str(raw).ok())
+            .unwrap_or_default();
+        let mut source = self.source.clone();
+        source.cookies = match self.owner {
+            Owner::Platform => cookies.unwrap_or_default(),
+            Owner::Streamer => fields["cookies"].as_str().unwrap_or_default().to_owned(),
+        };
+        source.refresh_token = fields["refresh_token"].as_str().map(str::to_owned);
+        source.access_token = fields["access_token"].as_str().map(str::to_owned);
+        source
+    }
+
     async fn snapshot(&self) -> (Option<String>, Option<String>, String) {
         let sql = match self.owner {
             Owner::Platform => {
@@ -121,7 +137,7 @@ async fn credential_token_combinations_preserve_unrelated_json_and_absent_values
                         let credentials = refreshed(refresh, access);
                         let day_before = chrono::Utc::now().format("%Y-%m-%d").to_string();
                         f.store
-                            .update_credentials(&f.source, &credentials)
+                            .update_credentials(&f.expected_source().await, &credentials)
                             .await
                             .unwrap();
                         let (cookies, raw, _) = f.snapshot().await;
@@ -163,7 +179,7 @@ async fn credential_token_combinations_preserve_unrelated_json_and_absent_values
             }
             f.seed(None).await;
             f.store
-                .update_credentials(&f.source, &refreshed(true, true))
+                .update_credentials(&f.expected_source().await, &refreshed(true, true))
                 .await
                 .unwrap();
             let raw = f.snapshot().await.1.unwrap();
@@ -186,7 +202,7 @@ async fn malformed_and_non_object_json_cannot_partially_refresh_credentials() {
                 let before = f.snapshot().await;
                 assert!(
                     f.store
-                        .update_credentials(&f.source, &refreshed(true, true))
+                        .update_credentials(&f.expected_source().await, &refreshed(true, true))
                         .await
                         .is_err(),
                     "{owner:?}: {raw}"
@@ -195,7 +211,10 @@ async fn malformed_and_non_object_json_cannot_partially_refresh_credentials() {
                 if matches!(owner, Owner::Streamer) {
                     assert!(
                         f.store
-                            .update_credentials(&f.source, &refreshed(false, false))
+                            .update_credentials(
+                                &f.expected_source().await,
+                                &refreshed(false, false)
+                            )
                             .await
                             .is_err()
                     );
@@ -205,15 +224,15 @@ async fn malformed_and_non_object_json_cannot_partially_refresh_credentials() {
         }
         let f = Fixture::new(Owner::Platform).await;
         f.seed(Some("opaque legacy config")).await;
-        f.store
-            .update_credentials(&f.source, &refreshed(false, false))
-            .await
-            .unwrap();
-        let snapshot = f.snapshot().await;
-        assert_eq!(
-            snapshot.0.as_deref(),
-            Some(refreshed(false, false).cookies.as_str())
+        // An opaque document cannot establish the expected credential material.
+        assert!(
+            f.store
+                .update_credentials(&f.expected_source().await, &refreshed(false, false))
+                .await
+                .is_err()
         );
+        let snapshot = f.snapshot().await;
+        assert_eq!(snapshot.0.as_deref(), Some("old-cookie"));
         assert_eq!(snapshot.1.as_deref(), Some("opaque legacy config"));
     })
     .await
@@ -232,10 +251,10 @@ async fn late_token_write_failure_rolls_back_cookies_tokens_and_timestamps() {
                 Owner::Streamer => "CREATE TRIGGER reject_refreshed_tokens BEFORE UPDATE OF streamer_specific_config ON streamers WHEN NEW.id='credential-owner' AND json_extract(NEW.streamer_specific_config,'$.access_token')='new-access' BEGIN SELECT RAISE(ABORT,'injected late token failure'); END",
             };
             sqlx::query(trigger).execute(&f.pool).await.unwrap();
-            assert!(f.store.update_credentials(&f.source, &refreshed(true, true)).await.is_err());
+            assert!(f.store.update_credentials(&f.expected_source().await, &refreshed(true, true)).await.is_err());
             assert_eq!(f.snapshot().await, before);
             sqlx::query("DROP TRIGGER reject_refreshed_tokens").execute(&f.pool).await.unwrap();
-            f.store.update_credentials(&f.source, &refreshed(true, true)).await.unwrap();
+            f.store.update_credentials(&f.expected_source().await, &refreshed(true, true)).await.unwrap();
         }
     }).await.expect("credential rollback must release its transaction");
 }
@@ -252,7 +271,7 @@ async fn missing_and_retired_owners_do_not_report_refresh_success() {
         let before = f.snapshot().await;
         assert!(matches!(
             f.store
-                .update_credentials(&f.source, &refreshed(true, true))
+                .update_credentials(&f.expected_source().await, &refreshed(true, true))
                 .await,
             Err(CredentialError::NoCredentials)
         ));
@@ -328,7 +347,7 @@ async fn check_results_preserve_json_and_reject_invalid_platform_documents() {
         ))
         .await;
         f.store
-            .update_check_result(&f.source.scope, "needs_refresh")
+            .update_check_result(&f.expected_source().await, "needs_refresh")
             .await
             .unwrap();
         let (cookies, raw, _) = f.snapshot().await;
@@ -342,7 +361,7 @@ async fn check_results_preserve_json_and_reject_invalid_platform_documents() {
             let before = f.snapshot().await;
             assert!(
                 f.store
-                    .update_check_result(&f.source.scope, "valid")
+                    .update_check_result(&f.expected_source().await, "valid")
                     .await
                     .is_err()
             );
@@ -350,7 +369,7 @@ async fn check_results_preserve_json_and_reject_invalid_platform_documents() {
         }
         f.seed(None).await;
         f.store
-            .update_check_result(&f.source.scope, "valid")
+            .update_check_result(&f.expected_source().await, "valid")
             .await
             .unwrap();
         let (cookies, raw, _) = f.snapshot().await;
@@ -367,35 +386,47 @@ async fn check_results_preserve_json_and_reject_invalid_platform_documents() {
         assert!(matches!(
             f.store
                 .update_check_result(
-                    &CredentialScope::Platform {
-                        platform_id: "missing".into(),
-                        platform_name: "bilibili".into()
-                    },
+                    &CredentialSource::new(
+                        CredentialScope::Platform {
+                            platform_id: "missing".into(),
+                            platform_name: "bilibili".into()
+                        },
+                        String::new(),
+                        None,
+                        "bilibili".into()
+                    ),
                     "valid"
                 )
                 .await,
             Err(CredentialError::NoCredentials)
         ));
         let other = Fixture::new(Owner::Streamer).await;
-        other.seed(Some("opaque")).await;
+        other.seed(Some(r#"{"cookies":"current"}"#)).await;
         let before = other.snapshot().await;
         other
             .store
-            .update_check_result(&other.source.scope, "valid")
+            .update_check_result(&other.expected_source().await, "valid")
             .await
             .unwrap();
         assert_eq!(other.snapshot().await, before);
-        other
-            .store
-            .update_check_result(
-                &CredentialScope::Template {
-                    template_id: "missing".into(),
-                    template_name: "missing".into(),
-                },
-                "valid",
-            )
-            .await
-            .unwrap();
+        assert!(matches!(
+            other
+                .store
+                .update_check_result(
+                    &CredentialSource::new(
+                        CredentialScope::Template {
+                            template_id: "missing".into(),
+                            template_name: "missing".into(),
+                        },
+                        String::new(),
+                        None,
+                        "bilibili".into()
+                    ),
+                    "valid",
+                )
+                .await,
+            Err(CredentialError::NoCredentials)
+        ));
     })
     .await
     .expect("credential check-result contracts must finish");

--- a/rust-srec/tests/preset_template_timestamps.rs
+++ b/rust-srec/tests/preset_template_timestamps.rs
@@ -433,7 +433,7 @@ async fn timestamp_repository_writes_and_credentials_keep_integer_storage_and_st
         assert!(updated >= expected);
     }
     let store = SqlxCredentialStore::new(pool.clone(), pool.clone());
-    let source = CredentialSource {
+    let mut source = CredentialSource {
         scope: CredentialScope::Template {
             template_id: template.id.clone(),
             template_name: template.name.clone(),
@@ -457,6 +457,7 @@ async fn timestamp_repository_writes_and_credentials_keep_integer_storage_and_st
             )
             .await
             .unwrap();
+        source = store.reload_source(&source).await.unwrap();
         let refreshed = config_repo.get_template_config(&template.id).await.unwrap();
         assert_eq!(refreshed.created_at.timestamp_millis(), expected);
         assert_eq!(refreshed.cookies.as_deref(), Some("test-cookie=value"));


### PR DESCRIPTION
## What changed?

A refresh that started before a manual credential save could overwrite the newer cookies and tokens. A delayed validity check could also mark the new login invalid. Reject stale results at platform, template and streamer scopes by comparing the provider's credential inputs inside the same SQLite write transaction used for persistence.

The comparison covers cookies, refresh/access tokens and reauthentication material, including inherited SOOP credentials. Unrelated JSON fields and display-name edits still allow refresh. Daily cache entries are bound to the checked credential source, so a late result cannot supply cached validity for a different login. Conflicts return `SourceChanged`, which is retryable and does not require re-login. Streamer commits retain their existing supervised publication owner.

Session-cookie persistence also checks its supplied original source instead of combining old cookies with freshly loaded tokens. Callers must supply the source that produced those cookies; extraction provenance transport is outside this change.

## Scope

- Affected components: backend credential service/store/cache, API error messaging and regression tests.
- Breaking change: Rust source API only. `CredentialStore::update_check_result` and daily tracker methods now accept a credential source instead of a scope. Repository callers are updated. No REST payload or database schema change.
- Cookie-only store updates now reject malformed opaque platform JSON because the expected credential material cannot be verified. Normal refresh source loading already rejected those documents.
- Independent of pipeline throttling PR #950.

## How to test

Four reproductions failed before the fix: refresh overwrote a new login at each of the three scopes, and a delayed check wrote an invalid status onto newer credentials.

**221 distinct focused tests passed** across the validation runs: 197 backend tests and 24 integration tests. Eleven tests were added for provider races, writer contention, token-only edits, unrelated config edits, inherited passwords, supplied extraction sources, cache isolation and committed streamer publication.

Checks run on Windows with default features:

- Backend suite, **197 passed**:
  ```sh
  cargo nextest run --locked -p rust-srec --lib --build-jobs 1 --test-threads 4 -E 'test(credentials::) | test(credential) | test(config::) | test(streamer::state_store) | test(shutdown) | test(session_cookies) | test(import_contract)' --no-fail-fast --status-level fail --final-status-level fail
  ```
- `credential_refresh_races`: **9 passed** after correcting a contention-test fixture to read its expected snapshot inside the editing transaction.
- `credential_store_contracts`, `database_mutation_atomicity`, `preset_template_timestamps`: **15 passed**.
- `cargo check --locked -p rust-srec --lib --jobs 1`: passed.
- `cargo clippy --locked -p rust-srec --all-targets --jobs 1 -- -D warnings`: passed.
- `cargo fmt --all -- --check` and `git diff --check`: passed.

The credential patch was validated before fast-forwarding its branch over merged #949; credential files did not change during that update. The full platform matrix remains with CI.

## Checklist

- Formatting for affected files: passed.
- Lint and relevant tests for affected behavior: passed.
- Additional checks for affected interfaces, builds, migrations, or releases: affected callers covered by focused tests and all-target Clippy; migrations/releases N/A.
- Related docs, config examples, and generated outputs: internal contract comments updated; generated outputs N/A.
- Final diff reviewed; unrelated changes excluded and shared logs/screenshots redacted: done; tests use synthetic credentials.

## Related issues

None.
